### PR TITLE
Vue: Raise the vue-component-meta floor to ^3.3.9

### DIFF
--- a/code/renderers/vue3/package.json
+++ b/code/renderers/vue3/package.json
@@ -53,7 +53,7 @@
     "@vue/compiler-dom": "^3.2.47",
     "@vue/language-core": "^3.2.7",
     "type-fest": "^5.6.0",
-    "vue-component-meta": "^3.2.7",
+    "vue-component-meta": "^3.3.9",
     "vue-component-type-helpers": "^3.2.9",
     "vue-docgen-api": "^4.75.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13050,7 +13050,7 @@ __metadata:
     type-fest: "npm:^5.6.0"
     typescript: "npm:^6.0.3"
     vue: "npm:^3.2.47"
-    vue-component-meta: "npm:^3.2.7"
+    vue-component-meta: "npm:^3.3.9"
     vue-component-type-helpers: "npm:^3.2.9"
     vue-docgen-api: "npm:^4.75.1"
     vue-tsc: "npm:latest"

--- a/yarn.lock
+++ b/yarn.lock
@@ -39857,7 +39857,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue-component-meta@npm:^3.2.7, vue-component-meta@npm:^3.3.9":
+"vue-component-meta@npm:^3.3.9":
   version: 3.3.9
   resolution: "vue-component-meta@npm:3.3.9"
   dependencies:


### PR DESCRIPTION
## What I did

`@storybook/vue3` depends on `vue-component-meta` at `^3.2.7`. Every release below 3.3.9 has a side effect in `getProgramAndFile`: querying a file that is not already in the TS program adds it to `fileNamesSet`, bumps `projectVersion` and rebuilds the program. Each read of an outside file costs roughly a second, and the project keeps growing as the build goes on.

I reported that as [vuejs/language-tools#6134](https://github.com/vuejs/language-tools/issues/6134) and fixed it in [vuejs/language-tools#6136](https://github.com/vuejs/language-tools/pull/6136). It shipped in `vue-component-meta` 3.3.9.

The floor here decides whether a consumer gets that fix. `^3.2.7` is satisfied by 3.3.7, so any lockfile already holding an older version keeps it. Ours did, and pnpm had no reason to move.

It does not show up in this repo. The root `yarn.lock` resolves both `^3.2.7` and `^3.3.9` to 3.3.9, so CI has been installing a fixed version all along. `frameworks/vue3-vite` asks for `^3.3.9` too, but only as a devDependency, so it never reaches anyone installing Storybook.

## The numbers

Our design system, 151 components, `storybook build` on 10.6.0-alpha.8 with nothing changed but the `vue-component-meta` version:

| vue-component-meta | build | peak RSS | components documented |
| --- | --- | --- | --- |
| 3.3.7 | 851s | 8.8 GB | 151 ours + 37 from `node_modules/vuetify` |
| 3.3.11 | 144s | 6.5 GB | 151 ours |

Worth being clear about that last column, since it looks like a loss and isn't. The 37 extra are Vuetify's own components. 3.3.7 documented them because it dragged each one into the TS program on demand, which is exactly where the 12 minutes went. Every component we actually ship docs for is still documented. The build just stops walking into `node_modules`.

## Why it matters more from here

`vue-docgen-api` is deprecated and the docgen server becomes the default in Storybook 11, so `vue-component-meta` is the path every Vue user ends up on. The floor is worth getting right before that.

I wanted to take this to `^3.3.11`, the current release. This repo will not resolve it:

```
➤ YN0016: │ vue-component-meta@npm:^3.3.11: All versions satisfying "^3.3.11" are quarantined
```

`npmMinimalAgeGate` is 10080 minutes and 3.3.11 published on 21 August, so it clears on the 28th. So this is `^3.3.9`, the first release carrying the fix.

Little practical difference either way. The caret means a fresh install still resolves 3.3.11, and `^3.3.9` is the tightest floor that rules out only the releases with the bug. Happy to push the bump to `^3.3.11` once the gate lifts if you would rather have it.

The lockfile has two mechanical changes: the two descriptors merge into one key, and the `@storybook/vue3` workspace entry records the new range. The resolution was already 3.3.9 and does not move.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Pin `vue-component-meta` to 3.3.7 in a Vue project using `docgen: 'vue-component-meta'`, with enough components that the checker reads files outside the tsconfig program, and compare a production `storybook build` against 3.3.9. The gap scales with how many outside files it touches, so a small sandbox will not show it.

---

Drafted with Claude. The measurements are from our own build, and I have reviewed the diff.

