### PR TITLE
Angular: Render the required badge for required inputs in the props table

### DIFF
--- a/code/frameworks/angular-vite/src/docgen/api-description.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/api-description.test.ts
@@ -13,20 +13,22 @@ describe('buildApiDescription', () => {
         label: {
           name: 'label',
           description: 'Text on the button.',
+          type: { name: 'string' },
           table: {
             category: 'inputs',
-            type: { summary: 'string', required: false },
+            type: { summary: 'string' },
             defaultValue: { summary: "'Click me'" },
           },
         },
         disabled: {
           name: 'disabled',
-          table: { category: 'inputs', type: { summary: 'boolean', required: true } },
+          type: { name: 'boolean', required: true },
+          table: { category: 'inputs', type: { summary: 'boolean' } },
         },
         clicked: {
           name: 'clicked',
           description: 'Fires on every click.',
-          table: { category: 'outputs', type: { summary: 'EventEmitter<Event>', required: false } },
+          table: { category: 'outputs', type: { summary: 'EventEmitter<Event>' } },
         },
       }),
       'ButtonComponent'
@@ -66,13 +68,13 @@ describe('buildApiDescription', () => {
           description: 'The currently selected colour',
           table: {
             category: 'inputs',
-            type: { summary: 'string', required: false },
+            type: { summary: 'string' },
             defaultValue: { summary: "'#345F92'" },
           },
         },
         colorChange: {
           name: 'colorChange',
-          table: { category: 'outputs', type: { summary: '(e: string) => void', required: false } },
+          table: { category: 'outputs', type: { summary: '(e: string) => void' } },
         },
       }),
       'ColorPickerComponent'
