### PR TITLE
Core: Fix Windows unit tests for instance-record ACLs

### DIFF
--- a/code/core/src/core-server/utils/runtime-instance-registry.memfs.test.ts
+++ b/code/core/src/core-server/utils/runtime-instance-registry.memfs.test.ts
@@ -1,5 +1,6 @@
 import { execFile } from 'node:child_process';
 import { chmod, mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { userInfo } from 'node:os';
 
 import { vol } from 'memfs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -158,5 +159,69 @@ describe('writeStorybookRuntimeInstanceRecord', () => {
     expect(readRecordFile(recordPath).token).toBe('ws-token');
     expect(modeOf(recordPath)).toBe(0o600);
     expect(modeOf(REGISTRY_DIR)).toBe(0o700);
+  });
+});
+
+describe('writeRuntimeInstanceRecord on Windows', () => {
+  beforeEach(() => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+  });
+
+  it('restricts the registry dir and record temp file with icacls', async () => {
+    const record = createRuntimeInstanceRecord({
+      address: 'http://localhost:6006/',
+      instanceId: 'win-acl',
+      port: 6006,
+      storybookVersion: '10.5.0-alpha.0',
+      token: 'secret-token',
+    });
+
+    const recordPath = await writeRuntimeInstanceRecord(record, REGISTRY_DIR);
+    const grant = `${userInfo().username}:(F)`;
+
+    expect(execFile).toHaveBeenCalledWith(
+      'icacls',
+      [REGISTRY_DIR, '/inheritance:r', '/grant:r', grant],
+      expect.any(Function)
+    );
+    expect(execFile).toHaveBeenCalledWith(
+      'icacls',
+      expect.arrayContaining([
+        expect.stringMatching(/win-acl\..+\.tmp$/),
+        '/inheritance:r',
+        '/grant:r',
+        grant,
+      ]),
+      expect.any(Function)
+    );
+    expect(readRecordFile(recordPath).token).toBe('secret-token');
+  });
+});
+
+describe('writeRuntimeInstanceRecord on Windows when icacls fails', () => {
+  beforeEach(() => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    vi.mocked(execFile).mockImplementation((...args: unknown[]) => {
+      const callback = args.find((arg) => typeof arg === 'function') as
+        | ((error: Error | null, stdout: string, stderr: string) => void)
+        | undefined;
+      callback?.(Object.assign(new Error('icacls failed'), { code: 87 }), '', '');
+      return { pid: 0 } as ReturnType<typeof execFile>;
+    });
+  });
+
+  it('does not write a record that other accounts could read', async () => {
+    const record = createRuntimeInstanceRecord({
+      address: 'http://localhost:6006/',
+      instanceId: 'win-acl-fail',
+      port: 6006,
+      storybookVersion: '10.5.0-alpha.0',
+      token: 'secret-token',
+    });
+
+    await expect(writeRuntimeInstanceRecord(record, REGISTRY_DIR)).rejects.toThrow(
+      `Could not restrict ${REGISTRY_DIR} to the current Windows user. The instance record would be readable by other accounts.`
+    );
+    expect(Object.keys(vol.toJSON())).toEqual([REGISTRY_DIR]);
   });
 });

--- a/code/core/src/core-server/utils/runtime-instance-registry.ts
+++ b/code/core/src/core-server/utils/runtime-instance-registry.ts
@@ -3,7 +3,6 @@ import { randomUUID } from 'node:crypto';
 import { existsSync, rmSync } from 'node:fs';
 import { chmod, mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { homedir, userInfo } from 'node:os';
-import { promisify } from 'node:util';
 
 import { normalizeAddonName } from 'storybook/internal/common';
 import type { StorybookConfig } from 'storybook/internal/types';
@@ -20,7 +19,19 @@ const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const SEVEN_DAYS_MS = 7 * ONE_DAY_MS;
 const REGISTRY_DIR_MODE = 0o700;
 const RECORD_FILE_MODE = 0o600;
-const execFileAsync = promisify(execFile);
+
+// Node's promisify(execFile) closes over the original execFile via promisify.custom, so spies never see icacls.
+function execFileAsync(file: string, args: readonly string[]) {
+  return new Promise<void>((resolveExec, rejectExec) => {
+    execFile(file, [...args], (error) => {
+      if (error) {
+        rejectExec(error);
+        return;
+      }
+      resolveExec();
+    });
+  });
+}
 
 async function restrictOwnerAccess(targetPath: string, mode: number) {
   await chmod(targetPath, mode);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Windows unit tests for the runtime instance registry failed on the 10.6.0-beta.0 prerelease PR (`tests-unit--windows` on #36050).

`restrictOwnerAccess` used `promisify(execFile)` to run `icacls`. Node's `execFile` `promisify.custom` closes over the original `execFile`, so the Vitest spy in `runtime-instance-registry.memfs.test.ts` never intercepted the spawn. On Windows that called the real `icacls` against memfs POSIX paths such as `/home/tester/.storybook/instances`. `icacls` treats a leading `/` as a switch and exits with `First parameter must be a file name pattern or "/?"`.

This calls `execFile` in callback form so spies can stub `icacls`. Memfs tests now exercise the Windows ACL path, including the fail-closed case.

The `icacls` arguments themselves are unchanged.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

No Storybook UI or sandbox walkthrough is needed. This is Node filesystem / test-mock plumbing.

1. On Linux or macOS, from `code/`:
   `yarn vitest run --config core/vitest.config.ts src/core-server/utils/runtime-instance-registry.memfs.test.ts src/core-server/utils/runtime-instance-registry.test.ts`
   Expect 42 passed and 1 skipped (`restricts the record ACL to the current Windows user`).
2. On this PR, wait for CircleCI `tests-unit--windows` (`ci:daily` enables that job). All six `runtime-instance-registry.memfs.test.ts` cases should pass. The real-FS ACL test should still run on Windows.
3. Regression to watch: if someone switches the helper back to `promisify(execFile)`, the new Windows-stubbed memfs tests fail because they hit the real `icacls` binary again.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3e5d7fc-22c4-4501-915b-823837cf3f51?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3e5d7fc-22c4-4501-915b-823837cf3f51&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

