### PR TITLE
Vue: Fix setup statement slicing on Windows

### DIFF
--- a/code/renderers/vue3/src/story-docs/forward-setup.test.ts
+++ b/code/renderers/vue3/src/story-docs/forward-setup.test.ts
@@ -116,6 +116,41 @@ export const Primary = {
     expect(story?.warning).toBeUndefined();
   });
 
+  it('forwards setup statements from CRLF story source', async () => {
+    const story = await primaryStory(
+      [
+        '',
+        'export const Primary = {',
+        "  args: { label: 'Hi' },",
+        '  render: (args) => ({',
+        '    components: { MyButton },',
+        '    setup() {',
+        '      const count = ref(0);',
+        '      return { args, count };',
+        '    },',
+        '    template: \'<MyButton :label="args.label" @click="count++" />\',',
+        '  }),',
+        '};',
+        '',
+      ].join('\r\n'),
+      "import { ref } from 'vue';\nimport MyButton from './MyButton.vue';"
+    );
+
+    expect(story?.snippet).toMatchInlineSnapshot(`
+      "<script lang="ts" setup>
+      import { ref } from "vue";
+      import MyButton from './MyButton.vue';
+
+      const count = ref(0);
+      </script>
+
+      <template>
+        <MyButton label="Hi" @click="count++" />
+      </template>"
+    `);
+    expect(story?.warning).toBeUndefined();
+  });
+
   it('substitutes arg reads inside statements, sharing hoisted consts with the template', async () => {
     const story = await primaryStory(
       `

--- a/code/renderers/vue3/src/story-docs/forward-setup.ts
+++ b/code/renderers/vue3/src/story-docs/forward-setup.ts
@@ -64,7 +64,11 @@ const ARGS_NAME = 'args';
 
 type SetupBody = { statements: t.Statement[]; returned?: t.Node };
 
-type ArgsReadsResult = { ok: true; reads: ArgsRead[] } | { ok: false; reference: string };
+type SourcePosition = NonNullable<t.Node['loc']>['start'];
+type SourceRange = { start: SourcePosition; end: SourcePosition };
+type ArgsReadLocation = SourceRange & { name: string };
+
+type ArgsReadsResult = { ok: true; reads: ArgsReadLocation[] } | { ok: false; reference: string };
 
 /**
  * Reads a render object's `setup` into statements the snippet forwards into `<script setup>`.
@@ -182,24 +186,45 @@ export function readForwardableSetup(
     return bail(setupReferencesWarning(unresolvable));
   }
 
+  const lineStarts = lineStartOffsets(options.source);
   const statements: ForwardableStatement[] = [];
   for (const statement of body.statements) {
-    const { start, end, loc } = statement;
-    if (start == null || end == null || loc == null || end > options.source.length) {
+    const { loc } = statement;
+    if (loc == null) {
+      return bail(SETUP_UNSUPPORTED_WARNING);
+    }
+    const start = offsetAt(lineStarts, loc.start);
+    const end = offsetAt(lineStarts, loc.end);
+    if (start == null || end == null || start > end || end > options.source.length) {
       return bail(SETUP_UNSUPPORTED_WARNING);
     }
     const reads = collectArgsReads(statement, options.argsParam);
     if (!reads.ok) {
       return bail(setupReferencesWarning([reads.reference]));
     }
+    const argsReads: ArgsRead[] = [];
+    for (const read of reads.reads) {
+      const readStart = offsetAt(lineStarts, read.start);
+      const readEnd = offsetAt(lineStarts, read.end);
+      if (
+        readStart == null ||
+        readEnd == null ||
+        readStart < start ||
+        readEnd < readStart ||
+        readEnd > end
+      ) {
+        return bail(SETUP_UNSUPPORTED_WARNING);
+      }
+      argsReads.push({
+        start: readStart - start,
+        end: readEnd - start,
+        name: read.name,
+      });
+    }
     statements.push({
       source: options.source.slice(start, end),
       column: loc.start.column,
-      argsReads: reads.reads.map((read) => ({
-        start: read.start - start,
-        end: read.end - start,
-        name: read.name,
-      })),
+      argsReads,
     });
   }
 
@@ -211,6 +236,27 @@ export function readForwardableSetup(
       statements: [...statements, ...aliasStatements],
     },
   };
+}
+
+function lineStartOffsets(source: string): number[] {
+  const starts = [0];
+  for (let index = 0; index < source.length; index += 1) {
+    const code = source.charCodeAt(index);
+    if (code === 13) {
+      if (source.charCodeAt(index + 1) === 10) {
+        index += 1;
+      }
+      starts.push(index + 1);
+    } else if (code === 10 || code === 0x2028 || code === 0x2029) {
+      starts.push(index + 1);
+    }
+  }
+  return starts;
+}
+
+function offsetAt(lineStarts: number[], pos: { line: number; column: number }): number | undefined {
+  const lineStart = lineStarts[pos.line - 1];
+  return lineStart == null ? undefined : lineStart + pos.column;
 }
 
 // setup() { ...statements; return {...}; } or setup: () => ({ ... })
@@ -245,7 +291,7 @@ function collectArgsReads(statement: t.Statement, argsParam: string | undefined)
     return { ok: true, reads: [] };
   }
 
-  const reads: ArgsRead[] = [];
+  const reads: ArgsReadLocation[] = [];
   let blocked: string | undefined;
 
   const visit = (node: t.Node, parent?: t.Node): void => {
@@ -272,16 +318,11 @@ function collectArgsReads(statement: t.Statement, argsParam: string | undefined)
         !parent.computed
           ? parent
           : undefined;
-      if (
-        !member ||
-        !t.isIdentifier(member.property) ||
-        member.start == null ||
-        member.end == null
-      ) {
+      if (!member || !t.isIdentifier(member.property) || member.loc == null) {
         blocked = argsParam;
         return;
       }
-      reads.push({ start: member.start, end: member.end, name: member.property.name });
+      reads.push({ start: member.loc.start, end: member.loc.end, name: member.property.name });
       return;
     }
 

--- a/code/renderers/vue3/src/story-docs/transform-template.ts
+++ b/code/renderers/vue3/src/story-docs/transform-template.ts
@@ -271,6 +271,7 @@ function appendSetupStatements(setup: ForwardableSetup, state: TransformState): 
       const wrapped = wrapSubstitution(rendered, text.slice(read.end));
       text = text.slice(0, read.start) + wrapped + text.slice(read.end);
     }
+    text = text.replace(/\r\n?/g, '\n');
     state.ctx.statements.push(dedentBy(text, statement.column));
   }
   return true;


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did


Test release broke on release branch due to the Vue Story snippet reachitecture PR. 

Setup forwarding sliced the story-file source with babel character offsets. 
But `loadCsf` parses through recast, which re-joins the source lines with `os.EOL` before parsing.

On Windows every offset is CRLF-space while the checked-out file is LF, shifting every forwarded statement and substitution right by one character per preceding line.

This pR 
- map babel `loc` line/column positions onto the source through a line-start offset table instead of trusting character offsets
- normalize `\r\n` in forwarded statement text so snippets stay LF even for CRLF story files

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