@@ -107,11 +109,13 @@ describe('buildApiDescription', () => {
       argTypes({
         color: {
           name: 'color',
-          table: { category: 'inputs', type: { summary: 'string', required: true } },
+          type: { name: 'string', required: true },
+          table: { category: 'inputs', type: { summary: 'string' } },
         },
         colorChange: {
           name: 'colorChange',
-          table: { category: 'inputs', type: { summary: 'boolean', required: true } },
+          type: { name: 'boolean', required: true },
+          table: { category: 'inputs', type: { summary: 'boolean' } },
         },
       }),
       'ColorPickerComponent'
@@ -125,7 +129,7 @@ describe('buildApiDescription', () => {
       argTypes({
         clicked: {
           name: 'clicked',
-          table: { category: 'outputs', type: { summary: 'EventEmitter<void>', required: false } },
+          table: { category: 'outputs', type: { summary: 'EventEmitter<void>' } },
         },
       }),
       'ButtonComponent'
@@ -140,11 +144,12 @@ describe('buildApiDescription', () => {
       argTypes({
         elementRef: {
           name: 'elementRef',
-          table: { category: 'properties', type: { summary: 'ElementRef', required: true } },
+          type: { name: 'other', value: 'ElementRef' },
+          table: { category: 'properties', type: { summary: 'ElementRef' } },
         },
         focus: {
           name: 'focus',
-          table: { category: 'methods', type: { summary: 'focus()', required: false } },
+          table: { category: 'methods', type: { summary: 'focus()' } },
         },
       }),
       'ButtonComponent'
@@ -162,7 +167,8 @@ describe('buildApiDescription', () => {
       argTypes({
         label: {
           name: 'label',
-          table: { category: 'inputs', type: { summary: 'string', required: true } },
+          type: { name: 'string', required: true },
+          table: { category: 'inputs', type: { summary: 'string' } },
         },
       }),
       'My Button.Component'
@@ -177,7 +183,8 @@ describe('buildApiDescription', () => {
         label: {
           name: 'label',
           description: 'Text on the button.\n\nSupports **markdown**.',
-          table: { category: 'inputs', type: { summary: 'string', required: true } },
+          type: { name: 'string', required: true },
+          table: { category: 'inputs', type: { summary: 'string' } },
         },
       }),
       'ButtonComponent'
@@ -206,7 +213,7 @@ describe('buildApiDescription', () => {
           name: 'size',
           table: {
             category: 'inputs',
-            type: { summary: 'number', required: false },
+            type: { summary: 'number' },
             defaultValue: { summary: '42' },
           },
         },
@@ -233,7 +240,7 @@ describe('buildApiDescription', () => {
           name: 'label',
           table: {
             category: 'inputs',
-            type: { summary: 'string', required: false },
+            type: { summary: 'string' },
             defaultValue: { summary: '' },
           },
         },
@@ -260,7 +267,7 @@ describe('buildApiDescription', () => {
           name: 'pattern',
           table: {
             category: 'inputs',
-            type: { summary: 'string', required: false },
+            type: { summary: 'string' },
             defaultValue: { summary: "'**/*.ts'" },
           },
         },
@@ -280,7 +287,7 @@ describe('buildApiDescription', () => {
           name: 'config',
           table: {
             category: 'inputs',
-            type: { summary: 'Config', required: false },
+            type: { summary: 'Config' },
             defaultValue: { summary: '{\n  depth: 1,\n}' },
           },
         },
@@ -313,7 +320,7 @@ describe('buildApiDescription', () => {
           table: {
             category: 'inputs',
             jsDocTags: { deprecated: 'since 2.0, remove in 4.0' },
-            type: { summary: 'boolean | string', required: false },
+            type: { summary: 'boolean | string' },
             defaultValue: { summary: 'false' },
           },
         },
@@ -343,10 +350,11 @@ describe('buildApiDescription', () => {
       argTypes({
         legacy: {
           name: 'legacy',
+          type: { name: 'boolean', required: true },
           table: {
             category: 'inputs',
             jsDocTags: { deprecated: '' },
-            type: { summary: 'boolean', required: true },
+            type: { summary: 'boolean' },
           },
         },
       }),
@@ -371,10 +379,11 @@ describe('buildApiDescription', () => {
         pattern: {
           name: 'pattern',
           description: 'Matches */ everything.',
+          type: { name: 'string', required: true },
           table: {
             category: 'inputs',
             jsDocTags: { deprecated: 'use */ instead' },
-            type: { summary: 'string', required: true },
+            type: { summary: 'string' },
           },
         },
       }),
@@ -387,7 +396,9 @@ describe('buildApiDescription', () => {
     expect(result?.match(/\*\//g)).toHaveLength(1);
   });
 
-  it('falls back to `any` when the analyzer reported no type', () => {
+  // No sbType at all is a shape the analyzer never emits, so this is about the defensive read:
+  // an unrecorded flag reports the input as optional rather than claiming it must be bound.
+  it('falls back to `any` and to optional when the analyzer reported no type', () => {
     const result = buildApiDescription(
       argTypes({
         label: { name: 'label', table: { category: 'inputs' } },
@@ -395,7 +406,7 @@ describe('buildApiDescription', () => {
       'ButtonComponent'
     );
 
-    expect(result).toContain('label: any;');
+    expect(result).toContain('label?: any;');
   });
 
   it('quotes apostrophes, backslashes, and newlines as valid JSON strings', () => {
@@ -403,15 +414,15 @@ describe('buildApiDescription', () => {
       argTypes({
         "it's": {
           name: "it's",
-          table: { category: 'inputs', type: { summary: 'string', required: false } },
+          table: { category: 'inputs', type: { summary: 'string' } },
         },
         'back\\slash': {
           name: 'back\\slash',
-          table: { category: 'inputs', type: { summary: 'string', required: false } },
+          table: { category: 'inputs', type: { summary: 'string' } },
         },
         'line\nbreak': {
           name: 'line\nbreak',
-          table: { category: 'inputs', type: { summary: 'string', required: false } },
+          table: { category: 'inputs', type: { summary: 'string' } },
         },
       }),
       'OddNamesComponent'
@@ -428,7 +439,7 @@ describe('buildApiDescription', () => {
       argTypes({
         [name]: {
           name,
-          table: { category: 'inputs', type: { summary: 'string', required: false } },
+          table: { category: 'inputs', type: { summary: 'string' } },
         },
         [`${name}Change`]: {
           name: `${name}Change`,
@@ -447,7 +458,7 @@ describe('buildApiDescription', () => {
       argTypes({
         [name]: {
           name,
-          table: { category: 'inputs', type: { summary: 'string', required: false } },
+          table: { category: 'inputs', type: { summary: 'string' } },
         },
         [`${name}Change`]: {
           name: `${name}Change`,
@@ -468,17 +479,18 @@ describe('buildApiDescription', () => {
       argTypes({
         'aria-label': {
           name: 'aria-label',
-          table: { category: 'inputs', type: { summary: 'string', required: false } },
+          table: { category: 'inputs', type: { summary: 'string' } },
         },
         'sr-title': {
           name: 'sr-title',
-          table: { category: 'inputs', type: { summary: 'string', required: true } },
+          type: { name: 'string', required: true },
+          table: { category: 'inputs', type: { summary: 'string' } },
         },
         'row-select': {
           name: 'row-select',
           table: {
             category: 'outputs',
-            type: { summary: 'EventEmitter<Event>', required: false },
+            type: { summary: 'EventEmitter<Event>' },
           },
         },
       }),

--- a/code/frameworks/angular-vite/src/docgen/api-description.ts
+++ b/code/frameworks/angular-vite/src/docgen/api-description.ts
@@ -9,11 +9,11 @@ interface Member {
   deprecated: string | undefined;
 }
 
-// `table.type.required` is Angular's own addition to the argType shape, which `InputType` does not
+// `table.jsDocTags` is Angular's own addition to the argType shape, which `InputType` does not
 // declare, so the section it lives in is read structurally.
 type AngularTable = {
   category?: string;
-  type?: { summary?: string; required?: boolean };
+  type?: { summary?: string };
   defaultValue?: { summary?: string };
   jsDocTags?: { deprecated?: string };
 };
@@ -24,7 +24,9 @@ const readMember = (name: string, argType: StrictInputType): Member => {
     name,
     description: argType.description,
     type: table?.type?.summary,
-    required: table?.type?.required !== false,
+    // The same declared flag the props table badges from, so what an agent reads and what a
+    // maintainer sees can never disagree again.
+    required: argType.type?.required === true,
     defaultValue: table?.defaultValue?.summary,
     deprecated: table?.jsDocTags?.deprecated,
   };

--- a/code/frameworks/angular-vite/src/docgen/api-description.ts
+++ b/code/frameworks/angular-vite/src/docgen/api-description.ts
@@ -24,8 +24,6 @@ const readMember = (name: string, argType: StrictInputType): Member => {
     name,
     description: argType.description,
     type: table?.type?.summary,
-    // The same declared flag the props table badges from, so what an agent reads and what a
-    // maintainer sees can never disagree again.
     required: argType.type?.required === true,
     defaultValue: table?.defaultValue?.summary,
     deprecated: table?.jsDocTags?.deprecated,

--- a/code/frameworks/angular-vite/src/docgen/build-docgen.test.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-docgen.test.ts
@@ -307,7 +307,7 @@ describe('buildDocgenPayload', () => {
       const payload = buildDocgenPayload({ entry }, context(managerReturning(metaFor(classMeta))));
 
       expect(payload?.argTypes?.count?.table?.defaultValue).toEqual({ summary: undefined });
-      expect(payload?.argTypes?.formatter?.type).toEqual({ name: 'function' });
+      expect(payload?.argTypes?.formatter?.type).toEqual({ name: 'function', required: true });
       expect(payload?.argTypes?.legend?.table?.jsDocTags).toEqual({
         deprecated: 'Use `label` instead.',
       });

--- a/code/frameworks/angular-vite/src/docgen/build-docgen.ts
+++ b/code/frameworks/angular-vite/src/docgen/build-docgen.ts
@@ -1,10 +1,5 @@
 import { getComponentIdFromEntry, getStoryImportPathFromEntry } from 'storybook/internal/common';
-import type {
-  DocgenJsDocTags,
-  DocgenPayload,
-  DocgenProviderInput,
-  StrictArgTypes,
-} from 'storybook/internal/types';
+import type { DocgenJsDocTags, DocgenPayload, DocgenProviderInput } from 'storybook/internal/types';
 
 import { resolve } from 'node:path';
 
@@ -220,18 +215,18 @@ export const buildDocgenPayload = (
     metadataJson: meta.json,
     propsTable: options.propsTable,
     logger,
-  }) as StrictArgTypes;
+  });
 
   // Agent documentation is pinned to `api` whatever the user chose for their props table: `all`
   // would hand an agent private wiring it cannot bind, and `inputs` would empty the Outputs section.
   const apiArgTypes =
     options.propsTable === 'api'
       ? argTypes
-      : (extractArgTypesFromData(meta.entry, {
+      : extractArgTypesFromData(meta.entry, {
           metadataJson: meta.json,
           propsTable: 'api',
           logger,
-        }) as StrictArgTypes);
+        });
 
   const jsDocTags: DocgenJsDocTags = meta.jsDocInfo?.jsDocTags ?? analyzerJsDocTags(meta.entry);
   const description =

--- a/code/lib/angular-cm/src/analyzer/inheritance-regressions.test.ts
+++ b/code/lib/angular-cm/src/analyzer/inheritance-regressions.test.ts
@@ -175,7 +175,7 @@ describe('generic inheritance', () => {
       description: 'Child-facing value.',
       type: { name: 'string' },
       table: {
-        type: { summary: 'string', required: false },
+        type: { summary: 'string' },
         defaultValue: { summary: 'base' },
       },
     });

--- a/code/lib/angular-cm/src/analyzer/input-transform.test.ts
+++ b/code/lib/angular-cm/src/analyzer/input-transform.test.ts
@@ -33,7 +33,11 @@ describe('input transforms', () => {
       metadataJson: meta,
       ...ANALYZER_EXTRACT_OPTIONS,
     });
-    expect(argTypes.level.type).toEqual({ name: 'enum', value: ['primary', 'secondary'] });
+    expect(argTypes.level.type).toEqual({
+      name: 'enum',
+      value: ['primary', 'secondary'],
+      required: true,
+    });
   });
 
   it('documents the second type argument of input.required as the write type', () => {

--- a/code/lib/angular-cm/src/analyzer/members.test.ts
+++ b/code/lib/angular-cm/src/analyzer/members.test.ts
@@ -97,12 +97,12 @@ describe('@Input and @Output aliases', () => {
     const argTypes = extractArgTypesFromData(componentIn(SOURCE), {
       metadataJson: undefined,
       ...ANALYZER_EXTRACT_OPTIONS,
-    }) as Record<string, { table?: { type?: { required?: boolean } } }>;
+    });
 
     // An initializer is what settles it: `buttonLabel` has one, so binding it is optional.
-    expect(argTypes.buttonLabel?.table?.type?.required).toBe(false);
-    expect(argTypes.tone?.table?.type?.required).toBe(true);
-    expect(argTypes.hint?.table?.type?.required).toBe(false);
+    expect(argTypes.buttonLabel?.type?.required).toBeUndefined();
+    expect(argTypes.tone?.type?.required).toBe(true);
+    expect(argTypes.hint?.type?.required).toBeUndefined();
   });
 
   it('leaves an accessor input’s `@default` tag as its only default carrier', () => {

--- a/code/lib/angular-cm/src/analyzer/members.test.ts
+++ b/code/lib/angular-cm/src/analyzer/members.test.ts
@@ -1141,7 +1141,11 @@ describe('inheritance', () => {
       metadataJson: meta,
       ...ANALYZER_EXTRACT_OPTIONS,
     });
-    expect(argTypes.size.type).toEqual({ name: 'enum', value: ['small', 'large'] });
+    expect(argTypes.size.type).toEqual({
+      name: 'enum',
+      value: ['small', 'large'],
+      required: true,
+    });
   });
 
   it('substitutes through a middle generic base down to the leaf’s concrete argument', () => {
@@ -1412,9 +1416,12 @@ describe('function-typed members', () => {
     const argTypes = extractArgTypesFromData(component, {
       metadataJson: undefined,
       ...ANALYZER_EXTRACT_OPTIONS,
-    }) as Record<string, { type?: { name?: string }; table?: { type?: { summary?: string } } }>;
+    }) as Record<
+      string,
+      { type?: { name?: string; required?: boolean }; table?: { type?: { summary?: string } } }
+    >;
 
-    expect(argTypes.format?.type).toEqual({ name: 'function' });
+    expect(argTypes.format?.type).toEqual({ name: 'function', required: true });
     expect(argTypes.format?.table?.type?.summary).toBe('(value: number, unit?: string) => string');
     expect(argTypes.nullableCallback?.table?.type?.summary).toBe(
       '((value: string) => void) | null'

--- a/code/lib/angular-cm/src/extract-arg-types.test.ts
+++ b/code/lib/angular-cm/src/extract-arg-types.test.ts
@@ -26,7 +26,9 @@ const inputTyped = (type: string) => {
   return extractArgTypesFromData(component, { metadataJson: undefined, propsTable: 'all' }).value;
 };
 
-const FUNCTION_CONTROL = { name: 'function' };
+// `inputTyped` declares an input with no default, so every control it produces is also a required
+// one.
+const FUNCTION_CONTROL = { name: 'function', required: true };
 
 describe('function-typed inputs', () => {
   it('keeps the signature and the function control for a plain arrow type', () => {
@@ -122,13 +124,13 @@ describe('primitive-union inputs', () => {
 
   it('prefers number over string for a declared primitive union', () => {
     const arg = inputTyped('string | number');
-    expect(arg.type).toEqual({ name: 'number' });
+    expect(arg.type).toEqual({ name: 'number', required: true });
     expect(arg.table?.type?.summary).toBe('string | number');
   });
 
   it('leaves a union that mixes a primitive with a named type on the catch-all', () => {
     const arg = inputTyped('string | Thing');
-    expect(arg.type).toEqual({ name: 'other', value: 'empty-enum' });
+    expect(arg.type).toEqual({ name: 'other', value: 'empty-enum', required: true });
   });
 });
 
@@ -368,5 +370,70 @@ describe('authored default tags', () => {
         @Input() value = 'vertical';
       `)
     ).toBe('horizontal');
+  });
+});
+
+const argTypesOf = (classBody: string) => {
+  const component = componentIn(`
+    import { Component, Input, input, output } from '@angular/core';
+
+    @Component({ selector: 'sb-probe', template: '' })
+    export class ProbeComponent {
+      ${classBody}
+    }
+  `);
+  // `table.type.required` is Angular's own addition to the argType shape, which `InputType` does
+  // not declare, so the section it lives in is read structurally.
+  return extractArgTypesFromData(component, {
+    metadataJson: undefined,
+    propsTable: 'all',
+  }) as Record<string, { type?: unknown; table?: { type?: { required?: boolean } } }>;
+};
+
+/**
+ * `ArgRow` reads `row.type.required`, so the flag in `table.type.required` alone renders no badge.
+ * Both halves are asserted together: they lived apart long enough for the props table to show no
+ * required input at all.
+ */
+describe('the required badge', () => {
+  it('marks a signal input declared with `input.required`', () => {
+    const arg = argTypesOf(`value = input.required<string>();`).value;
+    expect(arg.type).toEqual({ name: 'string', required: true });
+    expect(arg.table?.type?.required).toBe(true);
+  });
+
+  it('marks a decorator input with no initializer', () => {
+    const arg = argTypesOf(`@Input() value!: string;`).value;
+    expect(arg.type).toEqual({ name: 'string', required: true });
+    expect(arg.table?.type?.required).toBe(true);
+  });
+
+  it('leaves a defaulted signal input unmarked', () => {
+    const arg = argTypesOf(`value = input('');`).value;
+    expect(arg.type).toEqual({ name: 'string' });
+    expect(arg.table?.type?.required).toBe(false);
+  });
+
+  it('leaves a defaulted decorator input unmarked', () => {
+    const arg = argTypesOf(`@Input() value = 'primary';`).value;
+    expect(arg.type).toEqual({ name: 'string' });
+    expect(arg.table?.type?.required).toBe(false);
+  });
+
+  it('leaves an optional input unmarked', () => {
+    const arg = argTypesOf(`@Input() value?: string;`).value;
+    expect(arg.type).toEqual({ name: 'string' });
+    expect(arg.table?.type?.required).toBe(false);
+  });
+
+  it('badges no output, which a parent is never obliged to bind', () => {
+    const arg = argTypesOf(`toggled = output<boolean>();`).toggled;
+    expect(arg.type).toEqual({ name: 'other', value: 'void' });
+  });
+
+  it('badges no plain property, which a parent cannot bind at all', () => {
+    const arg = argTypesOf(`value!: string;`).value;
+    expect(arg.type).toEqual({ name: 'string' });
+    expect(arg.table?.type?.required).toBe(true);
   });
 });

--- a/code/lib/angular-cm/src/extract-arg-types.test.ts
+++ b/code/lib/angular-cm/src/extract-arg-types.test.ts
@@ -382,58 +382,56 @@ const argTypesOf = (classBody: string) => {
       ${classBody}
     }
   `);
-  // `table.type.required` is Angular's own addition to the argType shape, which `InputType` does
-  // not declare, so the section it lives in is read structurally.
-  return extractArgTypesFromData(component, {
-    metadataJson: undefined,
-    propsTable: 'all',
-  }) as Record<string, { type?: unknown; table?: { type?: { required?: boolean } } }>;
+  return extractArgTypesFromData(component, { metadataJson: undefined, propsTable: 'all' });
 };
 
 /**
- * `ArgRow` reads `row.type.required`, so the flag in `table.type.required` alone renders no badge.
- * Both halves are asserted together: they lived apart long enough for the props table to show no
- * required input at all.
+ * Where the required flag lives, which is the whole of this defect.
+ *
+ * Every consumer - the props table badge and its sort order, the generated dummy args, the
+ * `apiDescription` an agent reads - takes it from `type.required`, the field `SBBaseType` declares.
+ * Recording it anywhere else documents nothing, so `table.type` must stay free of it.
  */
-describe('the required badge', () => {
+describe('the required flag', () => {
   it('marks a signal input declared with `input.required`', () => {
-    const arg = argTypesOf(`value = input.required<string>();`).value;
-    expect(arg.type).toEqual({ name: 'string', required: true });
-    expect(arg.table?.type?.required).toBe(true);
+    expect(argTypesOf(`value = input.required<string>();`).value.type).toEqual({
+      name: 'string',
+      required: true,
+    });
   });
 
   it('marks a decorator input with no initializer', () => {
-    const arg = argTypesOf(`@Input() value!: string;`).value;
-    expect(arg.type).toEqual({ name: 'string', required: true });
-    expect(arg.table?.type?.required).toBe(true);
+    expect(argTypesOf(`@Input() value!: string;`).value.type).toEqual({
+      name: 'string',
+      required: true,
+    });
   });
 
-  it('leaves a defaulted signal input unmarked', () => {
-    const arg = argTypesOf(`value = input('');`).value;
-    expect(arg.type).toEqual({ name: 'string' });
-    expect(arg.table?.type?.required).toBe(false);
+  it('says nothing about a defaulted signal input', () => {
+    expect(argTypesOf(`value = input('');`).value.type).toEqual({ name: 'string' });
   });
 
-  it('leaves a defaulted decorator input unmarked', () => {
-    const arg = argTypesOf(`@Input() value = 'primary';`).value;
-    expect(arg.type).toEqual({ name: 'string' });
-    expect(arg.table?.type?.required).toBe(false);
+  it('says nothing about a defaulted decorator input', () => {
+    expect(argTypesOf(`@Input() value = 'primary';`).value.type).toEqual({ name: 'string' });
   });
 
-  it('leaves an optional input unmarked', () => {
-    const arg = argTypesOf(`@Input() value?: string;`).value;
-    expect(arg.type).toEqual({ name: 'string' });
-    expect(arg.table?.type?.required).toBe(false);
+  it('says nothing about an optional input', () => {
+    expect(argTypesOf(`@Input() value?: string;`).value.type).toEqual({ name: 'string' });
   });
 
-  it('badges no output, which a parent is never obliged to bind', () => {
-    const arg = argTypesOf(`toggled = output<boolean>();`).toggled;
-    expect(arg.type).toEqual({ name: 'other', value: 'void' });
+  it('says nothing about an output, which a parent is never obliged to bind', () => {
+    expect(argTypesOf(`toggled = output<boolean>();`).toggled.type).toEqual({
+      name: 'other',
+      value: 'void',
+    });
   });
 
-  it('badges no plain property, which a parent cannot bind at all', () => {
-    const arg = argTypesOf(`value!: string;`).value;
-    expect(arg.type).toEqual({ name: 'string' });
-    expect(arg.table?.type?.required).toBe(true);
+  it('says nothing about a plain property, which a parent cannot bind at all', () => {
+    expect(argTypesOf(`value!: string;`).value.type).toEqual({ name: 'string' });
+  });
+
+  it('leaves `table.type` carrying the summary alone', () => {
+    const table = argTypesOf(`value = input.required<string>();`).value.table;
+    expect(table?.type).toEqual({ summary: 'string' });
   });
 });

--- a/code/lib/angular-cm/src/extract-arg-types.ts
+++ b/code/lib/angular-cm/src/extract-arg-types.ts
@@ -482,9 +482,6 @@ export const extractArgTypesFromData = (
           ? { name: 'other', value: 'void' }
           : extractType(item, defaultValue, metadataJson, componentData.file);
 
-      // The props table renders its required badge off the sbType, not off `table.type`, so an
-      // input that must be bound has to carry the flag in both. Only an input is bindable, so no
-      // other section earns a badge.
       const type: SBType =
         required && section === 'inputs' ? { ...declaredType, required: true } : declaredType;
 

--- a/code/lib/angular-cm/src/extract-arg-types.ts
+++ b/code/lib/angular-cm/src/extract-arg-types.ts
@@ -6,7 +6,7 @@
  * committed baselines pin; this one is the successor and carries only the corrected rules, so the
  * two are not kept in sync and fixes belong here.
  */
-import type { ArgTypes, InputType, SBEnumType, SBType } from 'storybook/internal/types';
+import type { SBEnumType, SBType, StrictArgTypes, StrictInputType } from 'storybook/internal/types';
 
 import type {
   Argument,
@@ -443,7 +443,7 @@ export const extractArgTypesFromData = (
   componentData: Entry,
   { metadataJson, propsTable, logger = NOOP_LOGGER }: ExtractArgTypesOptions
 ) => {
-  const sectionToItems: Record<string, InputType[]> = {};
+  const sectionToItems: Record<string, StrictInputType[]> = {};
   const componentClasses: MemberKey[] =
     propsTable === 'inputs'
       ? ['inputsClass']
@@ -475,15 +475,17 @@ export const extractArgTypesFromData = (
 
       const defaultValue = isMethod(item) ? undefined : extractDefaultValue(item, logger);
 
-      const required = isMethod(item) ? false : isRequired(item);
-
       const declaredType: SBType =
         isMethod(item) || (section !== 'inputs' && section !== 'properties')
           ? { name: 'other', value: 'void' }
           : extractType(item, defaultValue, metadataJson, componentData.file);
 
+      // Only an input can be obliged to bind, and every consumer reads the flag for truth, so an
+      // optional one records nothing rather than a `false` none of them can tell from an absent key.
       const type: SBType =
-        required && section === 'inputs' ? { ...declaredType, required: true } : declaredType;
+        section === 'inputs' && !isMethod(item) && isRequired(item)
+          ? { ...declaredType, required: true }
+          : declaredType;
 
       const action = section === 'outputs' ? { action: item.name } : {};
 
@@ -499,7 +501,6 @@ export const extractArgTypesFromData = (
           ...(jsDocTags !== undefined ? { jsDocTags } : {}),
           type: {
             summary: isMethod(item) ? displaySignature(item) : item.type,
-            required,
           },
           defaultValue: { summary: defaultValue },
         },
@@ -520,8 +521,8 @@ export const extractArgTypesFromData = (
     .forEach((item) => {
       const changeName = `${item.name}Change`;
 
-      // An output rather than the model input it derives from: no `defaultValue`, never required to
-      // bind, and typed as the emitted-payload handler signature.
+      // An output rather than the model input it derives from: no `defaultValue`, no `required`,
+      // and typed as the emitted-payload handler signature.
       const argType = {
         name: changeName,
         description: item.rawdescription || item.description,
@@ -531,7 +532,6 @@ export const extractArgTypesFromData = (
           category: 'outputs',
           type: {
             summary: `(e: ${item.type}) => void`,
-            required: false,
           },
         },
       };
@@ -542,12 +542,12 @@ export const extractArgTypesFromData = (
       sectionToItems.outputs.push(argType);
     });
 
-  const argTypes: ArgTypes = {};
+  const argTypes: StrictArgTypes = {};
   SECTION_ORDER.forEach((section) => {
     const items = sectionToItems[section];
     if (items) {
       items.forEach((argType) => {
-        argTypes[argType.name as string] = argType;
+        argTypes[argType.name] = argType;
       });
     }
   });

--- a/code/lib/angular-cm/src/extract-arg-types.ts
+++ b/code/lib/angular-cm/src/extract-arg-types.ts
@@ -475,10 +475,19 @@ export const extractArgTypesFromData = (
 
       const defaultValue = isMethod(item) ? undefined : extractDefaultValue(item, logger);
 
-      const type: SBType =
+      const required = isMethod(item) ? false : isRequired(item);
+
+      const declaredType: SBType =
         isMethod(item) || (section !== 'inputs' && section !== 'properties')
           ? { name: 'other', value: 'void' }
           : extractType(item, defaultValue, metadataJson, componentData.file);
+
+      // The props table renders its required badge off the sbType, not off `table.type`, so an
+      // input that must be bound has to carry the flag in both. Only an input is bindable, so no
+      // other section earns a badge.
+      const type: SBType =
+        required && section === 'inputs' ? { ...declaredType, required: true } : declaredType;
+
       const action = section === 'outputs' ? { action: item.name } : {};
 
       const jsDocTags = extractMemberJsDocTags(item);
@@ -493,7 +502,7 @@ export const extractArgTypesFromData = (
           ...(jsDocTags !== undefined ? { jsDocTags } : {}),
           type: {
             summary: isMethod(item) ? displaySignature(item) : item.type,
-            required: isMethod(item) ? false : isRequired(item),
+            required,
           },
           defaultValue: { summary: defaultValue },
         },

--- a/code/lib/angular-cm/src/extract-arg-types.ts
+++ b/code/lib/angular-cm/src/extract-arg-types.ts
@@ -480,8 +480,6 @@ export const extractArgTypesFromData = (
           ? { name: 'other', value: 'void' }
           : extractType(item, defaultValue, metadataJson, componentData.file);
 
-      // Only an input can be obliged to bind, and every consumer reads the flag for truth, so an
-      // optional one records nothing rather than a `false` none of them can tell from an absent key.
       const type: SBType =
         section === 'inputs' && !isMethod(item) && isRequired(item)
           ? { ...declaredType, required: true }

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/acm-argtypes-filtered.snapshot
@@ -8,7 +8,6 @@
         "summary": false,
       },
       "type": {
-        "required": false,
         "summary": "boolean",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/complex-selector/acm-argtypes.snapshot
@@ -8,7 +8,6 @@
         "summary": false,
       },
       "type": {
-        "required": false,
         "summary": "boolean",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/acm-argtypes-filtered.snapshot
@@ -8,7 +8,6 @@
         "summary": false,
       },
       "type": {
-        "required": false,
         "summary": "boolean",
       },
     },
@@ -25,7 +24,6 @@
         "summary": "",
       },
       "type": {
-        "required": false,
         "summary": "string",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/cross-file-inheritance/acm-argtypes.snapshot
@@ -9,7 +9,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": false,
         "summary": "EventEmitter",
       },
     },
@@ -27,7 +26,6 @@
         "summary": false,
       },
       "type": {
-        "required": false,
         "summary": "boolean",
       },
     },
@@ -44,7 +42,6 @@
         "summary": "",
       },
       "type": {
-        "required": false,
         "summary": "string",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/acm-argtypes-filtered.snapshot
@@ -8,7 +8,6 @@
         "summary": "[]",
       },
       "type": {
-        "required": false,
         "summary": "T[]",
       },
     },
@@ -26,7 +25,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": false,
         "summary": "T",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-generic/acm-argtypes.snapshot
@@ -8,7 +8,6 @@
         "summary": "[]",
       },
       "type": {
-        "required": false,
         "summary": "T[]",
       },
     },
@@ -26,7 +25,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": false,
         "summary": "T",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/acm-argtypes-filtered.snapshot
@@ -8,7 +8,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": true,
         "summary": "number",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/acm-argtypes-filtered.snapshot
@@ -14,6 +14,7 @@
     },
     "type": {
       "name": "number",
+      "required": true,
     },
   },
 }

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/acm-argtypes.snapshot
@@ -8,7 +8,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": true,
         "summary": "number",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-getter-setter/acm-argtypes.snapshot
@@ -14,6 +14,7 @@
     },
     "type": {
       "name": "number",
+      "required": true,
     },
   },
 }

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/acm-argtypes-filtered.snapshot
@@ -8,7 +8,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": false,
         "summary": "number",
       },
     },
@@ -25,7 +24,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": true,
         "summary": "any",
       },
     },
@@ -44,7 +42,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": true,
         "summary": "(value: number) => string",
       },
     },
@@ -62,7 +59,6 @@
         "summary": "Badge",
       },
       "type": {
-        "required": false,
         "summary": "string",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/acm-argtypes-filtered.snapshot
@@ -31,6 +31,7 @@
     },
     "type": {
       "name": "other",
+      "required": true,
       "value": "empty-enum",
     },
   },
@@ -49,6 +50,7 @@
     },
     "type": {
       "name": "function",
+      "required": true,
     },
   },
   "label": {

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/acm-argtypes.snapshot
@@ -50,6 +50,7 @@
     },
     "type": {
       "name": "other",
+      "required": true,
       "value": "empty-enum",
     },
   },
@@ -68,6 +69,7 @@
     },
     "type": {
       "name": "function",
+      "required": true,
     },
   },
   "label": {

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-io-basics/acm-argtypes.snapshot
@@ -9,7 +9,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": false,
         "summary": "EventEmitter",
       },
     },
@@ -27,7 +26,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": false,
         "summary": "number",
       },
     },
@@ -44,7 +42,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": true,
         "summary": "any",
       },
     },
@@ -63,7 +60,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": true,
         "summary": "(value: number) => string",
       },
     },
@@ -81,7 +77,6 @@
         "summary": "Badge",
       },
       "type": {
-        "required": false,
         "summary": "string",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/acm-argtypes-filtered.snapshot
@@ -8,7 +8,6 @@
         "summary": "ButtonKind.Primary",
       },
       "type": {
-        "required": false,
         "summary": "ButtonKind",
       },
     },
@@ -29,7 +28,6 @@
         "summary": "small",
       },
       "type": {
-        "required": false,
         "summary": ""small" | "large"",
       },
     },
@@ -50,7 +48,6 @@
         "summary": "info",
       },
       "type": {
-        "required": false,
         "summary": "ToneOption",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/decorator-union-enum/acm-argtypes.snapshot
@@ -8,7 +8,6 @@
         "summary": "ButtonKind.Primary",
       },
       "type": {
-        "required": false,
         "summary": "ButtonKind",
       },
     },
@@ -29,7 +28,6 @@
         "summary": "small",
       },
       "type": {
-        "required": false,
         "summary": ""small" | "large"",
       },
     },
@@ -50,7 +48,6 @@
         "summary": "info",
       },
       "type": {
-        "required": false,
         "summary": "ToneOption",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/acm-argtypes-filtered.snapshot
@@ -8,7 +8,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": false,
         "summary": "number",
       },
     },
@@ -25,7 +24,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": false,
         "summary": "number",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/expression-defaults/acm-argtypes.snapshot
@@ -8,7 +8,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": false,
         "summary": "number",
       },
     },
@@ -26,7 +25,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": false,
         "summary": "EventEmitter",
       },
     },
@@ -44,7 +42,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": false,
         "summary": "number",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/acm-argtypes-filtered.snapshot
@@ -8,7 +8,6 @@
         "summary": "steelblue",
       },
       "type": {
-        "required": false,
         "summary": "string",
       },
     },
@@ -28,7 +27,6 @@
         "deprecated": "Use `label` on the parent panel instead.",
       },
       "type": {
-        "required": false,
         "summary": "string",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/jsdoc-tags/acm-argtypes.snapshot
@@ -8,7 +8,6 @@
         "summary": "steelblue",
       },
       "type": {
-        "required": false,
         "summary": "string",
       },
     },
@@ -28,7 +27,6 @@
         "deprecated": "Use `label` on the parent panel instead.",
       },
       "type": {
-        "required": false,
         "summary": "string",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/acm-argtypes-filtered.snapshot
@@ -8,7 +8,6 @@
         "summary": "compact",
       },
       "type": {
-        "required": false,
         "summary": "string",
       },
     },
@@ -25,7 +24,6 @@
         "summary": "",
       },
       "type": {
-        "required": false,
         "summary": "string",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/properties-methods-noise/acm-argtypes.snapshot
@@ -8,7 +8,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": false,
         "summary": "() => void",
       },
     },
@@ -26,7 +25,6 @@
         "summary": 1,
       },
       "type": {
-        "required": false,
         "summary": "number",
       },
     },
@@ -43,7 +41,6 @@
         "summary": "compact",
       },
       "type": {
-        "required": false,
         "summary": "string",
       },
     },
@@ -61,7 +58,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": false,
         "summary": "EventEmitter",
       },
     },
