### PR TITLE
Core: Only copy a dev tools hook into the preview when the top frame has one

### DIFF
--- a/code/core/assets/server/base-preview-head.html
+++ b/code/core/assets/server/base-preview-head.html
@@ -483,8 +483,14 @@
   /* globals window */
   try {
     if (window.top !== window) {
-      window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = window.top.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-      window.__VUE_DEVTOOLS_GLOBAL_HOOK__ = window.top.__VUE_DEVTOOLS_GLOBAL_HOOK__;
+      // Copying an absent hook still creates the key, and hook detection tests for the key rather
+      // than its value, so an unguarded assignment reads as "already installed".
+      if (window.top.__REACT_DEVTOOLS_GLOBAL_HOOK__) {
+        window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = window.top.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+      }
+      if (window.top.__VUE_DEVTOOLS_GLOBAL_HOOK__) {
+        window.__VUE_DEVTOOLS_GLOBAL_HOOK__ = window.top.__VUE_DEVTOOLS_GLOBAL_HOOK__;
+      }
       window.top.__VUE_DEVTOOLS_CONTEXT__ = window.document;
     }
   } catch (e) {

--- a/code/core/src/common/utils/__tests__/base-preview-head.test.ts
+++ b/code/core/src/common/utils/__tests__/base-preview-head.test.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+interface StubWindow {
+  top?: unknown;
+  document?: unknown;
+  __REACT_DEVTOOLS_GLOBAL_HOOK__?: unknown;
+  __VUE_DEVTOOLS_GLOBAL_HOOK__?: unknown;
+  __VUE_DEVTOOLS_CONTEXT__?: unknown;
+}
+
+const basePreviewHead = readFileSync(
+  new URL('../../../../assets/server/base-preview-head.html', import.meta.url),
+  'utf8'
+);
+
+const runDevToolsBridge = (previewWindow: StubWindow) => {
+  const scriptBody = /<script>([\s\S]*?)<\/script>/.exec(basePreviewHead)?.[1];
+
+  if (!scriptBody) {
+    throw new Error('base-preview-head.html no longer contains an inline script');
+  }
+
+  new Function('window', scriptBody)(previewWindow);
+};
+
+describe('base-preview-head.html dev tools bridge', () => {
+  it('copies the dev tools hooks from the top frame when it has them', () => {
+    const reactHook = { renderers: new Map() };
+    const vueHook = { apps: [] };
+    const topWindow: StubWindow = {
+      __REACT_DEVTOOLS_GLOBAL_HOOK__: reactHook,
+      __VUE_DEVTOOLS_GLOBAL_HOOK__: vueHook,
+    };
+    const previewDocument = {};
+    const previewWindow: StubWindow = { top: topWindow, document: previewDocument };
+
+    runDevToolsBridge(previewWindow);
+
+    expect(previewWindow.__REACT_DEVTOOLS_GLOBAL_HOOK__).toBe(reactHook);
+    expect(previewWindow.__VUE_DEVTOOLS_GLOBAL_HOOK__).toBe(vueHook);
+    expect(topWindow.__VUE_DEVTOOLS_CONTEXT__).toBe(previewDocument);
+  });
+
+  it('leaves the hook keys absent when the top frame has none', () => {
+    const previewWindow: StubWindow = { top: {}, document: {} };
+
+    runDevToolsBridge(previewWindow);
+
+    expect('__REACT_DEVTOOLS_GLOBAL_HOOK__' in previewWindow).toBe(false);
+    expect('__VUE_DEVTOOLS_GLOBAL_HOOK__' in previewWindow).toBe(false);
+  });
+
+  it('keeps a hook the preview installed itself when the top frame has none', () => {
+    const previewHook = { renderers: new Map() };
+    const previewWindow: StubWindow = {
+      top: {},
+      document: {},
+      __REACT_DEVTOOLS_GLOBAL_HOOK__: previewHook,
+    };
+
+    runDevToolsBridge(previewWindow);
+
+    expect(previewWindow.__REACT_DEVTOOLS_GLOBAL_HOOK__).toBe(previewHook);
+  });
+
+  it('does nothing when the preview is not framed', () => {
+    const previewWindow: StubWindow = { document: {} };
+    previewWindow.top = previewWindow;
+
+    runDevToolsBridge(previewWindow);
+
+    expect('__REACT_DEVTOOLS_GLOBAL_HOOK__' in previewWindow).toBe(false);
+    expect('__VUE_DEVTOOLS_CONTEXT__' in previewWindow).toBe(false);
+  });
+});


### PR DESCRIPTION
No existing issue — I hit this on my own Storybook and traced it back to here.

## What I did

`base-preview-head.html` copies the top frame's dev tools hooks into the preview iframe:

```js
if (window.top !== window) {
  window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = window.top.__REACT_DEVTOOLS_GLOBAL_HOOK__;
  window.__VUE_DEVTOOLS_GLOBAL_HOOK__ = window.top.__VUE_DEVTOOLS_GLOBAL_HOOK__;
  ...
}
```

When the React DevTools extension isn't installed there is nothing to copy, so the assignment still creates an own property on the preview's `window` holding `undefined`.

That placeholder is the problem. Tools that hack React internals detect an installed hook by the key's *presence*, not its value. bippy is the one I ran into:

```js
export const hasRDTHook = () => Object.prototype.hasOwnProperty.call(globalThis, "__REACT_DEVTOOLS_GLOBAL_HOOK__");

export const getRDTHook = (onActive) => {
  if (!hasRDTHook()) return installRDTHook(onActive);
  patchRDTHook(onActive);
  return globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__; // undefined
};
```

`getRDTHook()` sees the key, skips its own install, and returns `undefined`. `instrument()` then does `rdtHook._instrumentationSource = ...` and throws `TypeError: undefined is not an object` — while the preview bundle is still evaluating. `PreviewWeb` is never constructed, so the manager never receives `storyRendered` and **every story sits on a permanent spinner**. No error surfaces anywhere, because the throw happens before Storybook's own error handling is wired up.

Opening `iframe.html` directly always worked, which is what made it look like a broken story rather than a broken preview: `window.top === window` there, so the copy is skipped entirely.

This reaches Storybook users through ordinary dependency chains — `react-scan` imports `bippy`, and also `react-grab` which imports its own copy. bippy fixed its side in 0.7.0, but `react-scan@0.5.7` pins `bippy@^0.5.39` and `react-grab@0.2.0` pins `^0.6.1`, so neither can currently reach that fix. Storybook is the layer that creates the invalid state, and guarding here fixes it for every tool that does presence-based detection, not just bippy.

The change is to only copy a hook that actually exists. Two behaviours worth calling out:

- With DevTools installed, the bridge works exactly as before.
- Without it, the preview's own `__REACT_DEVTOOLS_GLOBAL_HOOK__` — if a bundled tool installed one — is no longer clobbered.

`__VUE_DEVTOOLS_CONTEXT__` is still assigned unconditionally, since that direction writes the preview's document into the top frame and doesn't depend on a hook being present.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`code/core/src/common/utils/__tests__/base-preview-head.test.ts` reads the shipped asset, pulls out the inline script, and evaluates it against stub windows. Reverting the `.html` change fails two of the four cases:

```
× leaves the hook keys absent when the top frame has none
  AssertionError: expected true to be false
× keeps a hook the preview installed itself when the top frame has none
  AssertionError: expected undefined to be { renderers: Map{} }
```

Run with:

```bash
yarn vitest run --config code/core/vitest.config.ts --typecheck.enabled=false src/common/utils/__tests__/
```

All 7 files / 40 tests in that directory pass except `normalize-stories.test.ts`, which fails on my machine for an unrelated reason (`Cannot find package 'storybook/internal/server-errors'` — it needs a full `yarn build` first).

#### Manual testing

The invariant is one line, and needs a browser with **no React DevTools extension** — Safari, or a clean Chrome profile:

1. Start any sandbox, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open a story in the manager (not `iframe.html`)
3. In devtools, select the preview iframe as the JS context and run:
   ```js
   Object.prototype.hasOwnProperty.call(window, '__REACT_DEVTOOLS_GLOBAL_HOOK__')
   ```
   Before this PR: `true`, with `window.__REACT_DEVTOOLS_GLOBAL_HOOK__ === undefined`.
   After: `false`.
4. Confirm the bridge still works: with the React DevTools extension enabled, the same expression is `true` and the value is the extension's hook object (it has `getFiberRoots`).

For the full user-visible failure:

1. In the sandbox, `yarn add -D react-scan@0.5.7`
2. Add `import { scan } from 'react-scan'; scan({ enabled: true });` to `.storybook/preview.ts`
3. Open a story in the manager in Safari or a clean Chrome profile

   Before this PR: permanent spinner on every story, and `TypeError: undefined is not an object (evaluating 't._instrumentationSource=e.name??P2')` in the preview iframe's console. Opening the same story via `iframe.html?id=…` renders fine.
   After: the story renders.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

Nothing user-facing to document — the script is internal and its intended behaviour is unchanged.

---

*AI disclosure, per CONTRIBUTING.md: this was investigated and written with Claude Code assisting. The bug is one I hit on my own Storybook, and I'm following the thread — happy to adjust the approach or drop the unit test if you'd rather not test an HTML asset this way.*
