### PR TITLE
Build: Fix Windows unit tests for child-host spawn cwd

### DIFF
--- a/code/core/src/cli/tools/sdk/create-tools.test.ts
+++ b/code/core/src/cli/tools/sdk/create-tools.test.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { telemetry } from 'storybook/internal/telemetry';
 
@@ -16,6 +18,7 @@ vi.mock('./local-runtime.ts', { spy: true });
 vi.mock('storybook/internal/telemetry', { spy: true });
 
 const CONFIG_DIR = '/repo/.storybook';
+const ELSEWHERE = resolve('/elsewhere');
 
 const echo = defineToolset({
   id: 'echo',
@@ -130,9 +133,9 @@ describe('createTools', () => {
     expect(process.cwd()).toBe(cwdBefore);
     expect(bootstrapToolsRuntime).not.toHaveBeenCalled();
     expect(spawnChild).toHaveBeenCalledWith({
-      cwd: '/elsewhere',
+      cwd: ELSEWHERE,
       options: expect.objectContaining({
-        cwd: '/elsewhere',
+        cwd: ELSEWHERE,
         mode: 'local',
         autoSpawn: false,
       }),
@@ -341,7 +344,7 @@ describe('createTools', () => {
 
     expect(bootstrapToolsRuntime).not.toHaveBeenCalled();
     expect(spawnChild).toHaveBeenCalledWith({
-      cwd: '/elsewhere',
+      cwd: ELSEWHERE,
       options: expect.objectContaining({ mode: 'local', autoSpawn: false }),
       clientInfo: expect.objectContaining({ kind: 'sdk' }),
       requestedMode: 'auto',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Windows unit tests on the 10.6.0-beta.0 prerelease PR failed in `create-tools.test.ts` after local child-host spawning landed.

`createLocalTools` resolves `options.cwd` with `node:path`. On Windows, `path.resolve('/elsewhere')` is `C:\elsewhere`. Two tests still expected the POSIX fixture path, so `spawnChild` assertions failed.

Those assertions now compare against `path.resolve('/elsewhere')`, which matches both platforms. Production spawn behavior is unchanged.

Fixes the `tests-unit--windows` failure seen on https://github.com/storybookjs/storybook/pull/36050, https://app.circleci.com/pipelines/github/storybookjs/storybook/131715/workflows/19e737b2-51c2-4de4-8bb8-6d40e81c2592/jobs/1971799

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

No Storybook UI or sandbox walkthrough is needed. This only changes unit-test path assertions.

1. From `code/`:
   `yarn vitest run --config core/vitest.config.ts src/cli/tools/sdk/create-tools.test.ts`
   Expect all tests in that file to pass.
2. On this PR, wait for CircleCI `tests-unit--windows` (`ci:daily` enables that job). These two cases should pass:
   - `spawns a child host in local mode when cwd is another directory`
   - `falls back to a local child host when auto cannot attach from another cwd`

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3e5d7fc-22c4-4501-915b-823837cf3f51?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3e5d7fc-22c4-4501-915b-823837cf3f51&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