@@ -79,7 +75,6 @@
         "summary": "Next page",
       },
       "type": {
-        "required": false,
         "summary": "string",
       },
     },
@@ -96,7 +91,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": true,
         "summary": "ElementRef",
       },
     },
@@ -114,7 +108,6 @@
         "summary": false,
       },
       "type": {
-        "required": false,
         "summary": "boolean",
       },
     },
@@ -131,7 +124,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": false,
         "summary": "WritableSignal<boolean>",
       },
     },
@@ -149,7 +141,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": false,
         "summary": "() => void",
       },
     },
@@ -167,7 +158,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": true,
         "summary": "string",
       },
     },
@@ -184,7 +174,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": false,
         "summary": "ElementRef<HTMLDivElement>",
       },
     },
@@ -202,7 +191,6 @@
         "summary": "",
       },
       "type": {
-        "required": false,
         "summary": "string",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/acm-argtypes-filtered.snapshot
@@ -14,6 +14,7 @@
     },
     "type": {
       "name": "number",
+      "required": true,
     },
   },
   "disabled": {

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/acm-argtypes-filtered.snapshot
@@ -8,7 +8,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": true,
         "summary": "number",
       },
     },
@@ -26,7 +25,6 @@
         "summary": false,
       },
       "type": {
-        "required": false,
         "summary": "boolean",
       },
     },
