### PR TITLE
fix: add staticDirs for web-components-vite to copy Stencil loader directory (fixes #25704)

### DIFF
--- a/code/frameworks/web-components-vite/src/preset.ts
+++ b/code/frameworks/web-components-vite/src/preset.ts
@@ -4,3 +4,11 @@ export const core: PresetProperty<'core'> = {
   builder: import.meta.resolve('@storybook/builder-vite'),
   renderer: import.meta.resolve('@storybook/web-components/preset'),
 };
+
+// Ensure Stencil's generated loader directory is copied to the static build output
+// for web-components projects using Stencil. This fixes the issue where
+// defineCustomElements() loads components lazily from the generated loader/
+// directory, which was not included in the static build output.
+export const staticDirs: PresetProperty<'staticDirs'> = [
+  { from: 'loader', to: '/loader' },
+];


### PR DESCRIPTION
## Problem

Web-components projects using Stencil don't produce a runnable static build because the Stencil-generated `loader/` directory (with custom elements loaded via `defineCustomElements()`) isn't included in the `storybook-static/` output.

This happens because Vite only includes assets it can statically trace, and the dynamically loaded Stencil chunks aren't being copied.

## Solution

Added a default `staticDirs` preset property to the `web-components-vite` framework that copies the `loader/` directory to the static build output.

This ensures `defineCustomElements()` can find the generated Stencil loader/assets in the built Storybook.

## Changes

- `code/frameworks/web-components-vite/src/preset.ts`: Added `staticDirs` preset property to copy `loader/` directory

## Testing

- This is a configuration-only change that adds a default `staticDirs` entry
- The `loader/` directory is generated by Stencil at build time
- The fix follows the existing `staticDirs` pattern used by other addons (e.g., vitest addon)
- Verified the preset loads correctly (no breaking changes to existing config)

## Related

- Fixes #25704
- Related to PR #33438 (documentation workaround)
