### PR TITLE
Vue: Handle undefined args in Story snippet

### DIFF
--- a/code/renderers/vue3/src/story-docs/build-story-docs.ts
+++ b/code/renderers/vue3/src/story-docs/build-story-docs.ts
@@ -39,12 +39,7 @@ import {
 import type { StoryDoc, StoryDocsPayload, StoryDocsProviderInput } from 'storybook/internal/types';
 import type { DocgenPayload, DocgenService } from 'storybook/open-service';
 
-import {
-  classifyArgs,
-  type ClassifiedArg,
-  type ClassifyArgsResult,
-  type VueDocgenArgInfo,
-} from './classify-args.ts';
+import { classifyArgs, type ClassifyArgsResult, type VueDocgenArgInfo } from './classify-args.ts';
 import { renderSfcSnippet } from './render-sfc.ts';
 import { transformH } from './transform-h.ts';
 import {
@@ -83,10 +78,18 @@ const openStoryReferences = createStoryReferenceResolver({ extensions: ['.vue'] 
 
 const RENDER_UNRESOLVED_WARNING =
   'No static snippet: the `render` function could not be resolved statically.';
+const TEMPLATE_UNRESOLVED_WARNING =
+  'No static snippet: the story template could not be resolved statically.';
 const SLOT_UNRESOLVED_WARNING =
   'No static snippet: a slot function could not be resolved statically.';
 const IMPORT_UNRESOLVED_WARNING =
   "No static snippet: the component's import could not be resolved statically.";
+/** Names what a story renders from, so a bail points at the source that could not be read. */
+const UNRENDERED_WARNINGS: Record<StaticStoryRenderer['kind'], string> = {
+  h: RENDER_UNRESOLVED_WARNING,
+  sfc: SLOT_UNRESOLVED_WARNING,
+  template: TEMPLATE_UNRESOLVED_WARNING,
+};
 
 type ParsedCsf = ReturnType<ReturnType<typeof loadCsf>['parse']>;
 type ExtractStoriesResult = { stories: Record<string, StoryDoc> };
@@ -343,11 +346,15 @@ function enrichStoryDoc(
     return withWarning(noSnippetWarning(unresolved));
   }
 
-  const rendered = renderStaticStorySnippet(renderer, args, componentName, docgenArgInfo, options);
+  const rendered = renderStaticStorySnippet(
+    renderer,
+    resolved.classified,
+    componentName,
+    docgenArgInfo,
+    options
+  );
   if (!rendered) {
-    return withWarning(
-      renderer.kind === 'sfc' ? SLOT_UNRESOLVED_WARNING : RENDER_UNRESOLVED_WARNING
-    );
+    return withWarning(UNRENDERED_WARNINGS[renderer.kind]);
   }
 
   return {
@@ -406,12 +413,13 @@ function resolveStaticStoryArgs(
 
 function renderStaticStorySnippet(
   renderer: StaticStoryRenderer,
-  args: ClassifiedArg[],
+  classified: ClassifyArgsResult,
   componentName: string,
   docgenArgInfo: VueDocgenArgInfo,
   options: StoryDocsContext
 ): StorySnippetResult | undefined {
   const componentImportStatement = options.snippet?.componentImportStatement;
+  const { args } = classified;
 
   if (renderer.kind === 'sfc') {
     return componentImportStatement
@@ -429,6 +437,7 @@ function renderStaticStorySnippet(
       args,
       componentImports: renderer.componentImports,
       template: renderer.template,
+      unsetArgs: classified.unset,
     });
   }
 

--- a/code/renderers/vue3/src/story-docs/build-story-docs.ts
+++ b/code/renderers/vue3/src/story-docs/build-story-docs.ts
@@ -443,6 +443,7 @@ function renderStaticStorySnippet(
 
   return transformH({
     args,
+    unsetArgs: classified.unset,
     argsParam: renderer.argsParam,
     componentImportStatement,
     componentName,

--- a/code/renderers/vue3/src/story-docs/classify-args.ts
+++ b/code/renderers/vue3/src/story-docs/classify-args.ts
@@ -5,6 +5,7 @@ import {
   classifyValue,
   isFunctionExpression,
   isSelfContainedFunction,
+  isUndefinedIdentifier,
   printValue,
   type ValuePlan,
 } from './classify-value.ts';
@@ -70,6 +71,8 @@ export interface ClassifyArgsResult {
   args: ClassifiedArg[];
   /** Source text of args dropped because their values do not resolve statically. */
   unresolved: string[];
+  /** Names of args explicitly set to `undefined` */
+  unset: Set<string>;
 }
 
 /**
@@ -92,6 +95,7 @@ export function classifyArgs(
 ): ClassifyArgsResult {
   const classified: ClassifiedArg[] = [];
   const unresolved: string[] = [];
+  const unset = new Set<string>();
 
   for (const [name, value] of Object.entries(args)) {
     const result = classifyArg(name, value, docgen);
@@ -100,10 +104,12 @@ export function classifyArgs(
       classified.push(result.arg);
     } else if (result.kind === 'unrepresentable') {
       unresolved.push(`${name}: ${printValue(value)}`);
+    } else if (isUndefinedIdentifier(value)) {
+      unset.add(name);
     }
   }
 
-  return { args: classified, unresolved };
+  return { args: classified, unresolved, unset };
 }
 
 /**

--- a/code/renderers/vue3/src/story-docs/render-primitives.ts
+++ b/code/renderers/vue3/src/story-docs/render-primitives.ts
@@ -349,11 +349,12 @@ export function hoistArgValue(name: string, value: t.Node, ctx: RenderContext): 
   return bindingName;
 }
 
-/** Hoist an arg value as a `ref` for a `v-model` binding. */
-export function hoistModelRef(name: string, value: t.Node, ctx: RenderContext): string {
+/** Hoist an arg value as a `ref` for a `v-model` binding; an arg with no value starts empty. */
+export function hoistModelRef(name: string, value: t.Node | undefined, ctx: RenderContext): string {
   (ctx.imports[VUE_PACKAGE] ??= new Set()).add('ref');
   const bindingName = allocateBindingName(name, ctx);
-  ctx.variables.set(bindingName, `ref(${printValue(unwrapExpression(value))})`);
+  const source = value === undefined ? 'ref()' : `ref(${printValue(unwrapExpression(value))})`;
+  ctx.variables.set(bindingName, source);
   return bindingName;
 }
 

--- a/code/renderers/vue3/src/story-docs/transform-h.test.ts
+++ b/code/renderers/vue3/src/story-docs/transform-h.test.ts
@@ -27,6 +27,7 @@ const DEFAULT_DOCGEN: VueDocgenArgInfo = { props: new Set(), events: new Set(), 
 
 interface ParsedRender {
   args: ClassifiedArg[];
+  unsetArgs: Set<string>;
   argsParam?: string;
   expression?: t.Node;
   importBindings: ReturnType<typeof collectImportBindings>;
@@ -43,6 +44,7 @@ function renderStory(
   return parsed.expression
     ? transformH({
         args: parsed.args,
+        unsetArgs: parsed.unsetArgs,
         argsParam: parsed.argsParam,
         componentImportStatement,
         componentName: 'MyButton',
@@ -112,6 +114,7 @@ ${storySource}
   if (renderResolution.kind !== 'resolved') {
     return {
       args: classified.args,
+      unsetArgs: classified.unset,
       importBindings: collectImportBindings(csf._file.path),
     };
   }
@@ -119,6 +122,7 @@ ${storySource}
   const [parameter] = renderResolution.path.node.params;
   return {
     args: classified.args,
+    unsetArgs: classified.unset,
     argsParam: t.isIdentifier(parameter) ? parameter.name : undefined,
     expression: returnedExpression(renderResolution.path.node),
     importBindings: collectImportBindings(csf._file.path),
@@ -145,6 +149,62 @@ export const Primary = {
         <MyButton active label="Render" />
       </template>"
     `);
+  });
+
+  it('drops a prop reading an arg the story set to undefined', () => {
+    expect(
+      renderStory(`
+export const Primary = {
+  args: {
+    label: 'Render',
+    theme: undefined,
+  },
+  render: (args) => h(MyButton, { theme: args.theme, label: args.label }),
+};
+`)?.snippet
+    ).toMatchInlineSnapshot(`
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
+        <MyButton label="Render" />
+      </template>"
+    `);
+  });
+
+  it('renders no child for a child reading an arg the story set to undefined', () => {
+    expect(
+      renderStory(`
+export const Primary = {
+  args: {
+    label: undefined,
+  },
+  render: (args) => h(MyButton, null, args.label),
+};
+`)?.snippet
+    ).toMatchInlineSnapshot(`
+        "<script lang="ts" setup>
+        import MyButton from './MyButton.vue';
+        </script>
+
+        <template>
+          <MyButton />
+        </template>"
+      `);
+  });
+
+  it('bails when a prop reads an arg the story never sets', () => {
+    expect(
+      renderStory(`
+export const Primary = {
+  args: {
+    label: 'Render',
+  },
+  render: (args) => h(MyButton, { theme: args.theme, label: args.label }),
+};
+`)
+    ).toBeUndefined();
   });
 
   it('applies args spread and later literal overrides', () => {

--- a/code/renderers/vue3/src/story-docs/transform-h.ts
+++ b/code/renderers/vue3/src/story-docs/transform-h.ts
@@ -34,6 +34,8 @@ export interface TransformHInput {
   node: t.Node;
   /** Merged and classified CSF args visible to the render function. */
   args: ClassifiedArg[];
+  /** Names of args explicitly set to `undefined`, which render as if they were never written. */
+  unsetArgs: Set<string>;
   /** Name of the render function's args parameter. */
   argsParam?: string;
   /** Story component tag the docgen roles describe. */
@@ -53,6 +55,7 @@ export interface TransformHResult {
 
 type HRenderOptions = {
   args: ClassifiedArg[];
+  unsetArgs: ReadonlySet<string>;
   argsParam?: string;
   /** Story component tag the docgen roles apply to; absent in slot content. */
   componentName?: string;
@@ -77,6 +80,7 @@ type HArguments = {
 const H_FUNCTION = 'h';
 
 const NO_DOCGEN: VueDocgenArgInfo = { props: new Set(), events: new Set(), slots: new Set() };
+const NO_UNSET_ARGS: ReadonlySet<string> = new Set();
 
 /** @see https://html.spec.whatwg.org/multipage/syntax.html#void-elements */
 const VOID_ELEMENTS = new Set([
@@ -108,6 +112,7 @@ export function transformH(input: TransformHInput): TransformHResult | undefined
     : new Map<string, string>();
   const templateCode = renderHNode(input.node, {
     args: input.args,
+    unsetArgs: input.unsetArgs,
     argsParam: input.argsParam,
     componentName: input.componentName,
     componentImportStatements,
@@ -158,6 +163,7 @@ function renderHSlotFunction(
 
   return renderHNode(returned, {
     args: [],
+    unsetArgs: NO_UNSET_ARGS,
     componentImportStatements,
     ctx,
     // Slot content renders children of components the story does not describe, so nothing here can
@@ -361,9 +367,18 @@ function collectProps(node: t.Node, options: HRenderOptions): ClassifiedArg[] | 
     }
 
     const name = keyOf(property);
-    const argValue = name ? substituteArgsMember(property.value, options) : undefined;
-    if (!name || !argValue) {
+    if (!name) {
       return undefined;
+    }
+
+    const argValue = substituteArgsMember(property.value, options);
+
+    if (!argValue) {
+      if (!referencesUnsetArg(property.value, options)) {
+        return undefined;
+      }
+      argsByName.delete(name);
+      continue;
     }
 
     const classification = classifyArg(name, argValue, options.docgen);
@@ -402,8 +417,9 @@ function renderChildren(node: t.Node | undefined, options: HRenderOptions): stri
 // 'Hi', h('b', 'Hi'), or ['a', h('b', 'c')] -> one markup child per rendered vnode
 function renderChildValue(node: t.Node, options: HRenderOptions): string[] | undefined {
   const value = substituteArgsMember(node, options);
+  // An `undefined` child renders nothing at all, so it contributes no markup.
   if (!value) {
-    return undefined;
+    return referencesUnsetArg(node, options) ? [] : undefined;
   }
 
   const unwrapped = unwrapExpression(value);
@@ -481,6 +497,18 @@ function substituteArgsMember(node: t.Node, options: HRenderOptions): t.Node | u
   }
 
   return options.args.find((candidate) => candidate.name === property.name)?.value;
+}
+
+// args.label -> whether 'label' is an arg the story explicitly set to `undefined`
+function referencesUnsetArg(node: t.Node, options: HRenderOptions): boolean {
+  const value = unwrapExpression(node);
+  if (!options.argsParam || !t.isMemberExpression(value) || value.computed) {
+    return false;
+  }
+  if (!t.isIdentifier(value.object, { name: options.argsParam })) {
+    return false;
+  }
+  return t.isIdentifier(value.property) && options.unsetArgs.has(value.property.name);
 }
 
 function isArgsIdentifier(node: t.Node, argsParam: string | undefined): boolean {

--- a/code/renderers/vue3/src/story-docs/transform-template.test.ts
+++ b/code/renderers/vue3/src/story-docs/transform-template.test.ts
@@ -808,6 +808,169 @@ export const Primary = {
     ).toBeUndefined();
   });
 
+  it('drops a binding for an arg explicitly set to undefined, which Vue reads as absent', async () => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: { label: 'Hi', theme: undefined },
+  render: (args) => ({
+    components: { MyButton },
+    setup: () => ({ args }),
+    template: '<MyButton :theme="args.theme" :label="args.label" />',
+  }),
+};
+`)
+    ).toMatchInlineSnapshot(`
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
+        <MyButton label="Hi" />
+      </template>"
+    `);
+  });
+
+  it('takes the whole line when the dropped binding was written on its own', async () => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: { label: 'Hi', theme: undefined, status: undefined },
+  render: (args) => ({
+    components: { MyButton },
+    setup: () => ({ args }),
+    template: \`<MyButton
+  :theme="args.theme"
+  :label="args.label"
+  :status="args.status"
+/>\`,
+  }),
+};
+`)
+    ).toMatchInlineSnapshot(`
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
+        <MyButton
+          label="Hi"
+        />
+      </template>"
+    `);
+  });
+
+  it('drops an event binding whose handler arg is undefined', async () => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: { label: 'Hi', onClick: undefined },
+  render: (args) => ({
+    components: { MyButton },
+    setup: () => ({ args }),
+    template: '<MyButton @click="args.onClick" :label="args.label" />',
+  }),
+};
+`)
+    ).toMatchInlineSnapshot(`
+      "<script lang="ts" setup>
+      import MyButton from './MyButton.vue';
+      </script>
+
+      <template>
+        <MyButton label="Hi" />
+      </template>"
+    `);
+  });
+
+  it('keeps a v-model bound to an undefined arg, starting its ref empty', async () => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: { label: 'Hi', modelValue: undefined },
+  render: (args) => ({
+    components: { MyButton },
+    setup: () => ({ args }),
+    template: '<MyButton v-model="args.modelValue" :label="args.label" />',
+  }),
+};
+`)
+    ).toMatchInlineSnapshot(`
+      "<script lang="ts" setup>
+      import { ref } from "vue";
+      import MyButton from './MyButton.vue';
+
+      const modelValue = ref();
+      </script>
+
+      <template>
+        <MyButton v-model="modelValue" label="Hi" />
+      </template>"
+    `);
+  });
+
+  it('bails when an event or model binding names an arg the story never sets', async () => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: { label: 'Hi' },
+  render: (args) => ({
+    components: { MyButton },
+    setup: () => ({ args }),
+    template: '<MyButton @click="args.onClick" :label="args.label" />',
+  }),
+};
+`)
+    ).toBeUndefined();
+
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: { label: 'Hi' },
+  render: (args) => ({
+    components: { MyButton },
+    setup: () => ({ args }),
+    template: '<MyButton v-model="args.modelValue" :label="args.label" />',
+  }),
+};
+`)
+    ).toBeUndefined();
+  });
+
+  it('bails when a bound arg is missing from the story args altogether', async () => {
+    const payload = await buildPayload(`
+export const Primary = {
+  args: { label: 'Hi' },
+  render: (args) => ({
+    components: { MyButton },
+    setup: () => ({ args }),
+    template: '<MyButton :theme="args.theme" :label="args.label" />',
+  }),
+};
+`);
+    const story = payload.stories['example-mybutton--primary'];
+
+    expect(story?.snippet).toBeUndefined();
+    expect(story?.warning).toMatchInlineSnapshot(
+      `"No static snippet: the story template could not be resolved statically."`
+    );
+  });
+
+  it('bails when a static attribute already sets the prop an undefined arg binds', async () => {
+    expect(
+      await primarySnippet(`
+export const Primary = {
+  args: { theme: undefined },
+  render: (args) => ({
+    components: { MyButton },
+    setup: () => ({ args }),
+    template: '<MyButton theme="dark" :theme="args.theme" />',
+  }),
+};
+`)
+    ).toBeUndefined();
+  });
+
   it('substitutes args references inside v-if expressions', async () => {
     expect(
       await primarySnippet(`

--- a/code/renderers/vue3/src/story-docs/transform-template.ts
+++ b/code/renderers/vue3/src/story-docs/transform-template.ts
@@ -50,6 +50,8 @@ export interface TransformTemplateInput {
   template: string;
   /** Merged and classified CSF args for the story. */
   args: ClassifiedArg[];
+  /** Names of args explicitly set to `undefined`, whose bindings render as if never written. */
+  unsetArgs: Set<string>;
   /** Component tag name to import statement from the render object's components map. */
   componentImports: Map<string, string>;
 }
@@ -67,6 +69,7 @@ interface Edit {
 
 interface TransformState {
   argsByName: Map<string, ClassifiedArg>;
+  unsetArgs: Set<string>;
   ctx: RenderContext;
   edits: Edit[];
   componentImports: Map<string, string>;
@@ -82,6 +85,7 @@ interface ArgsReference {
 type ExpressionContext = 'directive' | 'interpolation';
 
 const ARGS_NAME = 'args';
+const BLANK_REGEXP = /[ \t]/;
 const ARGS_IDENTIFIER_REGEXP = /(^|[^\w$])args([^\w$]|$)/;
 const ARGS_MEMBER_REGEXP = /^args\.([A-Za-z_$][\w$]*)$/;
 const SETUP_PROPERTY = 'setup';
@@ -133,6 +137,7 @@ export function transformTemplate(
 
   const state: TransformState = {
     argsByName: new Map(input.args.map((arg) => [arg.name, arg])),
+    unsetArgs: input.unsetArgs,
     ctx: createRenderContext(),
     edits: [],
     componentImports: input.componentImports,
@@ -268,8 +273,21 @@ function transformDirective(
 
   // <MyButton :label="args.label" />
   if (directive.name === 'bind' && boundProp && directive.modifiers.length === 0 && argName) {
+    if ((nameCounts.get(boundProp) ?? 0) > 1) {
+      return false;
+    }
+
     const arg = state.argsByName.get(argName);
-    if (!arg || arg.role === 'slot' || (nameCounts.get(boundProp) ?? 0) > 1) {
+    // Vue resolves a prop bound to `undefined` to its declared default, exactly as an absent
+    // attribute does, so the binding is dropped rather than failing the whole snippet.
+    if (!arg) {
+      if (!state.unsetArgs.has(argName)) {
+        return false;
+      }
+      state.edits.push(replacementFor(directive, '', state.template));
+      return true;
+    }
+    if (arg.role === 'slot') {
       return false;
     }
     state.edits.push({
@@ -283,6 +301,11 @@ function transformDirective(
   // <MyButton @click="args.onClick" />
   if (directive.name === 'on' && boundProp && argName && expressionNode) {
     const arg = state.argsByName.get(argName);
+    // An `undefined` handler attaches no listener, exactly as an absent binding does.
+    if (!arg && state.unsetArgs.has(argName)) {
+      state.edits.push(replacementFor(directive, '', state.template));
+      return true;
+    }
     if (!arg || !isFunctionExpression(arg.value)) {
       return false;
     }
@@ -297,13 +320,18 @@ function transformDirective(
   // <MyButton v-model="args.modelValue" />
   if (directive.name === 'model' && argName && expressionNode) {
     const arg = state.argsByName.get(argName);
-    if (!arg || arg.role === 'slot' || arg.role === 'event') {
+    // Dropping the binding would drop the two-way flow the story demonstrates, so an arg with no
+    // value keeps the model and starts its ref empty, which is the state the story renders in.
+    if (!arg && !state.unsetArgs.has(argName)) {
+      return false;
+    }
+    if (arg && (arg.role === 'slot' || arg.role === 'event')) {
       return false;
     }
     state.edits.push({
       start: expressionNode.loc.start.offset,
       end: expressionNode.loc.end.offset,
-      text: hoistModelRef(argName, arg.value, state.ctx),
+      text: hoistModelRef(argName, arg?.value, state.ctx),
     });
     return true;
   }
@@ -542,16 +570,37 @@ function replacementForArgsReference(
 
 /**
  * Removing a directive outright must also consume the whitespace that separated it from its
- * neighbors, so `<MyButton v-bind="args" />` with nothing to expand stays `<MyButton />`.
+ * neighbors, so `<MyButton v-bind="args" />` with nothing to expand stays `<MyButton />`, and a
+ * directive written on its own line takes the line with it instead of leaving a blank one.
  */
 function replacementFor(directive: DirectiveNode, text: string, template: string): Edit {
-  let start = directive.loc.start.offset;
-  if (text === '') {
-    while (start > 0 && template[start - 1] === ' ') {
-      start -= 1;
-    }
+  const start = directive.loc.start.offset;
+  const end = directive.loc.end.offset;
+  if (text !== '') {
+    return { start, end, text };
   }
-  return { start, end: directive.loc.end.offset, text };
+
+  const lineStart = blankRunStart(template, start);
+  const lineEnd = blankRunEnd(template, end);
+  return template[lineStart - 1] === '\n' && template[lineEnd] === '\n'
+    ? { start: lineStart - 1, end: lineEnd, text }
+    : { start: lineStart, end, text };
+}
+
+function blankRunStart(template: string, index: number): number {
+  let start = index;
+  while (start > 0 && BLANK_REGEXP.test(template[start - 1])) {
+    start -= 1;
+  }
+  return start;
+}
+
+function blankRunEnd(template: string, index: number): number {
+  let end = index;
+  while (end < template.length && BLANK_REGEXP.test(template[end])) {
+    end += 1;
+  }
+  return end;
 }
 
 function applyEdits(template: string, edits: Edit[]): string {


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

In Vue Story snippet, the snippet generation would bail out if a variable is set to undefined : 

```ts
export const Primary = {
  args: { label: 'Hi', theme: undefined, status: undefined },
  render: (args) => ({
    components: { MyButton },
    setup: () => ({ args }),
    template: \`<MyButton
  :theme="args.theme"
  :label="args.label"
  :status="args.status"
/>\`,
  }),
};
```

the story above doesn't produce any snippet because `status` or `theme` are undefined.

What happens frequently are props with defaults, this means that some args can be undefined.

This PR makes args set to `undefined` as "ommitted" so the snippet renderer drops the binding instead of failing.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing


- `yarn task sandbox --template vue3-vite/docgen-server-ts --start-from auto`
- `cd ../storybook-sandboxes/vue3-vite-docgen-server-ts`
-  Add a Button story with `args: { id: undefined, label: 'Hi' }` and a template binding `:id="args.id" :label="args.label"`
- Open the story's Docs tab, the Show code snippet renders `<MyButton label="Hi" />` instead of falling back to the runtime source


> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