@@ -43,7 +41,6 @@
         "summary": 1,
       },
       "type": {
-        "required": false,
         "summary": "number",
       },
     },
@@ -60,7 +57,6 @@
         "summary": "",
       },
       "type": {
-        "required": false,
         "summary": "string",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/acm-argtypes.snapshot
@@ -14,6 +14,7 @@
     },
     "type": {
       "name": "number",
+      "required": true,
     },
   },
   "disabled": {

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-io/acm-argtypes.snapshot
@@ -8,7 +8,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": true,
         "summary": "number",
       },
     },
@@ -26,7 +25,6 @@
         "summary": false,
       },
       "type": {
-        "required": false,
         "summary": "boolean",
       },
     },
@@ -43,7 +41,6 @@
         "summary": 1,
       },
       "type": {
-        "required": false,
         "summary": "number",
       },
     },
@@ -60,7 +57,6 @@
         "summary": "",
       },
       "type": {
-        "required": false,
         "summary": "string",
       },
     },
@@ -78,7 +74,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": false,
         "summary": "boolean",
       },
     },
@@ -96,7 +91,6 @@
         "summary": "v1",
       },
       "type": {
-        "required": false,
         "summary": "string",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/acm-argtypes-filtered.snapshot
@@ -8,7 +8,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": true,
         "summary": "boolean",
       },
     },
