### PR TITLE
Tools: Spawn a child host for local mode when cwd differs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,8 @@ AST indexing keeps the sidebar fast and prevents one broken story file from brea
 - Register services and toolsets from the same `services` preset hook and behind the same feature
   gate. Missing or duplicate registrations fail loudly.
 - Read `code/core/src/shared/open-service/README.md` before changing the contract, adapters,
-  registration, docs access, transport rendering, or tools CLI.
+  registration, docs access, transport rendering, or tools CLI. Local `createTools` never
+  `chdir`s: a foreign `cwd` starts a project-local child host.
 
 ### Agent-facing skills
 

--- a/code/core/src/cli/tools/architecture.md
+++ b/code/core/src/cli/tools/architecture.md
@@ -119,7 +119,8 @@ consumer amortizes config load across many calls on the live synced runtime.
    state. `.loaded()` warms via delegated commands. Every command goes over the channel.
 6. **Render + close.** `ToolsetOutcome` through markdown / `--json`; `ok` drives the exit code.
 
-Local mode (no instance, or `--no-attach`) loads the target configuration in this process.
+Local mode (no instance, or `--no-attach`) loads in-process when `cwd` already matches, and
+starts a child host when it does not.
 
 ## Failure matrix
 

--- a/code/core/src/cli/tools/help.test.ts
+++ b/code/core/src/cli/tools/help.test.ts
@@ -51,7 +51,7 @@ describe('tools help rendering', () => {
         --cwd <path>                 Project directory of the target Storybook
         -c, --config-dir <dir-name>  Storybook config directory of the target Storybook
         --attach                     Require attaching to a running Storybook; gate failures are errors instead of a local fallback
-        --no-attach                  Load the project configuration in this process; never attach
+        --no-attach                  Load the project configuration without attaching
         --input <object>             Raw JSON object with the tool arguments (escape hatch for complex values)
         --json                       Print the tool's structured result data as JSON instead of markdown
         -o, --output <path>          Write the result to a file instead of stdout
@@ -61,7 +61,7 @@ describe('tools help rendering', () => {
         example get-http-frame  Inspect an HTTP frame  [local]
         example preview         Preview an example  [requires running Storybook]
 
-      [local] tools run in this process, without a running Storybook.
+      [local] tools run without a running Storybook.
       [requires running Storybook] tools need a running Storybook dev server; start it first.
       Individual \`--key value\` flags override entries of \`--input\`.
 

--- a/code/core/src/cli/tools/help.ts
+++ b/code/core/src/cli/tools/help.ts
@@ -121,7 +121,7 @@ export function renderToolsHelpFromCatalog(catalog: ToolsetCatalog): string {
     commandBlock,
   ].join('\n');
   const notes = [
-    `${LOCAL_BADGE} tools run in this process, without a running Storybook.`,
+    `${LOCAL_BADGE} tools run without a running Storybook.`,
     `${DEV_SERVER_BADGE} tools need a running Storybook dev server; start it first.`,
     'Individual `--key value` flags override entries of `--input`.',
   ].join('\n');

--- a/code/core/src/cli/tools/run.test.ts
+++ b/code/core/src/cli/tools/run.test.ts
@@ -758,6 +758,34 @@ describe('attached tools', () => {
     expect(result.output).toContain('Button');
   });
 
+  it('intercepts requiresDevServer tools on a local child host with the same guidance as in-process', async () => {
+    const tools = makeLocalTools();
+    const child: LocalTools = {
+      ...tools,
+      host: 'child',
+      runtime: {
+        ...tools.runtime,
+        toolsets: [],
+      },
+    };
+    const { deps, discoverInstance } = makeDeps({
+      createTools: vi.fn(async () => child),
+      discoverInstance: vi.fn(async () => ({ currentRecord: RECORD, records: [RECORD] })),
+    });
+
+    const result = await run(
+      ['stories', 'preview', '--stories', '[{"storyId":"button--primary"}]'],
+      deps,
+      { attach: false }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.outcome).toEqual({ kind: 'intercept', reason: 'requires-dev-server' });
+    expect(result.output).toContain('http://localhost:6006');
+    expect(result.output).toContain('--no-attach');
+    expect(discoverInstance).toHaveBeenCalled();
+  });
+
   it('runs a requiresDevServer tool caller-side with the instance origin, without proxying', async () => {
     clearToolsetRegistry();
     registerToolset(

--- a/code/core/src/cli/tools/run.test.ts
+++ b/code/core/src/cli/tools/run.test.ts
@@ -806,7 +806,7 @@ describe('attached tools', () => {
   it('prints the SDK fallback notice separately from the local result', async () => {
     const tools = makeLocalTools();
     tools.fallbackNotice =
-      "No running Storybook was found for this project.\n\nFalling back to loading this project's Storybook configuration in this process.";
+      "No running Storybook was found for this project.\n\nFalling back to loading this project's Storybook configuration.";
     const { deps, createTools } = makeDeps({
       createTools: vi.fn(async () => tools),
     });

--- a/code/core/src/cli/tools/run.test.ts
+++ b/code/core/src/cli/tools/run.test.ts
@@ -86,6 +86,7 @@ function makeLocalTools(runtimeOverrides: Partial<ToolsRuntime> = {}): LocalTool
   const storybook = { version: '0.0.0', configDir: runtime.configDir };
   return {
     mode: 'local',
+    host: 'in-process',
     clientInfo: { name: 'storybook-cli', version: '0.0.0', kind: 'cli' },
     runtime,
     storybook,
@@ -727,6 +728,26 @@ describe('attached tools', () => {
     await run(['docs', 'list'], deps, { attach: false });
 
     expect(createTools).toHaveBeenCalledWith(expect.objectContaining({ mode: 'local' }));
+  });
+
+  it('dispatches a local child host through describe and call', async () => {
+    const tools = makeLocalTools();
+    const child: LocalTools = {
+      ...tools,
+      host: 'child',
+      runtime: {
+        ...tools.runtime,
+        toolsets: [],
+      },
+    };
+    const { deps } = makeDeps({
+      createTools: vi.fn(async () => child),
+    });
+
+    const result = await run(['docs', 'list'], deps, { attach: false });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('Button');
   });
 
   it('runs a requiresDevServer tool caller-side with the instance origin, without proxying', async () => {

--- a/code/core/src/cli/tools/run.ts
+++ b/code/core/src/cli/tools/run.ts
@@ -190,7 +190,7 @@ export async function runToolsCommand(
 
   try {
     const dispatched =
-      tools.mode === 'attached'
+      tools.mode === 'attached' || tools.host === 'child'
         ? await dispatchAttachedTools(tools, normalized, parsed, result, deps)
         : await dispatchLocalTools(tools, normalized, parsed, deps, requestedMode, result);
     return { ...dispatched, attachMode: tools.mode, fallbackNotice: tools.fallbackNotice };

--- a/code/core/src/cli/tools/run.ts
+++ b/code/core/src/cli/tools/run.ts
@@ -1,11 +1,6 @@
 import { versions } from 'storybook/internal/common';
 
-import type {
-  AnyToolsetDefinition,
-  AnyToolsetMethod,
-  ToolsetCtx,
-  ToolsetTelemetry,
-} from '../../shared/open-service/toolset-definition.ts';
+import type { ToolsetTelemetry } from '../../shared/open-service/toolset-definition.ts';
 import { parseToolsetMethodId, toCliMethodName } from '../../shared/open-service/toolset-names.ts';
 import type { StorybookInstanceRecord } from './instances/types.ts';
 import {
@@ -17,7 +12,6 @@ import {
   type Tools,
   type ToolsClientInfo,
   type ToolsMode,
-  type ToolsRuntime,
 } from './sdk/index.ts';
 import {
   discoverRunningInstance,
@@ -25,11 +19,8 @@ import {
   type ToolsTarget,
 } from './discover-instance.ts';
 import {
-  renderMethodHelp,
   renderMethodHelpFromCatalog,
-  renderToolsHelp,
   renderToolsHelpFromCatalog,
-  renderToolsetHelp,
   renderToolsetHelpFromCatalog,
 } from './help.ts';
 import { parseToolsTokens, type ParsedToolsTokens, type ToolsOutputFlags } from './tool-tokens.ts';
@@ -194,22 +185,20 @@ export async function runToolsCommand(
   }
 
   try {
-    const dispatched =
-      tools.mode === 'attached' || tools.host === 'child'
-        ? await dispatchAttachedTools(tools, normalized, parsed, result, deps)
-        : await dispatchLocalTools(tools, normalized, parsed, deps, requestedMode, result);
+    const dispatched = await dispatchTools(tools, normalized, parsed, deps, requestedMode, result);
     return { ...dispatched, attachMode: tools.mode, fallbackNotice: tools.fallbackNotice };
   } finally {
     await tools.close();
   }
 }
 
-async function dispatchAttachedTools(
+async function dispatchTools(
   tools: Tools,
   invocation: ToolsInvocation,
   parsed: Extract<ParsedToolsTokens, { ok: true }>,
-  result: (partial: Omit<ToolsRunResult, 'outputPath' | 'attachMode'>) => ToolsRunResult,
-  deps: ToolsRunDeps
+  deps: ToolsRunDeps,
+  requestedMode: ToolsMode,
+  result: (partial: Omit<ToolsRunResult, 'outputPath' | 'attachMode'>) => ToolsRunResult
 ): Promise<ToolsRunResult> {
   const { toolset: toolsetName, tool: toolName } = invocation;
   let catalog;
@@ -271,102 +260,11 @@ async function dispatchAttachedTools(
     });
   }
 
-  try {
-    const outcome = await tools.call(method.ref, parsed.args, {
-      ...(tools.storybook.url ? { origin: tools.storybook.url } : {}),
-      ...(deps.methodTelemetry ? { telemetry: deps.methodTelemetry } : {}),
-    });
-    const output = parsed.json
-      ? JSON.stringify(outcome.data, null, 2)
-      : joinMarkdown(outcome.markdown);
-    return result({
-      exitCode: outcome.ok ? 0 : 1,
-      output,
-      outcome: { kind: outcome.ok ? 'success' : 'failure' },
-    });
-  } catch (error) {
-    if (isInvalidInputError(error)) {
-      const { methodName } = parseToolsetMethodId(method.ref);
-      return result({
-        exitCode: 1,
-        output: formatValidationIssues(
-          `npx storybook tools ${entry.id} ${toCliMethodName(methodName)}`,
-          error.data.issues ?? []
-        ),
-        outcome: { kind: 'intercept', reason: 'invalid-arguments' },
-      });
-    }
-    if (isAgentFacingError(error)) {
-      return result({ exitCode: 1, output: error.message, outcome: { kind: 'failure' } });
-    }
-    return result({
-      exitCode: 1,
-      output: error instanceof Error ? error.message : String(error),
-      outcome: { kind: 'error', error },
-    });
-  }
-}
+  const { methodName } = parseToolsetMethodId(method.ref);
+  const commandPath = `npx storybook tools ${entry.id} ${toCliMethodName(methodName)}`;
 
-async function dispatchLocalTools(
-  tools: Tools,
-  invocation: ToolsInvocation,
-  parsed: Extract<ParsedToolsTokens, { ok: true }>,
-  deps: ToolsRunDeps,
-  requestedMode: ToolsMode,
-  result: (partial: Omit<ToolsRunResult, 'outputPath' | 'attachMode'>) => ToolsRunResult
-): Promise<ToolsRunResult> {
-  const { toolset: toolsetName, tool: toolName, target } = invocation;
-  const runtime = tools.runtime;
-  const ctx = buildContext(runtime, deps, undefined);
-
-  if (!toolsetName) {
-    return result({
-      exitCode: 0,
-      output: renderToolsHelp(runtime.configDir, runtime.toolsets, ctx),
-      outcome: { kind: 'help' },
-    });
-  }
-
-  const toolset = runtime.toolsets.find((candidate) => candidate.id === toolsetName);
-  if (!toolset) {
-    return result({
-      exitCode: 1,
-      output: formatUnknownToolset(toolsetName, runtime),
-      outcome: { kind: 'intercept', reason: 'unknown-toolset' },
-    });
-  }
-
-  if (!toolName) {
-    return result({
-      exitCode: 0,
-      output: renderToolsetHelp(toolset, ctx),
-      outcome: { kind: 'help' },
-    });
-  }
-
-  const methodKey = Object.keys(toolset.methods).find(
-    (key) => key === toMethodKey(toolName) || toCliMethodName(key) === toolName
-  );
-  const method: AnyToolsetMethod | undefined = methodKey ? toolset.methods[methodKey] : undefined;
-  if (!methodKey || !method) {
-    return result({
-      exitCode: 1,
-      output: formatUnknownTool(toolName, toolset),
-      outcome: { kind: 'intercept', reason: 'unknown-tool' },
-    });
-  }
-  const commandPath = `npx storybook tools ${toolset.id} ${toCliMethodName(methodKey)}`;
-
-  if (parsed.help) {
-    return result({
-      exitCode: 0,
-      output: renderMethodHelp(toolset, methodKey, method, ctx),
-      outcome: { kind: 'help' },
-    });
-  }
-
-  if (method.requiresDevServer) {
-    const discovery = await (deps.discoverInstance ?? discoverRunningInstance)(target);
+  if (tools.mode === 'local' && method.requiresDevServer) {
+    const discovery = await (deps.discoverInstance ?? discoverRunningInstance)(invocation.target);
     return result({
       exitCode: 1,
       output: formatRequiresDevServer(commandPath, discovery, requestedMode),
@@ -375,7 +273,8 @@ async function dispatchLocalTools(
   }
 
   try {
-    const outcome = await tools.call(`${toolset.id}.${methodKey}`, parsed.args, {
+    const outcome = await tools.call(method.ref, parsed.args, {
+      ...(tools.storybook.url ? { origin: tools.storybook.url } : {}),
       ...(deps.methodTelemetry ? { telemetry: deps.methodTelemetry } : {}),
     });
     const output = parsed.json
@@ -431,42 +330,8 @@ ${available}
 Run \`npx storybook tools ${entry.id}\` for their descriptions.`;
 }
 
-function buildContext(
-  runtime: ToolsRuntime,
-  deps: ToolsRunDeps,
-  origin: string | undefined
-): ToolsetCtx {
-  const { methodTelemetry } = deps;
-  return {
-    transport: 'cli',
-    ...(origin ? { origin } : {}),
-    getService: runtime.getService,
-    ...(methodTelemetry ? { telemetry: methodTelemetry } : {}),
-  };
-}
-
 function joinMarkdown(markdown: string | string[]): string {
   return Array.isArray(markdown) ? markdown.join('\n\n') : markdown;
-}
-
-function formatUnknownToolset(toolsetName: string, runtime: ToolsRuntime): string {
-  const available = runtime.toolsets.map((toolset) => `- \`${toolset.id}\``).join('\n');
-  return `Unknown toolset \`${toolsetName}\`. The Storybook configuration at ${runtime.configDir} provides:
-
-${available}
-
-Run \`npx storybook tools --help\` for every tool.`;
-}
-
-function formatUnknownTool(toolName: string, toolset: AnyToolsetDefinition): string {
-  const available = Object.keys(toolset.methods)
-    .map((key) => `- \`${toCliMethodName(key)}\``)
-    .join('\n');
-  return `Unknown tool \`${toolName}\`. The \`${toolset.id}\` toolset provides:
-
-${available}
-
-Run \`npx storybook tools ${toolset.id}\` for their descriptions.`;
 }
 
 function formatRequiresDevServer(

--- a/code/core/src/cli/tools/sdk/attach-messages.test.ts
+++ b/code/core/src/cli/tools/sdk/attach-messages.test.ts
@@ -108,7 +108,7 @@ describe('attach failure messages', () => {
     ).toMatchInlineSnapshot(
       `"Restart Storybook (v10.2.0+) to enable attach.
 
-Falling back to loading this project's Storybook configuration in this process."`
+Falling back to loading this project's Storybook configuration."`
     );
   });
 });

--- a/code/core/src/cli/tools/sdk/attach-messages.ts
+++ b/code/core/src/cli/tools/sdk/attach-messages.ts
@@ -69,5 +69,5 @@ export function formatRestartRequired(
 }
 
 export function formatAttachFallback(remediation: string): string {
-  return `${remediation}\n\nFalling back to loading this project's Storybook configuration in this process.`;
+  return `${remediation}\n\nFalling back to loading this project's Storybook configuration.`;
 }

--- a/code/core/src/cli/tools/sdk/child-client.test.ts
+++ b/code/core/src/cli/tools/sdk/child-client.test.ts
@@ -25,6 +25,7 @@ const RECORD: StorybookInstanceRecord = {
 };
 
 const OPTIONS: CreateToolsOptions = { mode: 'attached', configDir: '/repo/.storybook' };
+const LOCAL_OPTIONS: CreateToolsOptions = { mode: 'local', configDir: '/repo/.storybook' };
 const CLIENT: Required<ToolsClientInfo> = {
   name: 'storybook-tools-sdk',
   version: '10.3.0',
@@ -103,9 +104,9 @@ describe('spawnChildHost', () => {
     vi.unstubAllGlobals();
   });
 
-  const spawn = () =>
+  const spawn = (options: CreateToolsOptions = OPTIONS) =>
     spawnChildHost(
-      { record: RECORD, options: OPTIONS, clientInfo: CLIENT },
+      { cwd: RECORD.cwd, options, clientInfo: CLIENT },
       {
         fork: fork as never,
         resolveScript: () => '/repo/node_modules/storybook/dist/cli/tools/sdk/child-host.js',
@@ -141,10 +142,39 @@ describe('spawnChildHost', () => {
     );
   });
 
+  it('forks a local child host without STORYBOOK_ATTACHED_TOOLS', async () => {
+    const tools = await spawn(LOCAL_OPTIONS);
+
+    expect(fork).toHaveBeenCalledWith(
+      '/repo/node_modules/storybook/dist/cli/tools/sdk/child-host.js',
+      [],
+      expect.objectContaining({
+        cwd: '/repo',
+        env: expect.not.objectContaining({
+          STORYBOOK_ATTACHED_TOOLS: 'true',
+        }),
+      })
+    );
+    expect(child.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'init',
+        options: expect.objectContaining({
+          cwd: '/repo',
+          mode: 'local',
+          autoSpawn: false,
+          clientInfo: CLIENT,
+        }),
+      })
+    );
+    expect(tools.mode).toBe('local');
+    expect(tools.host).toBe('child');
+  });
+
   it('proxies describe and call over IPC and returns the child storybook info', async () => {
     const tools = await spawn();
 
     expect(tools.mode).toBe('attached');
+    expect(tools.host).toBe('child');
     expect(tools.storybook).toEqual(HELLO.storybook);
     await expect(tools.describe()).resolves.toEqual({
       configDir: RECORD.configDir,
@@ -256,7 +286,7 @@ describe('spawnChildHost', () => {
 
   it('throws SpawnFailedError when the child-host script cannot be resolved', async () => {
     const failure = spawnChildHost(
-      { record: RECORD, options: OPTIONS, clientInfo: CLIENT },
+      { cwd: RECORD.cwd, options: OPTIONS, clientInfo: CLIENT },
       {
         fork: fork as never,
         resolveScript: () => {

--- a/code/core/src/cli/tools/sdk/child-client.ts
+++ b/code/core/src/cli/tools/sdk/child-client.ts
@@ -229,6 +229,7 @@ export async function spawnChildHost(
       cwd: cwd,
       options: args.options,
       clientInfo: args.clientInfo,
+      resolvedMode,
     });
   } catch (error) {
     closed = true;
@@ -378,9 +379,10 @@ async function waitForHello(
     cwd: string;
     options: CreateToolsOptions;
     clientInfo: Required<ToolsClientInfo>;
+    resolvedMode: 'local' | 'attached';
   }
 ): Promise<ChildHelloMessage> {
-  const { cwd, options, clientInfo } = args;
+  const { cwd, options, clientInfo, resolvedMode } = args;
   return new Promise<ChildHelloMessage>((resolve, reject) => {
     const onMessage = (raw: unknown) => {
       if (isChildMessage(raw) && raw.type === 'hello') {
@@ -435,7 +437,7 @@ async function waitForHello(
         options: {
           ...options,
           cwd,
-          mode: options.mode === 'local' ? 'local' : 'attached',
+          mode: resolvedMode,
           autoSpawn: false,
           clientInfo,
         },

--- a/code/core/src/cli/tools/sdk/child-client.ts
+++ b/code/core/src/cli/tools/sdk/child-client.ts
@@ -23,12 +23,14 @@ import { resolveChildHostScript } from './resolve-project-storybook.ts';
 import type {
   AttachedTools,
   CreateToolsOptions,
+  LocalTools,
+  Tools,
   ToolsCallOptions,
   ToolsClientInfo,
   ToolsDescribeOptions,
+  ToolsMode,
   ToolsetCatalog,
 } from './types.ts';
-import type { StorybookInstanceRecord } from '../instances/types.ts';
 import type { ToolsRuntime } from './local-runtime.ts';
 
 export type SpawnChildHostDeps = {
@@ -39,39 +41,71 @@ export type SpawnChildHostDeps = {
 
 export async function spawnChildHost(
   args: {
-    record: StorybookInstanceRecord;
+    cwd: string;
+    options: CreateToolsOptions & { mode: 'local' };
+    clientInfo: Required<ToolsClientInfo>;
+  },
+  deps?: SpawnChildHostDeps
+): Promise<LocalTools>;
+export async function spawnChildHost(
+  args: {
+    cwd: string;
+    options: CreateToolsOptions & { mode: 'attached' };
+    clientInfo: Required<ToolsClientInfo>;
+  },
+  deps?: SpawnChildHostDeps
+): Promise<AttachedTools>;
+export async function spawnChildHost(
+  args: {
+    cwd: string;
+    options: CreateToolsOptions;
+    clientInfo: Required<ToolsClientInfo>;
+  },
+  deps?: SpawnChildHostDeps
+): Promise<Tools>;
+export async function spawnChildHost(
+  args: {
+    cwd: string;
     options: CreateToolsOptions;
     clientInfo: Required<ToolsClientInfo>;
   },
   deps: SpawnChildHostDeps = {}
-): Promise<AttachedTools> {
+): Promise<Tools> {
   const log = deps.logger ?? logger;
   const forkChild = deps.fork ?? fork;
+  const cwd = args.cwd;
+  const resolvedMode: ToolsMode = args.options.mode === 'local' ? 'local' : 'attached';
 
   let scriptPath: string;
   try {
-    scriptPath = (deps.resolveScript ?? resolveChildHostScript)(args.record.cwd);
+    scriptPath = (deps.resolveScript ?? resolveChildHostScript)(cwd);
   } catch (cause) {
     throw new SpawnFailedError({
-      reason: `Could not resolve \`storybook/internal/tools/child-host\` from ${args.record.cwd}. Install Storybook in that project, then retry.`,
+      reason: `Could not resolve \`storybook/internal/tools/child-host\` from ${cwd}. Install Storybook in that project, then retry.`,
       cause,
     });
+  }
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    STORYBOOK_TOOLS_CHILD_HOST: 'true',
+  };
+  if (resolvedMode === 'attached') {
+    env.STORYBOOK_ATTACHED_TOOLS = 'true';
+  } else {
+    delete env.STORYBOOK_ATTACHED_TOOLS;
   }
 
   let child: ChildProcess;
   try {
     child = forkChild(scriptPath, [], {
-      cwd: args.record.cwd,
+      cwd,
       stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
-      env: {
-        ...process.env,
-        STORYBOOK_TOOLS_CHILD_HOST: 'true',
-        STORYBOOK_ATTACHED_TOOLS: 'true',
-      },
+      env,
     } satisfies ForkOptions);
   } catch (cause) {
     throw new SpawnFailedError({
-      reason: `Could not start a tools child host for ${args.record.cwd}.`,
+      reason: `Could not start a tools child host for ${cwd}.`,
       cause,
     });
   }
@@ -104,7 +138,7 @@ export async function spawnChildHost(
       }
       const error = new ToolsRuntimeError({
         reason: 'connection-lost',
-        message: `The tools child host for ${args.record.cwd} exited${
+        message: `The tools child host for ${cwd} exited${
           signal ? ` (${signal})` : code != null ? ` (code ${code})` : ''
         }.`,
       });
@@ -116,7 +150,7 @@ export async function spawnChildHost(
         return;
       }
       const error = new SpawnFailedError({
-        reason: `The tools child host for ${args.record.cwd} failed.`,
+        reason: `The tools child host for ${cwd} failed.`,
         cause,
       });
       failPending(error);
@@ -144,7 +178,7 @@ export async function spawnChildHost(
   const send = (message: ParentMessage) => {
     if (!child.send) {
       throw new SpawnFailedError({
-        reason: `The tools child host for ${args.record.cwd} has no IPC channel.`,
+        reason: `The tools child host for ${cwd} has no IPC channel.`,
       });
     }
     child.send(message);
@@ -171,7 +205,7 @@ export async function spawnChildHost(
   let hello: ChildHelloMessage;
   try {
     hello = await waitForHello(child, send, {
-      cwd: args.record.cwd,
+      cwd: cwd,
       options: args.options,
       clientInfo: args.clientInfo,
     });
@@ -185,7 +219,7 @@ export async function spawnChildHost(
     closed = true;
     child.kill();
     throw new SpawnFailedError({
-      reason: `The tools child host at ${args.record.cwd} speaks protocol ${hello.version}, but this process expects ${CHILD_HOST_PROTOCOL_VERSION}. Restart your Storybook so both sides match.`,
+      reason: `The tools child host at ${cwd} speaks protocol ${hello.version}, but this process expects ${CHILD_HOST_PROTOCOL_VERSION}. Restart your Storybook so both sides match.`,
     });
   }
 
@@ -210,7 +244,8 @@ export async function spawnChildHost(
   };
 
   return {
-    mode: 'attached',
+    mode: resolvedMode,
+    host: 'child',
     clientInfo: hello.clientInfo,
     storybook: hello.storybook,
     runtime,
@@ -336,7 +371,7 @@ async function waitForHello(
         options: {
           ...options,
           cwd,
-          mode: 'attached',
+          mode: options.mode === 'local' ? 'local' : 'attached',
           autoSpawn: false,
           clientInfo,
         },

--- a/code/core/src/cli/tools/sdk/child-host.test.ts
+++ b/code/core/src/cli/tools/sdk/child-host.test.ts
@@ -32,9 +32,12 @@ describe('runChildHost', () => {
     describe.mockReset();
     call.mockReset();
     handlers.length = 0;
+    delete process.env.STORYBOOK_ATTACHED_TOOLS;
+    delete process.env.STORYBOOK_TOOLS_CHILD_HOST;
     vi.mocked(createTools).mockReset();
     vi.mocked(createTools).mockResolvedValue({
       mode: 'attached',
+      host: 'in-process',
       clientInfo: { name: 'storybook-tools-sdk', version: '10.2.0', kind: 'sdk' },
       storybook: { version: '10.2.0', configDir: '/repo/.storybook', url: 'http://localhost:6006' },
       runtime: {
@@ -58,6 +61,49 @@ describe('runChildHost', () => {
       }
       return { ok: true, data: { ran: true }, markdown: 'ok' };
     });
+  });
+
+  it('boots local tools when init asks for local mode', async () => {
+    vi.mocked(createTools).mockResolvedValue({
+      mode: 'local',
+      host: 'in-process',
+      clientInfo: { name: 'storybook-tools-sdk', version: '10.2.0', kind: 'sdk' },
+      storybook: { version: '10.2.0', configDir: '/repo/.storybook' },
+      runtime: {
+        configDir: '/repo/.storybook',
+        toolsets: [],
+        getService: () => {
+          throw new Error('unused');
+        },
+      },
+      describe,
+      call,
+      close,
+    } as unknown as Tools);
+
+    await runChildHost({
+      send,
+      subscribe: (handler) => {
+        handlers.push(handler);
+      },
+      cwd: () => '/repo',
+    });
+
+    handlers[0]({
+      type: 'init',
+      options: {
+        mode: 'local',
+        clientInfo: { name: 'storybook-cli', version: '1.0.0', kind: 'cli' },
+      },
+    });
+    await vi.waitFor(() => expect(createTools).toHaveBeenCalled());
+    expect(createTools).toHaveBeenCalledWith({
+      clientInfo: { name: 'storybook-cli', version: '1.0.0', kind: 'cli' },
+      cwd: '/repo',
+      mode: 'local',
+      autoSpawn: false,
+    });
+    expect(process.env.STORYBOOK_ATTACHED_TOOLS).toBeUndefined();
   });
 
   it('boots attached tools with autoSpawn declined and answers describe/call/close', async () => {

--- a/code/core/src/cli/tools/sdk/child-host.test.ts
+++ b/code/core/src/cli/tools/sdk/child-host.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AnyToolsetOutcome } from '../../../shared/open-service/toolset-definition.ts';
 import { runChildHost } from './child-host.ts';
@@ -32,8 +32,8 @@ describe('runChildHost', () => {
     describe.mockReset();
     call.mockReset();
     handlers.length = 0;
-    delete process.env.STORYBOOK_ATTACHED_TOOLS;
-    delete process.env.STORYBOOK_TOOLS_CHILD_HOST;
+    vi.stubEnv('STORYBOOK_ATTACHED_TOOLS', undefined);
+    vi.stubEnv('STORYBOOK_TOOLS_CHILD_HOST', undefined);
     vi.mocked(createTools).mockReset();
     vi.mocked(createTools).mockResolvedValue({
       mode: 'attached',
@@ -61,6 +61,10 @@ describe('runChildHost', () => {
       }
       return { ok: true, data: { ran: true }, markdown: 'ok' };
     });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('boots local tools when init asks for local mode', async () => {

--- a/code/core/src/cli/tools/sdk/child-host.ts
+++ b/code/core/src/cli/tools/sdk/child-host.ts
@@ -36,16 +36,10 @@ export async function runChildHost({
     const message = raw as ParentMessage;
     switch (message.type) {
       case 'init': {
-        const mode = message.options.mode === 'local' ? 'local' : 'attached';
-        if (mode === 'attached') {
-          process.env.STORYBOOK_ATTACHED_TOOLS = 'true';
-        } else {
-          delete process.env.STORYBOOK_ATTACHED_TOOLS;
-        }
         tools = await createTools({
           ...message.options,
           cwd: cwd(),
-          mode,
+          mode: message.options.mode ?? 'attached',
           autoSpawn: false,
         });
         send({

--- a/code/core/src/cli/tools/sdk/child-host.ts
+++ b/code/core/src/cli/tools/sdk/child-host.ts
@@ -28,7 +28,6 @@ export async function runChildHost({
     process.exit(0);
   });
   process.env.STORYBOOK_TOOLS_CHILD_HOST = 'true';
-  process.env.STORYBOOK_ATTACHED_TOOLS = 'true';
 
   let tools: Tools | undefined;
   const controllers = new Map<string, AbortController>();
@@ -37,10 +36,16 @@ export async function runChildHost({
     const message = raw as ParentMessage;
     switch (message.type) {
       case 'init': {
+        const mode = message.options.mode === 'local' ? 'local' : 'attached';
+        if (mode === 'attached') {
+          process.env.STORYBOOK_ATTACHED_TOOLS = 'true';
+        } else {
+          delete process.env.STORYBOOK_ATTACHED_TOOLS;
+        }
         tools = await createTools({
           ...message.options,
           cwd: cwd(),
-          mode: 'attached',
+          mode,
           autoSpawn: false,
         });
         send({

--- a/code/core/src/cli/tools/sdk/child-protocol.ts
+++ b/code/core/src/cli/tools/sdk/child-protocol.ts
@@ -42,7 +42,7 @@ export type ChildMessage =
 
 export type ParentInitMessage = {
   type: 'init';
-  options: CreateToolsOptions;
+  options: CreateToolsOptions & { mode: 'local' | 'attached'; autoSpawn: false };
 };
 
 export type ParentDescribeMessage = {

--- a/code/core/src/cli/tools/sdk/create-tools.test.ts
+++ b/code/core/src/cli/tools/sdk/create-tools.test.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../shared/open-service/toolset-definition.ts';
 import { getToolName } from '../../../shared/open-service/toolset-names.ts';
 import { createTools } from './create-tools.ts';
-import { AttachUnavailableError, SpawnFailedError } from './errors.ts';
+import { AttachUnavailableError, SpawnFailedError, ToolsRuntimeError } from './errors.ts';
 import { bootstrapToolsRuntime, type ToolsRuntime } from './local-runtime.ts';
 
 vi.mock('./local-runtime.ts', { spy: true });
@@ -392,7 +392,38 @@ describe('createTools', () => {
     await expect(localLoadFailure).rejects.toMatchObject({
       data: { reason: 'config-load-failed' },
     });
+    await expect(localLoadFailure).rejects.toThrow(ToolsRuntimeError);
     await expect(localLoadFailure).rejects.toThrow('Falling back');
+  });
+
+  it('keeps spawn and mode-unavailable reasons when auto local fallback also fails', async () => {
+    const attachUnavailable = async () => {
+      throw new AttachUnavailableError({
+        reason: 'no-instance',
+        instances: [],
+        remediation: 'No running Storybook was found for this project.',
+      });
+    };
+
+    const modeUnavailable = createTools(
+      { cwd: '/elsewhere', mode: 'auto', autoSpawn: false },
+      { attach: attachUnavailable, spawnChild }
+    );
+    await expect(modeUnavailable).rejects.toBeInstanceOf(ToolsRuntimeError);
+    await expect(modeUnavailable).rejects.toMatchObject({ data: { reason: 'mode-unavailable' } });
+    await expect(modeUnavailable).rejects.toThrow('Falling back');
+    expect(spawnChild).not.toHaveBeenCalled();
+
+    vi.mocked(spawnChild).mockRejectedValue(
+      new SpawnFailedError({ reason: 'Could not resolve the `storybook` package from /elsewhere.' })
+    );
+    const spawnFailed = createTools(
+      { cwd: '/elsewhere', mode: 'auto' },
+      { attach: attachUnavailable, spawnChild }
+    );
+    await expect(spawnFailed).rejects.toBeInstanceOf(SpawnFailedError);
+    await expect(spawnFailed).rejects.toThrow('Falling back');
+    await expect(spawnFailed).rejects.toThrow('Could not resolve the `storybook` package');
   });
 
   it('applies per-call origin and telemetry to the method context', async () => {

--- a/code/core/src/cli/tools/sdk/create-tools.test.ts
+++ b/code/core/src/cli/tools/sdk/create-tools.test.ts
@@ -67,13 +67,78 @@ const attach = vi.fn();
 const spawnChild = vi.fn();
 
 describe('createTools', () => {
-  it('loads the target configuration in this process in local mode', async () => {
-    const tools = await createTools({ cwd: '/repo', configDir: '.storybook', mode: 'local' });
+  it('loads the target configuration in this process when cwd already matches', async () => {
+    const tools = await createTools({
+      cwd: process.cwd(),
+      configDir: '.storybook',
+      mode: 'local',
+    });
 
-    expect(bootstrapToolsRuntime).toHaveBeenCalledWith({ cwd: '/repo', configDir: '.storybook' });
+    expect(bootstrapToolsRuntime).toHaveBeenCalledWith({
+      cwd: process.cwd(),
+      configDir: '.storybook',
+    });
+    expect(spawnChild).not.toHaveBeenCalled();
     expect(tools.mode).toBe('local');
+    expect(tools.host).toBe('in-process');
     expect(tools.storybook.configDir).toBe(CONFIG_DIR);
     expect(tools.storybook.version).toEqual(expect.any(String));
+  });
+
+  it('spawns a child host in local mode when cwd is another directory', async () => {
+    const spawned = {
+      mode: 'local' as const,
+      host: 'child' as const,
+      clientInfo: { name: 'storybook-tools-sdk', version: '0.0.0', kind: 'sdk' as const },
+      storybook: { version: '0.0.0', configDir: CONFIG_DIR },
+      runtime: makeRuntime(),
+      describe: async () => ({ configDir: CONFIG_DIR, toolsets: [] }),
+      call: async () => ({ ok: true as const, data: {}, markdown: 'spawned' }),
+      close: async () => {},
+    };
+    vi.mocked(spawnChild).mockResolvedValue(spawned);
+
+    const cwdBefore = process.cwd();
+    const tools = await createTools(
+      { cwd: '/elsewhere', configDir: '.storybook', mode: 'local' },
+      { spawnChild }
+    );
+
+    expect(process.cwd()).toBe(cwdBefore);
+    expect(bootstrapToolsRuntime).not.toHaveBeenCalled();
+    expect(spawnChild).toHaveBeenCalledWith({
+      cwd: '/elsewhere',
+      options: expect.objectContaining({
+        cwd: '/elsewhere',
+        mode: 'local',
+        autoSpawn: false,
+      }),
+      clientInfo: expect.objectContaining({ kind: 'sdk' }),
+    });
+    expect(tools.mode).toBe('local');
+    expect(tools.host).toBe('child');
+    await expect(tools.call('echo.ok')).resolves.toEqual({
+      ok: true,
+      data: {},
+      markdown: 'spawned',
+    });
+  });
+
+  it('refuses a foreign cwd in local mode when auto-spawn is declined', async () => {
+    await expect(
+      createTools({ cwd: '/elsewhere', mode: 'local', autoSpawn: false }, { spawnChild })
+    ).rejects.toMatchObject({ data: { reason: 'mode-unavailable' } });
+    expect(spawnChild).not.toHaveBeenCalled();
+    expect(bootstrapToolsRuntime).not.toHaveBeenCalled();
+  });
+
+  it('does not spawn a nested child host when already running as one', async () => {
+    vi.stubEnv('STORYBOOK_TOOLS_CHILD_HOST', 'true');
+
+    await expect(
+      createTools({ cwd: '/elsewhere', mode: 'local' }, { spawnChild })
+    ).rejects.toMatchObject({ data: { reason: 'mode-unavailable' } });
+    expect(spawnChild).not.toHaveBeenCalled();
   });
 
   it('stamps the client as the SDK unless the caller says otherwise', async () => {
@@ -152,6 +217,7 @@ describe('createTools', () => {
     };
     const spawned = {
       mode: 'attached' as const,
+      host: 'child' as const,
       clientInfo: { name: 'storybook-tools-sdk', version: '0.0.0', kind: 'sdk' as const },
       storybook: { version: '10.2.0', configDir: CONFIG_DIR, url: record.url, pid: record.pid },
       runtime: makeRuntime(),
@@ -168,7 +234,7 @@ describe('createTools', () => {
     );
 
     expect(spawnChild).toHaveBeenCalledWith({
-      record,
+      cwd: '/repo',
       options: expect.objectContaining({
         cwd: '/repo',
         mode: 'attached',
@@ -196,6 +262,7 @@ describe('createTools', () => {
     expect(attach).toHaveBeenCalledWith({ cwd: '/repo', configDir: undefined });
     expect(bootstrapToolsRuntime).not.toHaveBeenCalled();
     expect(attached.mode).toBe('attached');
+    expect(attached.host).toBe('in-process');
     expect(attached.fallbackNotice).toBeUndefined();
 
     attach.mockRejectedValueOnce(
@@ -207,11 +274,50 @@ describe('createTools', () => {
       })
     );
 
-    const fallback = await createTools({ cwd: '/repo' }, { attach });
+    const fallback = await createTools({ mode: 'auto' }, { attach });
 
-    expect(bootstrapToolsRuntime).toHaveBeenCalledWith({ cwd: '/repo', configDir: undefined });
+    expect(bootstrapToolsRuntime).toHaveBeenCalledWith({
+      cwd: process.cwd(),
+      configDir: undefined,
+    });
+    expect(spawnChild).not.toHaveBeenCalled();
     expect(fallback.mode).toBe('local');
+    expect(fallback.host).toBe('in-process');
     expect(fallback.fallbackNotice).toContain('No running Storybook was found');
+    expect(fallback.fallbackNotice).toContain('Falling back');
+  });
+
+  it('falls back to a local child host when auto cannot attach from another cwd', async () => {
+    const spawned = {
+      mode: 'local' as const,
+      host: 'child' as const,
+      clientInfo: { name: 'storybook-tools-sdk', version: '0.0.0', kind: 'sdk' as const },
+      storybook: { version: '0.0.0', configDir: CONFIG_DIR },
+      runtime: makeRuntime(),
+      describe: async () => ({ configDir: CONFIG_DIR, toolsets: [] }),
+      call: async () => ({ ok: true as const, data: {}, markdown: 'spawned' }),
+      close: async () => {},
+    };
+    vi.mocked(attach).mockRejectedValueOnce(
+      new AttachUnavailableError({
+        reason: 'no-instance',
+        instances: [],
+        remediation:
+          'No running Storybook was found for this project. Start it first (for example `npm run storybook`), then retry with `--attach`.',
+      })
+    );
+    vi.mocked(spawnChild).mockResolvedValue(spawned);
+
+    const fallback = await createTools({ cwd: '/elsewhere' }, { attach, spawnChild });
+
+    expect(bootstrapToolsRuntime).not.toHaveBeenCalled();
+    expect(spawnChild).toHaveBeenCalledWith({
+      cwd: '/elsewhere',
+      options: expect.objectContaining({ mode: 'local', autoSpawn: false }),
+      clientInfo: expect.objectContaining({ kind: 'sdk' }),
+    });
+    expect(fallback.mode).toBe('local');
+    expect(fallback.host).toBe('child');
     expect(fallback.fallbackNotice).toContain('Falling back');
   });
 

--- a/code/core/src/cli/tools/sdk/create-tools.ts
+++ b/code/core/src/cli/tools/sdk/create-tools.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path';
+
 import { versions } from 'storybook/internal/common';
 
 import { StorybookDevServerDisconnectedError } from '../../../server-errors.ts';
@@ -13,7 +15,12 @@ import { toCatalogEntry } from './catalog.ts';
 import type { AttachedBootstrapResult } from './attached-runtime.ts';
 import { formatAttachFallback } from './attach-messages.ts';
 import { spawnChildHost } from './child-client.ts';
-import { AttachUnavailableError, ToolsRuntimeError, isAttachGateError } from './errors.ts';
+import {
+  AttachUnavailableError,
+  SpawnFailedError,
+  ToolsRuntimeError,
+  isAttachGateError,
+} from './errors.ts';
 import type { ToolsRuntime } from './local-runtime.ts';
 import type {
   AttachedTools,
@@ -23,6 +30,7 @@ import type {
   ToolsCallOptions,
   ToolsClientInfo,
   ToolsDescribeOptions,
+  ToolsHostKind,
   ToolsMode,
   ToolsStorybookInfo,
   ToolsetCatalog,
@@ -48,9 +56,9 @@ export type CreateToolsDeps = {
 /**
  * Resolve a host for the tools the target Storybook configuration registers.
  *
- * `local` loads that configuration in this process, which adopts the target directory as
- * `process.cwd()` for the rest of the process — everything the `services` preset hooks register
- * keys its file mapping off it. Capture your launch directory first if you still need it.
+ * `local` loads that configuration without a running Storybook. When this process is already in
+ * the target directory, it loads in-process. Otherwise it spawns a child host from the `storybook`
+ * package resolved under that directory. It never changes `process.cwd()`.
  *
  * `attached` joins a running Storybook over its channel and never changes `process.cwd()`. When
  * this process is not that instance's twin, attached mode defaults to spawning a child host from
@@ -60,7 +68,8 @@ export type CreateToolsDeps = {
  * then carries `fallbackNotice` with the gate message and that it fell back.
  *
  * @throws {ToolsRuntimeError} With reason `config-load-failed` when the target configuration cannot
- *   be loaded.
+ *   be loaded, or `mode-unavailable` when a foreign `cwd` needs a child host and `autoSpawn` is
+ *   declined.
  * @throws {AttachUnavailableError} When `attached` cannot find or reach a matching instance.
  * @throws {EnvironmentMismatchError} When this process is not the instance's twin and auto-spawn is
  *   declined, or when spawning cannot reconcile the running instance with the project package.
@@ -101,14 +110,11 @@ export async function createTools(
           const local = await createLocalTools(options, deps, clientInfo);
           return { ...local, fallbackNotice: notice };
         } catch (localError) {
-          if (
-            localError instanceof ToolsRuntimeError &&
-            localError.data.reason === 'config-load-failed'
-          ) {
+          if (shouldWrapAutoLocalFailure(localError)) {
             throw new ToolsRuntimeError({
               reason: 'config-load-failed',
-              message: `${notice}\n\n${localError.message}`,
-              cause: localError.data.cause,
+              message: `${notice}\n\n${localError instanceof Error ? localError.message : String(localError)}`,
+              cause: localError instanceof ToolsRuntimeError ? localError.data.cause : localError,
             });
           }
           throw localError;
@@ -141,7 +147,7 @@ async function createAttachedTools(
   });
   if ('kind' in attached && attached.kind === 'spawn') {
     return (deps.spawnChild ?? spawnChildHost)({
-      record: attached.record,
+      cwd: attached.record.cwd,
       options: { ...options, mode: 'attached', autoSpawn: false, cwd: attached.record.cwd },
       clientInfo,
     });
@@ -153,6 +159,7 @@ async function createAttachedTools(
   };
   return createToolsHost({
     mode: 'attached',
+    host: 'in-process',
     runtime: inProcess.runtime,
     clientInfo,
     storybook: {
@@ -172,11 +179,29 @@ async function createLocalTools(
   clientInfo: Required<ToolsClientInfo>
 ): Promise<LocalTools> {
   delete process.env.STORYBOOK_ATTACHED_TOOLS;
+  const cwd = resolve(options.cwd ?? process.cwd());
+  const isChildHost = process.env.STORYBOOK_TOOLS_CHILD_HOST === 'true';
+  const autoSpawn = isChildHost ? false : (options.autoSpawn ?? true);
+
+  if (cwd !== process.cwd()) {
+    if (!autoSpawn) {
+      throw new ToolsRuntimeError({
+        reason: 'mode-unavailable',
+        message: `This process is running from ${process.cwd()}, but the target Storybook is at ${cwd}. Re-run from that directory, or omit \`autoSpawn: false\` so a child host can load the project.`,
+      });
+    }
+    return (deps.spawnChild ?? spawnChildHost)({
+      cwd,
+      options: { ...options, mode: 'local', autoSpawn: false, cwd },
+      clientInfo,
+    });
+  }
+
   const { bootstrapToolsRuntime } = await import('./local-runtime.ts');
   let runtime: ToolsRuntime;
   try {
     runtime = await (deps.bootstrap ?? bootstrapToolsRuntime)({
-      cwd: options.cwd,
+      cwd,
       configDir: options.configDir,
     });
   } catch (error) {
@@ -191,14 +216,26 @@ async function createLocalTools(
 
   return createToolsHost({
     mode: 'local',
+    host: 'in-process',
     runtime,
     clientInfo,
     storybook: { version: versions.storybook, configDir: runtime.configDir },
   });
 }
 
+function shouldWrapAutoLocalFailure(error: unknown): boolean {
+  if (error instanceof SpawnFailedError) {
+    return true;
+  }
+  return (
+    error instanceof ToolsRuntimeError &&
+    (error.data.reason === 'config-load-failed' || error.data.reason === 'mode-unavailable')
+  );
+}
+
 function createToolsHost(args: {
   mode: 'local';
+  host: ToolsHostKind;
   runtime: ToolsRuntime;
   clientInfo: Required<ToolsClientInfo>;
   storybook: ToolsStorybookInfo;
@@ -207,6 +244,7 @@ function createToolsHost(args: {
 }): LocalTools;
 function createToolsHost(args: {
   mode: 'attached';
+  host: ToolsHostKind;
   runtime: ToolsRuntime;
   clientInfo: Required<ToolsClientInfo>;
   storybook: ToolsStorybookInfo;
@@ -215,13 +253,14 @@ function createToolsHost(args: {
 }): AttachedTools;
 function createToolsHost(args: {
   mode: 'local' | 'attached';
+  host: ToolsHostKind;
   runtime: ToolsRuntime;
   clientInfo: Required<ToolsClientInfo>;
   storybook: ToolsStorybookInfo;
   close?: () => void;
   disconnected?: Promise<never>;
 }): Tools {
-  const { mode, runtime, clientInfo, storybook } = args;
+  const { mode, host, runtime, clientInfo, storybook } = args;
   const baseCtx: ToolsetCtx = {
     transport: 'cli',
     getService: runtime.getService,
@@ -278,6 +317,7 @@ function createToolsHost(args: {
 
   return {
     mode,
+    host,
     clientInfo,
     runtime,
     storybook,

--- a/code/core/src/cli/tools/sdk/create-tools.ts
+++ b/code/core/src/cli/tools/sdk/create-tools.ts
@@ -135,11 +135,7 @@ export async function createTools(
           });
         } catch (localError) {
           if (shouldWrapAutoLocalFailure(localError)) {
-            throw new ToolsRuntimeError({
-              reason: 'config-load-failed',
-              message: `${notice}\n\n${localError instanceof Error ? localError.message : String(localError)}`,
-              cause: localError instanceof ToolsRuntimeError ? localError.data.cause : localError,
-            });
+            throw wrapAutoLocalFailure(notice, localError);
           }
           throw localError;
         }
@@ -256,7 +252,7 @@ async function createLocalTools(
   });
 }
 
-function shouldWrapAutoLocalFailure(error: unknown): boolean {
+function shouldWrapAutoLocalFailure(error: unknown): error is SpawnFailedError | ToolsRuntimeError {
   if (error instanceof SpawnFailedError) {
     return true;
   }
@@ -264,6 +260,25 @@ function shouldWrapAutoLocalFailure(error: unknown): boolean {
     error instanceof ToolsRuntimeError &&
     (error.data.reason === 'config-load-failed' || error.data.reason === 'mode-unavailable')
   );
+}
+
+function wrapAutoLocalFailure(notice: string, localError: SpawnFailedError | ToolsRuntimeError) {
+  const message = `${notice}\n\n${localError.message}`;
+  if (localError instanceof SpawnFailedError) {
+    return new SpawnFailedError({
+      reason: message,
+      cause: localError.data.cause ?? localError,
+    });
+  }
+  if (localError instanceof ToolsRuntimeError) {
+    return new ToolsRuntimeError({
+      reason: localError.data.reason,
+      message,
+      cause: localError.data.cause,
+    });
+  }
+  const exhaustive: never = localError;
+  throw exhaustive;
 }
 
 function transportFor(kind: Required<ToolsClientInfo>['kind']): ToolsetTransport {

--- a/code/core/src/cli/tools/sdk/index.ts
+++ b/code/core/src/cli/tools/sdk/index.ts
@@ -21,6 +21,7 @@ export type {
   ToolsetCatalog,
   ToolsetCatalogEntry,
   ToolsetCatalogMethod,
+  ToolsHostKind,
   ToolsMode,
   ToolsStorybookInfo,
 } from './types.ts';

--- a/code/core/src/cli/tools/sdk/local-runtime.test.ts
+++ b/code/core/src/cli/tools/sdk/local-runtime.test.ts
@@ -36,4 +36,24 @@ describe('bootstrapToolsRuntime', () => {
     expect(setChangeDetectionHost).toHaveBeenCalledOnce();
     expect(setChangeDetectionHost).toHaveBeenCalledWith(expect.any(Function));
   });
+
+  it('does not change process.cwd()', async () => {
+    const cwdBefore = process.cwd();
+    vi.mocked(prepareHeadlessUniversalStores).mockReturnValue({} as Channel);
+    vi.mocked(experimental_loadStorybook).mockResolvedValue({} as never);
+
+    await bootstrapToolsRuntime({ cwd: process.cwd(), configDir: '.storybook' });
+
+    expect(process.cwd()).toBe(cwdBefore);
+  });
+
+  it('refuses a target directory other than process.cwd()', async () => {
+    const cwdBefore = process.cwd();
+
+    await expect(
+      bootstrapToolsRuntime({ cwd: '/elsewhere', configDir: '.storybook' })
+    ).rejects.toThrow('requires process.cwd()');
+    expect(process.cwd()).toBe(cwdBefore);
+    expect(experimental_loadStorybook).not.toHaveBeenCalled();
+  });
 });

--- a/code/core/src/cli/tools/sdk/local-runtime.ts
+++ b/code/core/src/cli/tools/sdk/local-runtime.ts
@@ -18,6 +18,7 @@ import type {
 import { getRegisteredToolsets } from '../../../shared/open-service/toolset-registry.ts';
 import { resolveStorybookConfigDir } from '../config-dir.ts';
 import type { ToolsTarget } from '../discover-instance.ts';
+import { ToolsRuntimeError } from './errors.ts';
 
 export type ToolsRuntime = {
   configDir: string;
@@ -37,21 +38,20 @@ export type ToolsRuntime = {
  * `getChangeDetectionReadiness` call. Help, docs, and test-run never touch either path. A missing
  * adapter settles the graph as unavailable instead of making unrelated tools fail.
  *
- * This changes `process.cwd()` to the targeted Storybook project for the rest of the one-shot CLI
- * process. Callers embedding this runtime must capture their launch directory before bootstrapping
- * if they still need it.
+ * Requires `process.cwd()` to already be the target project. The `services` preset samples it for
+ * file mapping, the same way the dev server does. `createTools` starts a child host when they
+ * differ, instead of changing this process.
  */
 export async function bootstrapToolsRuntime(
   target: ToolsTarget,
   deps: { setChangeDetectionHost?: typeof experimental_setChangeDetectionHost } = {}
 ): Promise<ToolsRuntime> {
   const cwd = resolve(target.cwd ?? process.cwd());
-  // Everything the `services` hooks register keys its file mapping off `process.cwd()` — the
-  // module-graph working dir, the git diff provider, docgen — exactly as in the dev server, whose
-  // process runs from the project. A one-shot CLI adopts the target directory so `--cwd` aligns
-  // every consumer at once, instead of threading a working dir through each of them.
   if (cwd !== process.cwd()) {
-    process.chdir(cwd);
+    throw new ToolsRuntimeError({
+      reason: 'mode-unavailable',
+      message: `Local tools bootstrap requires process.cwd() to be the target project (${cwd}), not ${process.cwd()}.`,
+    });
   }
   const configDir = resolveStorybookConfigDir({ cwd, configDir: target.configDir });
 

--- a/code/core/src/cli/tools/sdk/types.ts
+++ b/code/core/src/cli/tools/sdk/types.ts
@@ -9,10 +9,13 @@ import type { ToolsRuntime } from './local-runtime.ts';
 /**
  * How the SDK hosts the target project's tools.
  *
- * `attached` talks to a running Storybook dev server, `local` loads the target configuration in
- * this process, and `auto` prefers the former and falls back to the latter.
+ * `attached` talks to a running Storybook dev server. `local` loads the target configuration
+ * without one: in this process when `cwd` already matches, otherwise in a child host started from
+ * that directory. `auto` prefers attached and falls back to local.
  */
 export type ToolsMode = 'auto' | 'attached' | 'local';
+
+export type ToolsHostKind = 'in-process' | 'child';
 
 /** Identifies the surface calling the SDK, for the attach handshake and for telemetry. */
 export type ToolsClientInfo = {
@@ -83,6 +86,8 @@ export type ToolsCallOptions = {
 type ToolsBase = {
   clientInfo: Required<ToolsClientInfo>;
   storybook: ToolsStorybookInfo;
+  /** `in-process` unless this host is a project-local child. */
+  host: ToolsHostKind;
   /** Set when `auto` mode could not attach and loaded the project configuration instead. */
   fallbackNotice?: string;
   /** Toolset registry and service accessor the CLI uses for help and dispatch. */
@@ -108,8 +113,8 @@ type ToolsBase = {
 };
 
 /**
- * A host that loaded the target configuration in this process. The `storybook tools` CLI renders
- * its help from the toolset registry.
+ * A host that loaded the target configuration without a running Storybook. The `storybook tools`
+ * CLI renders its help from the in-process registry, or from `describe` when this host is a child.
  */
 export type LocalTools = ToolsBase & {
   mode: 'local';

--- a/code/core/src/cli/tools/sdk/types.ts
+++ b/code/core/src/cli/tools/sdk/types.ts
@@ -90,7 +90,7 @@ type ToolsBase = {
   host: ToolsHostKind;
   /** Set when `auto` mode could not attach and loaded the project configuration instead. */
   fallbackNotice?: string;
-  /** Toolset registry and service accessor the CLI uses for help and dispatch. */
+  /** Toolset registry and service accessor for an in-process host. Empty when this host is a child. */
   runtime: ToolsRuntime;
   describe(options?: ToolsDescribeOptions): Promise<ToolsetCatalog>;
   /**
@@ -113,8 +113,7 @@ type ToolsBase = {
 };
 
 /**
- * A host that loaded the target configuration without a running Storybook. The `storybook tools`
- * CLI renders its help from the in-process registry, or from `describe` when this host is a child.
+ * A host that loaded the target configuration without a running Storybook.
  */
 export type LocalTools = ToolsBase & {
   mode: 'local';

--- a/code/core/src/cli/tools/tool-tokens.ts
+++ b/code/core/src/cli/tools/tool-tokens.ts
@@ -200,7 +200,7 @@ export const TOOLS_OPTION_SPECS: ReadonlyArray<{ flags: string; description: str
   },
   {
     flags: '--no-attach',
-    description: 'Load the project configuration in this process; never attach',
+    description: 'Load the project configuration without attaching',
   },
   {
     flags: '--input <object>',

--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -164,8 +164,8 @@ second engine. `storybook/internal/toolsets-docs` is a portable entry consumed b
 so its bundled declaration must remain flat and import only its declared allowlist.
 
 The `storybook tools` CLI is a slim shell over `storybook/internal/tools`. Default mode is `auto`:
-attach to a matching running instance as a delegated leaf, and fall back to an in-process local
-host when `createTools` cannot attach. `--attach` requires attachment (gate failures are errors).
+attach to a matching running instance as a delegated leaf, and fall back to a local host when
+`createTools` cannot attach. `--attach` requires attachment (gate failures are errors).
 `--no-attach` forces local. Toolset handlers run in the SDK process, and attached service commands
 execute on the instance.
 

--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -163,12 +163,12 @@ and provider accesses feed the same definition; composition combines accesses ra
 second engine. `storybook/internal/toolsets-docs` is a portable entry consumed by both MCP packages,
 so its bundled declaration must remain flat and import only its declared allowlist.
 
-The `storybook tools` CLI loads the target Storybook configuration in its own process and derives
-dispatch, help, validation, and output from the registered toolsets. Bootstrap always hosts the
-module graph so addon-owned toolsets can query it without appearing in a core allowlist; an
-unsupported builder settles the graph as unavailable without failing unrelated tools. Bootstrap
-also changes `process.cwd()` to the target project for the rest of the one-shot process. Embedders
-that need the launch directory must capture it first.
+The `storybook tools` CLI loads the target Storybook configuration through
+`storybook/internal/tools`. When this process is already in the project, local mode loads in-process
+and derives dispatch, help, validation, and output from the registered toolsets. When `--cwd` points
+elsewhere, it starts a child host in that directory instead of changing `process.cwd()`. Bootstrap
+always hosts the module graph so addon-owned toolsets can query it without appearing in a core
+allowlist; an unsupported builder settles the graph as unavailable without failing unrelated tools.
 
 Methods marked `requiresDevServer` use the runtime instance registry. `stories.preview` needs only
 the recorded origin. Until connect mode exists, `review.create` is the one temporary exception

--- a/code/e2e-internal/tools-attach.spec.ts
+++ b/code/e2e-internal/tools-attach.spec.ts
@@ -134,6 +134,15 @@ test.describe('storybook tools attach', () => {
     expect(result.output).toContain('npm run storybook');
   });
 
+  test('--no-attach from a different cwd loads via a project-local child host', async () => {
+    const list = await runTools(
+      ['--no-attach', '--cwd', process.cwd(), 'docs', 'list'],
+      join(process.cwd(), '..')
+    );
+    expect(list.exitCode, list.output).toBe(0);
+    expect(list.output).toContain('example-button');
+  });
+
   test('attaches from a different cwd via a project-local child host', async () => {
     test.skip(
       !runsAgainstDevServer,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Calling tools via `createTools` must happen in the correct CWD, to get the exact same Storybook config, version and dependencies. When running tools CLI and SDK in attached mode (where it communicates with a running dev server), this is solved by the `createTools` command spawning a child host process in the correct CWD _if_ it detects that current `process.cwd` is incorrect.

However in local mode, (isolated, not communicating with a dev server) a CWD mismatch would instead result in a `process.chdir` call to make it match before bootstrapping the tool environment. This is fine when called from the tools CLI, because it's a short-lived, isolated process. This is less fine when a consumer (application developer) uses the Tools SDK directly, because `process.chdir` would actively modify their whole process, which would be very bad. So now, local mode behaves like attach mode, and never calls `process.chdir`, but instead spawns a child process when necessary.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.
-->

From the `code/` directory, after compile:

1. Confirm in-process local still works from the project itself:

```bash
node core/dist/bin/dispatcher.js tools --no-attach docs list
```

Expect docs output. `process` of this command is `code/`.

2. Confirm a foreign cwd does not require `chdir` in the caller. From the repo root:

```bash
node code/core/dist/bin/dispatcher.js tools --no-attach --cwd "$PWD/code" docs list
```

Expect the same docs list. Watch that the shell's cwd stays the repo root (`pwd` is unchanged).

3. Confirm `--attach` from a foreign cwd is unchanged (needs Storybook on 6006):

```bash
cd code && yarn storybook:ui
# other terminal, from repo root:
node code/core/dist/bin/dispatcher.js tools --attach --cwd "$PWD/code" docs list
```

Worth extra scrutiny: `auto` fallback when no instance is running and `--cwd` points at another package; `autoSpawn: false` with a foreign cwd should error instead of loading in-process.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3e5d7fc-22c4-4501-915b-823837cf3f51?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3e5d7fc-22c4-4501-915b-823837cf3f51&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

