### PR TITLE
UI: Fix docs heading search results ranking below identical headings on other pages

### DIFF
--- a/code/core/src/manager/components/sidebar/Search.tsx
+++ b/code/core/src/manager/components/sidebar/Search.tsx
@@ -8,7 +8,6 @@ import { CloseIcon, SearchIcon } from '@storybook/icons';
 
 import type { DownshiftState, StateChangeOptions } from 'downshift';
 import Downshift from 'downshift';
-import type { FuseOptions } from 'fuse.js';
 import Fuse from 'fuse.js';
 import { shortcutToHumanString, useStorybookApi } from 'storybook/manager-api';
 import { styled } from 'storybook/theming';
@@ -17,6 +16,7 @@ import { useLandmark } from '../../hooks/useLandmark.ts';
 import { getGroupStatus, getMostCriticalStatusValue } from '../../utils/status.tsx';
 import { scrollIntoView, searchItem } from '../../utils/tree.ts';
 import { useLayout } from '../layout/LayoutProvider.tsx';
+import { docsAnchorItem, expandDocsAnchors, fuseOptions } from './Search.utils.ts';
 import { DEFAULT_REF_ID } from './Sidebar.tsx';
 import type {
   CombinedDataset,
@@ -31,24 +31,6 @@ import { isExpandType, isSearchResult } from './types.ts';
 const { document } = global;
 
 const DEFAULT_MAX_SEARCH_RESULTS = 50;
-
-const options = {
-  shouldSort: true,
-  tokenize: true,
-  findAllMatches: true,
-  includeScore: true,
-  includeMatches: true,
-  threshold: 0.2,
-  location: 0,
-  distance: 100,
-  maxPatternLength: 32,
-  minMatchCharLength: 1,
-  keys: [
-    { name: 'name', weight: 0.6 },
-    { name: 'path', weight: 0.3 },
-    { name: 'anchors.title', weight: 0.1 },
-  ],
-} as FuseOptions<SearchItem>;
 
 const SearchBar = styled.div({
   display: 'flex',
@@ -214,29 +196,13 @@ export const Search = React.memo<SearchProps>(function Search({
           continue;
         }
 
-        const { anchors, ...baseSearchItem } = searchItem(datasetValue, dataset.hash[refId]);
-
-        list.push({
-          ...baseSearchItem,
-          status,
-        });
-
-        anchors?.forEach((anchor) => {
-          const namePostfix = baseSearchItem.path?.[0] === anchor.title ? '' : ` / ${anchor.title}`;
-
-          list.push({
-            ...baseSearchItem,
-            anchors: [anchor],
-            // Fuse requires unique ids, so suffix the entry id with the anchor's DOM id
-            id: `${datasetValue.id}#${anchor.id}`,
-            name: `${datasetValue.name}${namePostfix}`,
-            status,
-          });
-        });
+        list.push(
+          ...expandDocsAnchors({ ...searchItem(datasetValue, dataset.hash[refId]), status })
+        );
       }
     }
 
-    return new Fuse(list, options);
+    return new Fuse(list, fuseOptions);
   }, [dataset]);
 
   const getResults = useCallback(
@@ -440,19 +406,11 @@ export const Search = React.memo<SearchProps>(function Search({
               // @ts-expect-error (non strict)
               if (!acc.some((res) => res.item.refId === refId && res.item.id === entryId)) {
                 const baseItem = searchItem(item, dataset.hash[refId]);
-                let resultItem = baseItem;
-                if (anchor && item.type === 'docs') {
-                  const matchingAnchor = item.anchors?.find((a) => a.id === anchor);
+                let resultItem: SearchItem = baseItem;
+                if (anchor && baseItem.type === 'docs') {
+                  const matchingAnchor = baseItem.anchors?.find((a) => a.id === anchor);
                   if (matchingAnchor) {
-                    const namePostfix =
-                      baseItem.path?.[0] === matchingAnchor.title
-                        ? ''
-                        : ` / ${matchingAnchor.title}`;
-                    resultItem = {
-                      ...baseItem,
-                      id: entryId,
-                      name: `${item.name}${namePostfix}`,
-                    };
+                    resultItem = docsAnchorItem(baseItem, matchingAnchor);
                   }
                 }
                 // @ts-expect-error (non strict)

--- a/code/core/src/manager/components/sidebar/Search.utils.test.ts
+++ b/code/core/src/manager/components/sidebar/Search.utils.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import Fuse from 'fuse.js';
+
+import { expandDocsAnchors, fuseOptions } from './Search.utils.ts';
+import type { SearchItem, SearchResult } from './types.ts';
+
+/**
+ * The shape `makeFuse` produces for an autodocs page: the docs entry is named after the docs
+ * option (`Docs`), and the page it documents only shows up in the item's path.
+ */
+const autodocsPage = (title: string, headings: string[]) =>
+  ({
+    type: 'docs',
+    id: `${title.toLowerCase().replace(/ /g, '-')}--docs`,
+    name: 'Docs',
+    parent: title.toLowerCase().replace(/ /g, '-'),
+    refId: 'storybook_internal',
+    path: ['Example', title],
+    anchors: headings.map((heading) => ({ id: `anchor--${heading}`, title: heading })),
+  }) as unknown as Extract<SearchItem, { type: 'docs' }>;
+
+const search = (query: string) => {
+  const list = [
+    ...expandDocsAnchors(autodocsPage('Text', ['Default', 'Disabled'])),
+    ...expandDocsAnchors(autodocsPage('Text Filter', ['Default', 'Disabled'])),
+  ];
+
+  return (new Fuse(list, fuseOptions).search(query) as SearchResult[]).map(({ item }) => item.name);
+};
+
+describe('expandDocsAnchors', () => {
+  it('labels a heading with the page it belongs to, not with the docs entry name', () => {
+    expect(expandDocsAnchors(autodocsPage('Text Filter', ['Disabled']))).toMatchObject([
+      { id: 'text-filter--docs', name: 'Docs' },
+      { id: 'text-filter--docs#anchor--Disabled', name: 'Text Filter / Disabled' },
+    ]);
+  });
+
+  it('ranks a heading of the page named in the query above the same heading elsewhere', () => {
+    expect(search('Text Filter Disabled')[0]).toBe('Text Filter / Disabled');
+  });
+
+  it('still finds a heading that is searched for on its own', () => {
+    expect(search('Disabled')).toEqual(
+      expect.arrayContaining(['Text / Disabled', 'Text Filter / Disabled'])
+    );
+  });
+});

--- a/code/core/src/manager/components/sidebar/Search.utils.ts
+++ b/code/core/src/manager/components/sidebar/Search.utils.ts
@@ -1,0 +1,45 @@
+import type { FuseOptions } from 'fuse.js';
+
+import type { DocsAnchor } from 'storybook/internal/types';
+
+import type { SearchItem } from './types.ts';
+
+type DocsSearchItem = Extract<SearchItem, { type: 'docs' }>;
+
+export const fuseOptions = {
+  shouldSort: true,
+  tokenize: true,
+  findAllMatches: true,
+  includeScore: true,
+  includeMatches: true,
+  threshold: 0.2,
+  location: 0,
+  distance: 100,
+  maxPatternLength: 32,
+  minMatchCharLength: 1,
+  keys: [
+    { name: 'name', weight: 0.6 },
+    { name: 'path', weight: 0.3 },
+    { name: 'anchors.title', weight: 0.1 },
+  ],
+} as FuseOptions<SearchItem>;
+
+/** A search item for a single heading of a docs page. */
+export const docsAnchorItem = (page: DocsSearchItem, anchor: DocsAnchor): SearchItem => {
+  const namePostfix = page.path?.[0] === anchor.title ? '' : ` / ${anchor.title}`;
+
+  return {
+    ...page,
+    anchors: [anchor],
+    // Fuse requires unique ids, so suffix the entry id with the anchor's DOM id
+    id: `${page.id}#${anchor.id}`,
+    name: `${page.name}${namePostfix}`,
+  };
+};
+
+/** The docs page itself, followed by one item per heading so headings are findable on their own. */
+export const expandDocsAnchors = (item: DocsSearchItem): SearchItem[] => {
+  const { anchors, ...page } = item;
+
+  return [page, ...(anchors ?? []).map((anchor) => docsAnchorItem(item, anchor))];
+};

--- a/code/core/src/manager/components/sidebar/Search.utils.ts
+++ b/code/core/src/manager/components/sidebar/Search.utils.ts
@@ -24,16 +24,22 @@ export const fuseOptions = {
   ],
 } as FuseOptions<SearchItem>;
 
-/** A search item for a single heading of a docs page. */
+/**
+ * A search item for a single heading of a docs page.
+ *
+ * The label is built from the page's own label rather than its entry name, because autodocs pages
+ * are all named "Docs": scoring "Docs / Installation" gives Fuse nothing to tell one page's heading
+ * from another's, so every page with that heading ranks alike.
+ */
 export const docsAnchorItem = (page: DocsSearchItem, anchor: DocsAnchor): SearchItem => {
-  const namePostfix = page.path?.[0] === anchor.title ? '' : ` / ${anchor.title}`;
+  const label = page.path.at(-1) ?? page.name;
 
   return {
     ...page,
     anchors: [anchor],
     // Fuse requires unique ids, so suffix the entry id with the anchor's DOM id
     id: `${page.id}#${anchor.id}`,
-    name: `${page.name}${namePostfix}`,
+    name: label === anchor.title ? label : `${label} / ${anchor.title}`,
   };
 };
 


### PR DESCRIPTION
Closes #36053

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

With `experimentalSearchDocsHeadings: true`, searching for a page **and** one of its headings did not rank that page's heading first. Every page with a same-named heading scored alike, so the intended one was buried.

The search index expands each docs page into one synthetic Fuse item per heading, named `` `${entry.name} / ${heading}` ``. For autodocs, `entry.name` is the docs option name — `"Docs"` — for *every* page, so the item name was `"Docs / Disabled"` on every page alike. The page it belongs to only appeared in `path` (weight `0.3`), which Fuse scored identically for `Text` and `Text Filter`:

```
query "Text filter disabled"
Text        > Docs / Disabled :: 0.898
Text Filter > Docs / Disabled :: 0.898   ← exact tie, order decided by insertion order
```

Heading items are now labelled with the page's own label (`path.at(-1)`, falling back to the entry name) rather than the entry name, so the page identity is back in the `name` key and Fuse ranks them correctly:

```
query "Text filter disabled"
Text Filter > Text Filter / Disabled :: 0.556
Text        > Text / Disabled        :: 0.866
```

MDX docs pages were never affected — their entry name already *is* the page title — which is why the bug only showed up with autodocs.

While in here:

- Moved the Fuse options and the heading expansion out of `Search.tsx` into `Search.utils.ts`, so the ranking behaviour is unit-testable without rendering the sidebar.
- The "last viewed" list rebuilt the heading label with its own copy of the naming logic, which had already drifted (it compared `path[0]` against the heading title). It now shares the same helper.

Two adjacent problems were found while investigating and are deliberately **not** in this PR — I'll open separate issues:

- Anchor items inherit `parent` from their docs page, so the dedupe pass in `getResults` drops every heading of a page after the first one. Fixing it changes how many rows a search returns, which is a UX call of its own.
- `makeFuse()` is called inside `getResults`, so the whole list is rebuilt and re-indexed on every keystroke. Pre-existing, unrelated to headings.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`code/core/src/manager/components/sidebar/Search.utils.test.ts` covers the labelling and the resulting Fuse order, using an autodocs-shaped index. The ranking assertions were verified to fail against the previous naming.

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Use the reproduction from #36053: https://stackblitz.com/edit/github-zud9rbq9?file=src%2Fstories%2FTextFilter.stories.ts — or create a sandbox with `yarn task sandbox --template react-vite/default-ts --start-from auto`, enable `features: { experimentalSearchDocsHeadings: true }` in `.storybook/main.ts`, and add two autodocs components (e.g. `Text` and `Text Filter`) that each have a story named `Disabled`.
2. Open Storybook and search for `Text filter disabled`.
3. The heading of the **Text Filter** page should be ranked first; before this change **Text**'s identically-named heading won.
4. Search for `Disabled` alone and confirm both pages' headings are still found.
5. Select a heading result, then reopen the search input and confirm the entry shows up under "Last viewed" with the same label.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->