@@ -24,7 +23,6 @@
     "table": {
       "category": "outputs",
       "type": {
-        "required": false,
         "summary": "(e: boolean) => void",
       },
     },
@@ -42,7 +40,6 @@
         "summary": "start",
       },
       "type": {
-        "required": false,
         "summary": "string",
       },
     },
@@ -57,7 +54,6 @@
     "table": {
       "category": "outputs",
       "type": {
-        "required": false,
         "summary": "(e: string) => void",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/acm-argtypes-filtered.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/acm-argtypes-filtered.snapshot
@@ -14,6 +14,7 @@
     },
     "type": {
       "name": "boolean",
+      "required": true,
     },
   },
   "checkedChange": {

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/acm-argtypes.snapshot
@@ -8,7 +8,6 @@
         "summary": undefined,
       },
       "type": {
-        "required": true,
         "summary": "boolean",
       },
     },
@@ -24,7 +23,6 @@
     "table": {
       "category": "outputs",
       "type": {
-        "required": false,
         "summary": "(e: boolean) => void",
       },
     },
@@ -42,7 +40,6 @@
         "summary": "start",
       },
       "type": {
-        "required": false,
         "summary": "string",
       },
     },
@@ -57,7 +54,6 @@
     "table": {
       "category": "outputs",
       "type": {
-        "required": false,
         "summary": "(e: string) => void",
       },
     },

