### PR TITLE
fix(docs): prevent source transform from being applied twice on docs pages

### DIFF
--- a/code/addons/docs/src/blocks/blocks/Source.test.tsx
+++ b/code/addons/docs/src/blocks/blocks/Source.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SourceType } from 'storybook/internal/docs-tools';
+import { useCode } from './Source.tsx';
+
+describe('useCode', () => {
+  it('does not apply sourceParameters.transform twice when snippet is already provided (issue #35889)', () => {
+    const transform = vi.fn((code: string) => /*transformed*/ );
+
+    const result = useCode({
+      snippet: '/*transformed*/ <Button />', // already transformed by emitTransformCode
+      serviceSnippet: '',
+      storyContext: {
+        parameters: {
+          __isArgsStory: true,
+          docs: {
+            source: {
+              type: SourceType.DYNAMIC,
+              transform,
+            },
+          },
+        },
+      } as any,
+      typeFromProps: SourceType.DYNAMIC,
+    });
+
+    expect(transform).not.toHaveBeenCalled();
+    expect(result).toBe('/*transformed*/ <Button />');
+  });
+
+  it('applies transformFromProps if explicitly provided on props', () => {
+    const propTransform = vi.fn((code: string) => /*prop*/ );
+
+    const result = useCode({
+      snippet: '<Button />',
+      serviceSnippet: '',
+      storyContext: {
+        parameters: {
+          __isArgsStory: true,
+          docs: {
+            source: {
+              type: SourceType.DYNAMIC,
+            },
+          },
+        },
+      } as any,
+      typeFromProps: SourceType.DYNAMIC,
+      transformFromProps: propTransform,
+    });
+
+    expect(propTransform).toHaveBeenCalledWith('<Button />', expect.anything());
+    expect(result).toBe('/*prop*/ <Button />');
+  });
+
+  it('applies sourceParameters.transform when using originalSource fallback', () => {
+    const transform = vi.fn((code: string) => /*transformed*/ );
+
+    const result = useCode({
+      snippet: '',
+      serviceSnippet: '',
+      storyContext: {
+        parameters: {
+          __isArgsStory: false,
+          docs: {
+            source: {
+              type: SourceType.CODE,
+              originalSource: '<Button />',
+              transform,
+            },
+          },
+        },
+      } as any,
+      typeFromProps: SourceType.CODE,
+    });
+
+    expect(transform).toHaveBeenCalledWith('<Button />', expect.anything());
+    expect(result).toBe('/*transformed*/ <Button />');
+  });
+});

--- a/code/addons/docs/src/blocks/blocks/Source.tsx
+++ b/code/addons/docs/src/blocks/blocks/Source.tsx
@@ -91,7 +91,10 @@ const useCode = ({
     (type === SourceType.AUTO && staticSnippet && isArgsStory);
 
   const code = useSnippet ? staticSnippet : sourceParameters.originalSource || '';
-  const transformer = transformFromProps ?? sourceParameters.transform;
+  // When using snippet (emitted via SNIPPET_RENDERED), emitTransformCode has already applied sourceParameters.transform.
+  // Avoid re-applying it unless explicitly overridden via transformFromProps.
+  const transformer =
+    transformFromProps ?? (useSnippet && snippet ? undefined : sourceParameters.transform);
 
   const transformedCode = transformer ? useTransformCode(code, transformer, storyContext) : code;
 


### PR DESCRIPTION
<!-- Please prefix the title with the issue type, and the package name, if applicable! -->

## What I did

Fixes #35889

When dynamic story snippets are rendered, emitTransformCode applies parameters.docs.source.transform before emitting SNIPPET_RENDERED to SourceContext.

When the docs <Source /> block rendered the snippet, useCode re-applied sourceParameters.transform to the already-transformed snippet code, resulting in 	ransform being executed twice on docs pages while running only once on the individual story page.

## How to test

1. Set a parameters.docs.source.transform function (e.g. prepending a comment or styling).
2. On docs pages, verify that the transform is executed exactly once on dynamic story code snippets.
3. Verify unit tests in code/addons/docs/src/blocks/blocks/Source.test.tsx.
