### PR TITLE
Docs: Fix dead storyshots migration guide link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ If you're using info/notes, we highly recommend you migrate to [docs](code/addon
 
 If you're using contexts, we highly recommend you migrate to [toolbars](https://github.com/storybookjs/storybook/tree/next/code/addons/toolbars) and [here is a guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-addon-contexts) to help you.
 
-If you're using addon-storyshots, we highly recommend you migrate to the Storybook [test-runner](https://github.com/storybookjs/test-runner) and [here is a guide](https://storybook.js.org/docs/writing-tests/storyshots-migration-guide?ref=readme) to help you.
+If you're using addon-storyshots, we highly recommend you migrate to the Storybook [test-runner](https://github.com/storybookjs/test-runner) and [here is a guide](https://storybook.js.org/docs/8.6/writing-tests/snapshot-testing/storyshots-migration-guide?ref=readme) to help you.
 
 ## Badges & Presentation materials
 


### PR DESCRIPTION
Closes #

## What I did

The storyshots migration guide link in the README is dead — the page was removed from the current docs:

- `https://storybook.js.org/docs/writing-tests/storyshots-migration-guide` → **HTTP 404**

The guide still exists in the versioned 8.6 docs (storyshots was removed in 8.x, so the versioned page is also the more appropriate target):

- `https://storybook.js.org/docs/8.6/writing-tests/snapshot-testing/storyshots-migration-guide` → **HTTP 200**

One-line README change, `?ref=readme` query kept.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

(README-only change, no automated tests apply.)

#### Manual testing

1. Open `README.md` on this branch and find the "storyshots migration guide" link in the migration section.
2. Click it: it should open `https://storybook.js.org/docs/8.6/writing-tests/snapshot-testing/storyshots-migration-guide` and return 200.
3. For comparison, the previous URL `https://storybook.js.org/docs/writing-tests/storyshots-migration-guide` returns 404.

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below: `documentation`