--- a/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/acm-argtypes.snapshot
+++ b/code/lib/docgen-harness/src/angular/__testfixtures__/signal-model/acm-argtypes.snapshot
@@ -14,6 +14,7 @@
     },
     "type": {
       "name": "boolean",
+      "required": true,
     },
   },
   "checkedChange": {

--- a/code/lib/docgen-harness/src/compare/argtypes.test.ts
+++ b/code/lib/docgen-harness/src/compare/argtypes.test.ts
@@ -659,16 +659,15 @@ describe('compareArgTypes', () => {
     ]);
   });
 
-  it('flags a table.type.required true->false flip only under strictTable', () => {
+  // `canonicalType` ignores `required`, so the type-fidelity comparison cannot see this flip and
+  // this gate is the only thing standing between a lost required flag and a laundered `-u`.
+  it('flags a required true->false flip only under strictTable', () => {
     const required = (value: boolean) =>
       argTypes({
-        count: {
-          name: 'count',
-          table: { type: { required: value, summary: 'number' } as never },
-        },
+        count: { name: 'count', type: { name: 'number', required: value } },
       });
     const missing = argTypes({
-      count: { name: 'count', table: { type: { summary: 'number' } } },
+      count: { name: 'count', type: { name: 'number' } },
     });
     expect(compareArgTypes(required(true), required(false))).toEqual([]);
     expect(compareArgTypes(required(true), required(false), { strictTable: true })).toEqual([

--- a/code/lib/docgen-harness/src/compare/argtypes.ts
+++ b/code/lib/docgen-harness/src/compare/argtypes.ts
@@ -6,7 +6,7 @@ import type { Violation } from './types.ts';
 export interface CompareArgTypesOptions {
   /** Waive the legacy Angular pipeline's invented defaults, which must not be ratcheted. */
   legacyBaseline?: boolean;
-  /** Also gate `table.type.summary` text and `table.type.required`, for a same-engine baseline. */
+  /** Also gate `table.type.summary` text and the `required` flag, for a same-engine baseline. */
   strictTable?: boolean;
 }
 
@@ -62,6 +62,7 @@ export function compareArgTypes(
       });
     }
     violations.push(...compareTypeSummary(arg, baseEntry, candidateEntry, options));
+    violations.push(...compareRequired(arg, baseEntry, candidateEntry, options));
     const baseType = baseEntry.type;
     const candidateType = candidateEntry.type;
     if (baseType != null) {
@@ -116,8 +117,8 @@ const isRecordedSummary = (summary: unknown, legacyBaseline: boolean): boolean =
   );
 };
 
-// `table.type` is loosely typed upstream - `required` is a corpus field the csf type does not
-// declare - hence the unknown-safe reads.
+// `table.type` is loosely typed upstream and a recorded corpus can carry anything in it, hence the
+// unknown-safe reads.
 function compareTypeSummary(
   arg: string,
   baseEntry: StrictInputType,
@@ -147,18 +148,31 @@ function compareTypeSummary(
       message: `table.type.summary changed: baseline ${JSON.stringify(baseSummary)}, candidate ${JSON.stringify(candidateSummary)}`,
     });
   }
+  return violations;
+}
+
+// `canonicalType` strips `required` so a type-fidelity comparison ignores it, which leaves this the
+// only gate on the flag. It reads the sbType because that is where `SBBaseType` declares it.
+function compareRequired(
+  arg: string,
+  baseEntry: StrictInputType,
+  candidateEntry: StrictInputType,
+  options: CompareArgTypesOptions
+): Violation[] {
   if (
-    options.strictTable === true &&
-    baseTableType.required === true &&
-    candidateTableType.required !== true
+    options.strictTable !== true ||
+    baseEntry.type?.required !== true ||
+    candidateEntry.type?.required === true
   ) {
-    violations.push({
+    return [];
+  }
+  return [
+    {
       arg,
       kind: 'lost-required',
-      message: 'the baseline records table.type.required true but the candidate does not',
-    });
-  }
-  return violations;
+      message: 'the baseline records the arg as required but the candidate does not',
+    },
+  ];
 }
 
 const recordedTypeSummary = (summary: unknown): string | undefined => {

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/example-button.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/example-button.json
@@ -7,7 +7,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "string"
         }
       },
@@ -21,7 +20,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "string[]"
         }
       },
@@ -39,7 +37,6 @@
           "summary": "Button"
         },
         "type": {
-          "required": false,
           "summary": "string"
         }
       },
@@ -55,7 +52,6 @@
         "category": "outputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "EventEmitter"
         }
       },
@@ -73,7 +69,6 @@
           "summary": false
         },
         "type": {
-          "required": false,
           "summary": "boolean"
         }
       },
@@ -90,7 +85,6 @@
           "summary": "medium"
         },
         "type": {
-          "required": false,
           "summary": "\"small\" | \"medium\" | \"large\""
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/example-header.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/example-header.json
@@ -7,7 +7,6 @@
         "category": "outputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "EventEmitter"
         }
       },
@@ -23,7 +22,6 @@
         "category": "outputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "EventEmitter"
         }
       },
@@ -39,7 +37,6 @@
         "category": "outputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "EventEmitter"
         }
       },
@@ -56,7 +53,6 @@
           "summary": null
         },
         "type": {
-          "required": false,
           "summary": "User | null"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/example-page.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/example-page.json
@@ -6,7 +6,6 @@
         "category": "methods",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "() => void"
         }
       },
@@ -21,7 +20,6 @@
         "category": "methods",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "() => void"
         }
       },
@@ -36,7 +34,6 @@
         "category": "methods",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "() => void"
         }
       },
@@ -53,7 +50,6 @@
           "summary": null
         },
         "type": {
-          "required": false,
           "summary": "User | null"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-argtypes-doc-button.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-argtypes-doc-button.json
@@ -8,7 +8,6 @@
           "summary": "Another default value"
         },
         "type": {
-          "required": false,
           "summary": "string"
         }
       },
@@ -25,7 +24,6 @@
           "summary": "ButtonAccent.Normal"
         },
         "type": {
-          "required": false,
           "summary": "ButtonAccent"
         }
       },
@@ -43,7 +41,6 @@
           "summary": "Another default value"
         },
         "type": {
-          "required": true,
           "summary": "string"
         }
       },
@@ -61,7 +58,6 @@
           "summary": null
         },
         "type": {
-          "required": false,
           "summary": "string | null"
         }
       },
@@ -78,7 +74,6 @@
           "summary": 123
         },
         "type": {
-          "required": false,
           "summary": "number"
         }
       },
@@ -93,7 +88,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "undefined"
         }
       },
@@ -112,7 +106,6 @@
           "summary": "secondary"
         },
         "type": {
-          "required": false,
           "summary": "\"primary\" | \"secondary\""
         }
       },
@@ -127,7 +120,6 @@
         "category": "view child",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "ElementRef"
         }
       },
@@ -143,7 +135,6 @@
         "category": "methods",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "(x: number, y: string | number) => number"
         }
       },
@@ -160,7 +151,6 @@
           "summary": false
         },
         "type": {
-          "required": false,
           "summary": "boolean"
         }
       },
@@ -175,7 +165,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "string"
         }
       },
@@ -193,7 +182,6 @@
           "summary": "Public hello"
         },
         "type": {
-          "required": false,
           "summary": "string"
         }
       },
@@ -210,7 +198,6 @@
           "summary": false
         },
         "type": {
-          "required": false,
           "summary": "boolean"
         }
       },
@@ -224,7 +211,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "T[]"
         }
       },
@@ -241,7 +227,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "string"
         }
       },
@@ -258,7 +243,6 @@
         "category": "outputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "EventEmitter"
         }
       },
@@ -273,7 +257,6 @@
         "category": "methods",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "(event: Event) => void"
         }
       },
@@ -288,7 +271,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "T[]"
         }
       },
@@ -304,7 +286,6 @@
         "category": "methods",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "(id?: number) => void"
         }
       },
@@ -320,7 +301,6 @@
         "category": "methods",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "(things: ISomeInterface) => void"
         }
       },
@@ -335,7 +315,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "keyof T"
         }
       },
@@ -354,7 +333,6 @@
           "summary": "medium"
         },
         "type": {
-          "required": false,
           "summary": "ButtonSize"
         }
       },
@@ -370,7 +348,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "ISomeInterface"
         }
       },
@@ -392,7 +369,6 @@
           "deprecated": ""
         },
         "type": {
-          "required": false,
           "summary": "boolean"
         }
       },
@@ -409,7 +385,6 @@
           "summary": "Default value in component"
         },
         "type": {
-          "required": false,
           "summary": "string"
         }
       },
@@ -424,7 +399,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "string | number"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-argtypes-doc-button.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-argtypes-doc-button.json
@@ -48,7 +48,8 @@
         }
       },
       "type": {
-        "name": "string"
+        "name": "string",
+        "required": true
       }
     },
     "aNullValue": {
@@ -98,6 +99,7 @@
       },
       "type": {
         "name": "other",
+        "required": true,
         "value": "empty-enum"
       }
     },
@@ -178,7 +180,8 @@
         }
       },
       "type": {
-        "name": "string"
+        "name": "string",
+        "required": true
       }
     },
     "internalProperty": {
@@ -227,6 +230,7 @@
       },
       "type": {
         "name": "other",
+        "required": true,
         "value": "empty-enum"
       }
     },
@@ -242,7 +246,8 @@
         }
       },
       "type": {
-        "name": "string"
+        "name": "string",
+        "required": true
       }
     },
     "onClick": {
@@ -336,6 +341,7 @@
       },
       "type": {
         "name": "other",
+        "required": true,
         "value": "empty-enum"
       }
     },
@@ -370,6 +376,7 @@
       },
       "type": {
         "name": "other",
+        "required": true,
         "value": "empty-enum"
       }
     },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-argtypes-doc-directive.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-argtypes-doc-directive.json
@@ -9,7 +9,6 @@
           "summary": false
         },
         "type": {
-          "required": false,
           "summary": "boolean"
         }
       },
@@ -23,7 +22,6 @@
         "category": "methods",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "() => void"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-argtypes-doc-injectable.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-argtypes-doc-injectable.json
@@ -7,7 +7,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "any"
         }
       },
@@ -23,7 +22,6 @@
         "category": "methods",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "() => unknown[]"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-argtypes-doc-pipe.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-argtypes-doc-pipe.json
@@ -7,7 +7,6 @@
         "category": "methods",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "(value: string) => string"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-angular-forms-customcontrolvalueaccessor-custom-cva-component.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-angular-forms-customcontrolvalueaccessor-custom-cva-component.json
@@ -6,7 +6,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "boolean"
         }
       },
@@ -20,7 +19,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "any"
         }
       },
@@ -35,7 +33,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "(value: any) => void"
         }
       },
@@ -49,7 +46,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "() => void"
         }
       },
@@ -63,7 +59,6 @@
         "category": "methods",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "(fn: any) => void"
         }
       },
@@ -78,7 +73,6 @@
         "category": "methods",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "(fn: any) => void"
         }
       },
@@ -93,7 +87,6 @@
         "category": "methods",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "(isDisabled: boolean) => void"
         }
       },
@@ -108,7 +101,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "any"
         }
       },
@@ -123,7 +115,6 @@
         "category": "methods",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "(value: any) => void"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-complex-selectors-attribute-selectors-component.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-complex-selectors-attribute-selectors-component.json
@@ -6,7 +6,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "ElementRef"
         }
       },
@@ -21,7 +20,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "string"
         }
       },
@@ -35,7 +33,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "string"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-complex-selectors-class-selector-component.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-complex-selectors-class-selector-component.json
@@ -6,7 +6,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "ElementRef"
         }
       },
@@ -21,7 +20,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "string"
         }
       },
@@ -35,7 +33,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "string"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-complex-selectors-multiple-class-selector-component.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-complex-selectors-multiple-class-selector-component.json
@@ -6,7 +6,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "ElementRef"
         }
       },
@@ -21,7 +20,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "string"
         }
       },
@@ -35,7 +33,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "string"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-complex-selectors-multiple-selector-component.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-complex-selectors-multiple-selector-component.json
@@ -6,7 +6,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "ElementRef"
         }
       },
@@ -21,7 +20,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "string"
         }
       },
@@ -35,7 +33,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "string"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-enums-enums-component.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-enums-enums-component.json
@@ -7,7 +7,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "TypeAlias"
         }
       },
@@ -23,7 +22,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "EnumAlias"
         }
       },
@@ -39,7 +37,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "EnumNumeric"
         }
       },
@@ -55,7 +52,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "EnumNumericInitial"
         }
       },
@@ -71,7 +67,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "EnumStringValues"
         }
       },
@@ -87,7 +82,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "\"Union A\" | \"Union B\" | \"Union C\""
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-inheritance-base-button.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-inheritance-base-button.json
@@ -6,7 +6,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "string"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-inheritance-icon-button.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-inheritance-icon-button.json
@@ -6,7 +6,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "string"
         }
       },
@@ -20,7 +19,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "string"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-ng-content-ng-content-about-parent.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-ng-content-ng-content-about-parent.json
@@ -8,7 +8,6 @@
           "summary": "#5eadf5"
         },
         "type": {
-          "required": false,
           "summary": "string"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-ng-on-destroy-component-with-on-destroy.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-ng-on-destroy-component-with-on-destroy.json
@@ -6,7 +6,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "any"
         }
       },
@@ -21,7 +20,6 @@
         "category": "methods",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "() => void"
         }
       },
@@ -36,7 +34,6 @@
         "category": "methods",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "() => void"
         }
       },
@@ -51,7 +48,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "string"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-on-push-on-push.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-on-push-on-push.json
@@ -6,7 +6,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "string"
         }
       },
@@ -20,7 +19,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "string"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-pipe-custom-pipes.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-pipe-custom-pipes.json
@@ -12,6 +12,7 @@
       },
       "type": {
         "name": "other",
+        "required": true,
         "value": "empty-enum"
       }
     }

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-pipe-custom-pipes.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-pipe-custom-pipes.json
@@ -6,7 +6,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "any"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-provider-di-component.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-provider-di-component.json
@@ -6,7 +6,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "ElementRef"
         }
       },
@@ -21,7 +20,6 @@
         "category": "methods",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "() => string"
         }
       },
@@ -36,7 +34,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "Injector"
         }
       },
@@ -51,7 +48,6 @@
         "category": "methods",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "() => boolean"
         }
       },
@@ -66,7 +62,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "number"
         }
       },
@@ -80,7 +75,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "string"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-template-template.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-with-template-template.json
@@ -7,7 +7,6 @@
         "category": "outputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "EventEmitter"
         }
       },
@@ -22,7 +21,6 @@
         "category": "methods",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "() => void"
         }
       },
@@ -39,7 +37,6 @@
           "summary": "default label"
         },
         "type": {
-          "required": false,
           "summary": "string"
         }
       },
@@ -55,7 +52,6 @@
           "summary": "default label2"
         },
         "type": {
-          "required": false,
           "summary": "string"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-without-selector-without-selector-ng-component-outlet.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-without-selector-without-selector-ng-component-outlet.json
@@ -8,7 +8,6 @@
           "summary": "#1e88e5"
         },
         "type": {
-          "required": false,
           "summary": "string"
         }
       },
@@ -24,7 +23,6 @@
           "summary": "Joe Bar"
         },
         "type": {
-          "required": false,
           "summary": "string"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-without-selector-without-selector.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-component-without-selector-without-selector.json
@@ -8,7 +8,6 @@
           "summary": "#1e88e5"
         },
         "type": {
-          "required": false,
           "summary": "string"
         }
       },
@@ -24,7 +23,6 @@
           "summary": "Joe Bar"
         },
         "type": {
-          "required": false,
           "summary": "string"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-ng-module-import-module-chip.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-ng-module-import-module-chip.json
@@ -6,7 +6,6 @@
         "category": "properties",
         "defaultValue": {},
         "type": {
-          "required": true,
           "summary": "string"
         }
       },
@@ -20,7 +19,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "string"
         }
       },
@@ -35,7 +33,6 @@
         "category": "outputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "EventEmitter"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-ng-module-import-module-for-root.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-ng-module-import-module-for-root.json
@@ -6,7 +6,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "{ id: number; text: string; }[]"
         }
       },
@@ -22,7 +21,6 @@
         "category": "outputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "EventEmitter"
         }
       },
@@ -38,7 +36,6 @@
         "category": "outputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "EventEmitter"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-ng-module-import-module.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-basics-ng-module-import-module.json
@@ -6,7 +6,6 @@
         "category": "inputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "{ id: number; text: string; }[]"
         }
       },
@@ -22,7 +21,6 @@
         "category": "outputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "EventEmitter"
         }
       },
@@ -38,7 +36,6 @@
         "category": "outputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "EventEmitter"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-core-decorators-componentwrapperdecorator-decorators.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-core-decorators-componentwrapperdecorator-decorators.json
@@ -8,7 +8,6 @@
           "summary": ""
         },
         "type": {
-          "required": false,
           "summary": "string"
         }
       },
@@ -24,7 +23,6 @@
           "summary": ""
         },
         "type": {
-          "required": false,
           "summary": "string"
         }
       },
@@ -39,7 +37,6 @@
         "category": "outputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "EventEmitter"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-model-signal-color-picker.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-model-signal-color-picker.json
@@ -8,7 +8,6 @@
           "summary": "#345F92"
         },
         "type": {
-          "required": false,
           "summary": "string"
         }
       },
@@ -22,7 +21,6 @@
       "table": {
         "category": "outputs",
         "type": {
-          "required": false,
           "summary": "(e: string) => void"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-others-app-initializer-use-factory.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-others-app-initializer-use-factory.json
@@ -7,7 +7,6 @@
         "category": "outputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "EventEmitter"
         }
       },
@@ -24,7 +23,6 @@
           "summary": ""
         },
         "type": {
-          "required": false,
           "summary": "string"
         }
       },

--- a/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-others-issues-12009-unknown-component.json
+++ b/code/lib/docgen-harness/src/sandbox-baselines/__baselines__/angular-vite-docgen-server-ts/stories-frameworks-angular-vite-others-issues-12009-unknown-component.json
@@ -7,7 +7,6 @@
         "category": "outputs",
         "defaultValue": {},
         "type": {
-          "required": false,
           "summary": "EventEmitter"
         }
       },
@@ -24,7 +23,6 @@
           "summary": ""
         },
         "type": {
-          "required": false,
           "summary": "string"
         }
       },


### PR DESCRIPTION
## What I did

An Angular input declared `input.required<string>()` never got the required asterisk in the Controls panel or in the `<ArgTypes>` block, and neither did `@Input() name!: string`.
A genuinely optional `input(false)` rendered identically, so the props table gave you no way to tell a mandatory input from an optional one.

The tell was that MCP has always told them apart.
Both read the same docgen payload, and the Angular extractor was writing the required flag into a key it invented, while leaving empty the key core actually declares for it.

```
                                    ┌─ table.type.required ────────► apiDescription ──► MCP    ✅
  name = input.required<string>()   │  (undeclared, Angular-only)
       ──► angular-cm extractor ────┤
                                    └─ type: { name: 'string' } ───► every core consumer          ❌
                                       (SBBaseType.required, empty)
```

Core declares the flag on the sbType, on every variant, renderer-agnostically:

```ts
// code/core/src/csf/SBType.ts
interface SBBaseType {
  required?: boolean;
  raw?: string;
}
```

`InputType['table']['type']`, by contrast, is `{ summary?: string; detail?: string }` and nothing more.
So `table.type.required` was never a field anyone could read without a structural cast, and no renderer other than Angular ever wrote it. React, Vue, Svelte and web-components all write the declared one, which is why the badge has always worked for them and never for Angular.

Rather than write the flag twice, this moves it to where it belongs and deletes the invention:

```ts
// code/lib/angular-cm/src/extract-arg-types.ts
const type: SBType =
  section === 'inputs' && !isMethod(item) && isRequired(item)
    ? { ...declaredType, required: true }
    : declaredType;
```

Recorded payload for `count = input.required<number>()`, before and after:

```diff
  "count": {
    "table": {
      "category": "inputs",
      "type": {
-       "required": true,
        "summary": "number",
      },
    },
    "type": {
      "name": "number",
+     "required": true,
    },
  },
```

Three consequences worth calling out.

**Four consumers light up, not one.** Everything that asks whether an Angular input is required reads the declared field, so all of them were getting `undefined`:

| Consumer | Reads | Was |
| --- | --- | --- |
| `addons/docs` `ArgsTable/ArgRow.tsx:114` | `row.type?.required` | no asterisk, ever |
| `addons/docs` `ArgsTable/ArgsTable.tsx:204` | `!!b.type?.required` | required inputs never sorted first |
| `core-server` `get-dummy-args-from-argtypes.ts:28` | `argType.type.required` | no seeded args for a new story file, and none for the vitest component transformer |
| `angular-vite` `docgen/api-description.ts` | now `argType.type?.required` | the only one that worked |

**`apiDescription` stops guessing.** It read `table?.type?.required !== false`, so a missing key meant "required". That three-way read is what let the two halves disagree in the first place. It is now `argType.type?.required === true`, a plain boolean read of a boolean field, and an unrecorded flag reports the input as optional rather than claiming it must be bound.

**Only inputs carry it.** `required` answers "must a consuming template bind this?", which is a question only an input has. Outputs, properties, methods and `ViewChild` record nothing, where before they all carried a `table.type.required` nothing read. Optional inputs record nothing either: every consumer above reads the flag for truth, so a `false` would be a value none of them can tell apart from an absent key.

**The ratchet moved with it.** `canonicalType` in the docgen harness deliberately ignores `required`, so the type-fidelity comparison cannot see a required flip and the `strictTable` gate is the only thing standing between a lost flag and a laundered `vitest -u`. It now reads the sbType, which also makes it engine-agnostic instead of Angular-shaped.

Two things I deliberately left alone:

1. The Compodoc extractor in `@storybook/angular-compodoc` still writes only `table.type.required`, and so still renders no badge. That copy is frozen on the legacy behaviour its committed baselines pin and it goes away in Storybook 11, its `isRequired` reads a missing key as `true` so forwarding the flag would star nearly every row, and `buildApiDescription` never sees its output. `@storybook/angular-vite` runs the docgen server per default, so the default setup is covered.
2. `anotherDefaultValue` on the `doc-button` torture component shows a `*` while its Default column reads `Another default value`. `isRequired` treats "has no initializer" as "must be bound" and an accessor input never has one. That contradiction is not new, it is what the flag has said all along and what MCP reports today, this change only makes it visible. Tightening the predicate so a shown default also counts as evidence of optionality would fix it, but it moves what agents read as well, so it wants its own PR. Happy to write it right after this one.

Not a regression, by the way: the legacy Compodoc snapshots in `code/frameworks/angular/src/client/docs/__testfixtures__` carry the same split shape, so Angular has never rendered a required badge on any path.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

A new `the required flag` block in `code/lib/angular-cm/src/extract-arg-types.test.ts` drives the real analyzer over eight shapes and asserts where the flag lands, which is the whole of the defect:

| Declaration | `type.required` | `table.type` |
| --- | --- | --- |
| `value = input.required<string>()` | `true` | summary only |
| `@Input() value!: string` | `true` | summary only |
| `value = input('')` | absent | summary only |
| `@Input() value = 'primary'` | absent | summary only |
| `@Input() value?: string` | absent | summary only |
| `toggled = output<boolean>()` | absent | summary only |
| `value!: string` (plain property) | absent | summary only |

The harness comparator keeps its own test for the flip it gates, now against the sbType.
The recorded fixtures under `code/lib/docgen-harness/src/angular/__testfixtures__` and the Angular sandbox baselines are re-recorded; every row loses `table.type.required` and required inputs gain `type.required`.

#### Manual testing

1. `yarn task build --template angular-vite/docgen-server-ts --start-from auto`
2. Serve the result: `cd ../storybook-sandboxes/angular-vite-docgen-server-ts && npx http-server storybook-static -p 6017`
3. Open `stories/frameworks/angular-vite/argTypes/doc-button` → `Basic`, and look at the Controls panel.
4. Under `INPUTS`, exactly these seven carry a `*` after the name: `anotherDefaultValue`, `anUndefinedValue`, `inputValue`, `item`, `label`, `showKeyAlias`, `someDataObject`. (`anotherDefaultValue` is the accessor case from point 2 above.)
5. Exactly these eight do not: `aNullValue`, `aNumericValue`, `accent`, `appearance`, `isDisabled`, `size`, `somethingYouShouldNotUse`, `theDefaultValue`.
6. Under `PROPERTIES` and `OUTPUTS` no row is starred, whatever its declaration.
7. Check `next` without this PR for the same story: every row looks identical there, which is the bug.
8. For the agent-facing half, ask the MCP `docs-show` tool for the same component and confirm the `## Inputs` block marks the same seven without a `?` and the same eight with one.

Signal inputs are covered by the unit tests rather than by this sandbox, because none of the template stories the `angular-vite` sandbox pulls in declares an `input.required()`. If you want to see one in a browser, add `probe = input.required<string>();` to the `doc-button` component and it is starred alongside `label`.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No documentation change. The required badge is already documented behaviour of the props table, Angular simply never produced it, and `table.type.required` was never a documented field.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
