### PR TITLE
Vitest: Support Nested Storybook Config Directories

### DIFF
--- a/code/addons/vitest/src/vitest-plugin/index.test.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.test.ts
@@ -1,0 +1,121 @@
+import { resolve } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { normalizePath } from 'vite';
+
+import {
+  getInterpretedFile,
+  normalizeStories,
+  optionalEnvToBoolean,
+  resolvePathInStorybookCache,
+  validateConfigurationFiles,
+} from 'storybook/internal/common';
+import { StoryIndexGenerator, experimental_loadStorybook } from 'storybook/internal/core-server';
+import { vitestTransform } from 'storybook/internal/csf-tools';
+import {
+  isTelemetryModuleEnabled,
+  oneWayHash,
+  setTelemetryEnabled,
+} from 'storybook/internal/telemetry';
+
+import { withoutVitePlugins } from '../../../../builders/builder-vite/src/utils/without-vite-plugins.ts';
+import { storybookTest } from './index.ts';
+import { requiresProjectAnnotations } from './utils.ts';
+
+vi.mock('storybook/internal/common', { spy: true });
+vi.mock('storybook/internal/core-server', { spy: true });
+vi.mock('storybook/internal/csf-tools', { spy: true });
+vi.mock('storybook/internal/telemetry', { spy: true });
+vi.mock('../../../../builders/builder-vite/src/utils/without-vite-plugins.ts', { spy: true });
+vi.mock('./utils.ts', { spy: true });
+vi.mock('./agent-telemetry-reporter.ts', { spy: true });
+
+const stories = [
+  '../storybook/**/*.stories.ts',
+  '!../storybook/excluded/**/*.stories.ts',
+  { directory: '../[stories]', files: '**/*.stories.ts' },
+];
+const presets = {
+  apply: vi.fn(async (name: string, defaultValue?: unknown) => {
+    if (name === 'stories') {
+      return stories;
+    }
+    if (name === 'framework') {
+      return { name: '@storybook/react-vite' };
+    }
+    return defaultValue;
+  }),
+};
+
+describe('storybookTest', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITEST', 'true');
+    vi.mocked(getInterpretedFile).mockReturnValue(undefined);
+    vi.mocked(normalizeStories).mockReturnValue([]);
+    vi.mocked(optionalEnvToBoolean).mockImplementation((value) => value === 'true');
+    vi.mocked(resolvePathInStorybookCache).mockReturnValue('/cache');
+    vi.mocked(validateConfigurationFiles).mockResolvedValue(undefined);
+    vi.mocked(StoryIndexGenerator.findMatchingFilesForSpecifiers).mockResolvedValue([]);
+    vi.mocked(StoryIndexGenerator.storyFileNames).mockReturnValue([]);
+    vi.mocked(experimental_loadStorybook).mockResolvedValue({ presets } as never);
+    vi.mocked(vitestTransform).mockResolvedValue({ code: 'transformed' } as never);
+    vi.mocked(isTelemetryModuleEnabled).mockReturnValue(false);
+    vi.mocked(oneWayHash).mockReturnValue('project');
+    vi.mocked(setTelemetryEnabled).mockResolvedValue(undefined);
+    vi.mocked(withoutVitePlugins).mockImplementation(async (plugins) => plugins ?? []);
+    vi.mocked(requiresProjectAnnotations).mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it('discovers stories when the config directory is nested below the Vitest root', async () => {
+    const configDir = normalizePath(resolve('web/[project]/.storybook'));
+    const storyGlob = normalizePath(resolve('web/[project]/storybook/**/*.stories.ts'))
+      .replaceAll('[', '\\[')
+      .replaceAll(']', '\\]');
+    const excludedStoryGlob = `!${normalizePath(
+      resolve('web/[project]/storybook/excluded/**/*.stories.ts')
+    )}`
+      .replaceAll('[', '\\[')
+      .replaceAll(']', '\\]');
+    const objectStoryGlob = normalizePath(resolve('web/[project]/[stories]/**/*.stories.ts'))
+      .replaceAll('[', '\\[')
+      .replaceAll(']', '\\]');
+    const story = normalizePath(resolve('web/[project]/storybook/Button.stories.ts'));
+    const objectStory = normalizePath(resolve('web/[project]/[stories]/Button.stories.ts'));
+    const excludedStory = normalizePath(
+      resolve('web/[project]/storybook/excluded/Button.stories.ts')
+    );
+
+    const plugins = await storybookTest({ configDir });
+    const plugin = plugins.find(({ name }) => name === 'vite-plugin-storybook-test');
+    const configHook =
+      typeof plugin?.config === 'function' ? plugin.config : plugin?.config?.handler;
+    const transformHook =
+      typeof plugin?.transform === 'function' ? plugin.transform : plugin?.transform?.handler;
+    const config = await configHook?.call({} as never, {}, { mode: 'test' } as never);
+
+    expect(config).toMatchObject({
+      root: normalizePath(resolve('web/[project]')),
+      test: { include: [storyGlob, excludedStoryGlob, objectStoryGlob] },
+    });
+
+    await transformHook?.call({} as never, 'export default {}', story);
+    await transformHook?.call({} as never, 'export default {}', objectStory);
+
+    expect(vi.mocked(vitestTransform)).toHaveBeenCalledWith(
+      expect.objectContaining({ fileName: story })
+    );
+    expect(vi.mocked(vitestTransform)).toHaveBeenCalledWith(
+      expect.objectContaining({ fileName: objectStory })
+    );
+
+    vi.mocked(vitestTransform).mockClear();
+    await transformHook?.call({} as never, 'export default {}', excludedStory);
+
+    expect(vi.mocked(vitestTransform)).not.toHaveBeenCalled();
+  });
+});

--- a/code/addons/vitest/src/vitest-plugin/index.test.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.test.ts
@@ -32,6 +32,13 @@ vi.mock('../../../../builders/builder-vite/src/utils/without-vite-plugins.ts', {
 vi.mock('./utils.ts', { spy: true });
 vi.mock('./agent-telemetry-reporter.ts', { spy: true });
 
+const escapeGlobPath = (filePath: string) =>
+  filePath
+    .replaceAll('[', '\\[')
+    .replaceAll(']', '\\]')
+    .replaceAll('(', '\\(')
+    .replaceAll(')', '\\)');
+
 const stories = [
   '../storybook/**/*.stories.ts',
   '!../storybook/excluded/**/*.stories.ts',
@@ -75,25 +82,15 @@ describe('storybookTest', () => {
 
   it('discovers stories when the config directory is nested below the Vitest root', async () => {
     const configDir = normalizePath(resolve('web/[project]/(marketing)/.storybook'));
-    const storyGlob = normalizePath(resolve('web/[project]/(marketing)/storybook/**/*.stories.ts'))
-      .replaceAll('[', '\\[')
-      .replaceAll(']', '\\]')
-      .replaceAll('(', '\\(')
-      .replaceAll(')', '\\)');
-    const excludedStoryGlob = `!${normalizePath(
-      resolve('web/[project]/(marketing)/storybook/excluded/**/*.stories.ts')
-    )}`
-      .replaceAll('[', '\\[')
-      .replaceAll(']', '\\]')
-      .replaceAll('(', '\\(')
-      .replaceAll(')', '\\)');
-    const objectStoryGlob = normalizePath(
-      resolve('web/[project]/(marketing)/[stories]/**/*.stories.ts')
-    )
-      .replaceAll('[', '\\[')
-      .replaceAll(']', '\\]')
-      .replaceAll('(', '\\(')
-      .replaceAll(')', '\\)');
+    const storyGlob = escapeGlobPath(
+      normalizePath(resolve('web/[project]/(marketing)/storybook/**/*.stories.ts'))
+    );
+    const excludedStoryGlob = `!${escapeGlobPath(
+      normalizePath(resolve('web/[project]/(marketing)/storybook/excluded/**/*.stories.ts'))
+    )}`;
+    const objectStoryGlob = escapeGlobPath(
+      normalizePath(resolve('web/[project]/(marketing)/[stories]/**/*.stories.ts'))
+    );
     const story = normalizePath(resolve('web/[project]/(marketing)/storybook/Button.stories.ts'));
     const objectStory = normalizePath(
       resolve('web/[project]/(marketing)/[stories]/Button.stories.ts')

--- a/code/addons/vitest/src/vitest-plugin/index.test.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.test.ts
@@ -3,6 +3,8 @@ import { resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { normalizePath } from 'vite';
 
+import { match } from 'micromatch';
+
 import {
   getInterpretedFile,
   normalizeStories,
@@ -72,22 +74,32 @@ describe('storybookTest', () => {
   });
 
   it('discovers stories when the config directory is nested below the Vitest root', async () => {
-    const configDir = normalizePath(resolve('web/[project]/.storybook'));
-    const storyGlob = normalizePath(resolve('web/[project]/storybook/**/*.stories.ts'))
+    const configDir = normalizePath(resolve('web/[project]/(marketing)/.storybook'));
+    const storyGlob = normalizePath(resolve('web/[project]/(marketing)/storybook/**/*.stories.ts'))
       .replaceAll('[', '\\[')
-      .replaceAll(']', '\\]');
+      .replaceAll(']', '\\]')
+      .replaceAll('(', '\\(')
+      .replaceAll(')', '\\)');
     const excludedStoryGlob = `!${normalizePath(
-      resolve('web/[project]/storybook/excluded/**/*.stories.ts')
+      resolve('web/[project]/(marketing)/storybook/excluded/**/*.stories.ts')
     )}`
       .replaceAll('[', '\\[')
-      .replaceAll(']', '\\]');
-    const objectStoryGlob = normalizePath(resolve('web/[project]/[stories]/**/*.stories.ts'))
+      .replaceAll(']', '\\]')
+      .replaceAll('(', '\\(')
+      .replaceAll(')', '\\)');
+    const objectStoryGlob = normalizePath(
+      resolve('web/[project]/(marketing)/[stories]/**/*.stories.ts')
+    )
       .replaceAll('[', '\\[')
-      .replaceAll(']', '\\]');
-    const story = normalizePath(resolve('web/[project]/storybook/Button.stories.ts'));
-    const objectStory = normalizePath(resolve('web/[project]/[stories]/Button.stories.ts'));
+      .replaceAll(']', '\\]')
+      .replaceAll('(', '\\(')
+      .replaceAll(')', '\\)');
+    const story = normalizePath(resolve('web/[project]/(marketing)/storybook/Button.stories.ts'));
+    const objectStory = normalizePath(
+      resolve('web/[project]/(marketing)/[stories]/Button.stories.ts')
+    );
     const excludedStory = normalizePath(
-      resolve('web/[project]/storybook/excluded/Button.stories.ts')
+      resolve('web/[project]/(marketing)/storybook/excluded/Button.stories.ts')
     );
 
     const plugins = await storybookTest({ configDir });
@@ -99,9 +111,13 @@ describe('storybookTest', () => {
     const config = await configHook?.call({} as never, {}, { mode: 'test' } as never);
 
     expect(config).toMatchObject({
-      root: normalizePath(resolve('web/[project]')),
+      root: normalizePath(resolve('web/[project]/(marketing)')),
       test: { include: [storyGlob, excludedStoryGlob, objectStoryGlob] },
     });
+    expect(match([story, objectStory, excludedStory], config?.test?.include ?? [])).toEqual([
+      story,
+      objectStory,
+    ]);
 
     await transformHook?.call({} as never, 'export default {}', story);
     await transformHook?.call({} as never, 'export default {}', objectStory);

--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -31,7 +31,7 @@ import {
 } from 'storybook/internal/telemetry';
 import type { Presets } from 'storybook/internal/types';
 
-import { match } from 'micromatch';
+import { match, scan } from 'micromatch';
 import { join, normalize, relative, resolve, sep } from 'pathe';
 import path from 'pathe';
 import picocolors from 'picocolors';
@@ -51,6 +51,8 @@ import { requiresProjectAnnotations } from './utils.ts';
 import { AgentTelemetryReporter } from './agent-telemetry-reporter.ts';
 
 const WORKING_DIR = process.cwd();
+
+const escapeGlobPath = (filePath: string) => filePath.replace(/[()[\]{}!*?|+@]/g, '\\$&');
 
 const defaultOptions = {
   storybookScript: undefined,
@@ -302,21 +304,18 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
       finalOptions.vitestRoot =
         testConfig?.dir || testConfig?.root || nonMutableInputConfig.root || process.cwd();
 
-      const includeStories = stories
-        .map((story) => {
-          let storyPath;
+      const includeStories = stories.map((story) => {
+        if (typeof story !== 'string') {
+          const directory = escapeGlobPath(join(finalOptions.configDir, story.directory));
+          return `${directory}/${story.files ?? DEFAULT_FILES_PATTERN}`;
+        }
 
-          if (typeof story === 'string') {
-            storyPath = story;
-          } else {
-            storyPath = `${story.directory}/${story.files ?? DEFAULT_FILES_PATTERN}`;
-          }
+        const { base, glob, negated } = scan(story);
+        const literalPath = escapeGlobPath(join(finalOptions.configDir, base));
+        const pattern = glob ? `${literalPath}/${glob}` : literalPath;
 
-          return join(finalOptions.configDir, storyPath);
-        })
-        .map((story) => {
-          return relative(finalOptions.vitestRoot, story);
-        });
+        return negated ? `!${pattern}` : pattern;
+      });
 
       finalOptions.includeStories = includeStories;
       const projectId = oneWayHash(finalOptions.configDir);
@@ -537,9 +536,9 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
       }
     },
     async transform(code, id) {
-      const relativeId = relative(finalOptions.vitestRoot, id);
+      const normalizedId = normalize(id);
 
-      if (match([relativeId], finalOptions.includeStories).length > 0) {
+      if (match([normalizedId], finalOptions.includeStories).length > 0) {
         return vitestTransform({
           code,
           fileName: id,


### PR DESCRIPTION
Closes storybookjs/storybook#34554

## What I did

- Added regression coverage for a `nextjs/.storybook` config nested below a root Vitest workspace.
- Kept Storybook's generated story include globs absolute so Vitest resolves them independently of the configured Vite root.
- Matched transformed story module IDs against the same normalized absolute globs.

The first commit contains the failing regression test; the second commit contains the fix.

AI assistance disclosure: I used Codex to help investigate, implement, and test this change. I reviewed and verified the resulting code and description.

### Reproduction layout

```text
monorepo/                                  ← process.cwd() and Vitest config root
├── vitest.config.ts
└── nextjs/                                ← Next.js app and Vite root
    ├── .storybook/                        ← nested configDir
    │   └── main.ts
    └── storybook/
        └── Button.stories.ts
```

The root Vitest config calls `storybookTest({ configDir: 'nextjs/.storybook' })`, and `main.ts` includes `../storybook/**/*.stories.ts`. Storybook sets Vite's root to `monorepo/nextjs`, but the old include was `nextjs/storybook/**/*.stories.ts`, relative to `monorepo`. Vitest therefore searched the doubled path `monorepo/nextjs/nextjs/storybook/**/*.stories.ts`.

### Why the layout should not have to move

- Moving `nextjs/.storybook` to `monorepo/.storybook` would move the Storybook configuration outside the Next.js app. That changes the base directory for story globs, static directories, configuration imports, and environment files merely to compensate for path generation inside the addon.
- Moving `vitest.config.ts` into `nextjs` aligns the two roots as a workaround, but gives up a root Vitest workspace that coordinates Next.js and non-Next.js test projects.
- Adding a later Vite plugin that resets `root` to `monorepo` also hides the mismatch, but changes Storybook's intended app root and can affect module resolution, environment loading, and other root-relative Vite behavior.
- Setting the Vitest project root to `nextjs` aligns this specific layout, but duplicates the root that Storybook already derives from `configDir`. The addon still remains dependent on whichever `test.root`, `test.dir`, or Vite `root` the user configured.
- Changing only the `vitestRoot` fallback to `nextjs` fixes the default case but retains that same coupling for explicit root options. Absolute include globs preserve the meaning of each existing root option.
- Adding `server.fs.allow` is unnecessary for this path-resolution bug. When it is not overridden, Vite automatically detects the workspace root; setting an explicit allow list can disable that automatic behavior.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Configure `storybookTest({ configDir: 'nextjs/.storybook' })` from a root-level Vitest config.
2. In `nextjs/.storybook/main.ts`, include `../storybook/**/*.stories.ts`.
3. Add a story beneath `nextjs/storybook`.
4. Run the Storybook Vitest project.
5. Confirm the story is discovered and executes without a "No test files found" result.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No documentation change is needed because this restores existing behavior without changing a public API.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<details>
<summary>Shepherd Journal</summary>

- Addressed [CodeRabbit spy-mock feedback](https://github.com/storybookjs/storybook/pull/36071#discussion_r3879185676) by converting package/file mocks to `{ spy: true }` and configuring behavior through `vi.mocked()` in `beforeEach`; addressed [Codex glob-escaping feedback](https://github.com/storybookjs/storybook/pull/36071#discussion_r3879217375) by escaping the literal absolute path prefix while preserving the user glob.
- No code change is warranted for [Danger](https://github.com/storybookjs/storybook/pull/36071#issuecomment-5450350629): the title now follows `Area: Summary`; the remaining failures require upstream maintainer labels (`bug`, CI, and QA) and a core/DX approval, while the author has only READ repository permission. The edited outdated [CodeRabbit thread](https://github.com/storybookjs/storybook/pull/36071#discussion_r3879185676) describes the already-applied spy-mock fix.
- Addressed the follow-up CodeRabbit findings by preserving [literal object-form story directories](https://github.com/storybookjs/storybook/pull/36071#discussion_r3879411157) and [negated string story globs](https://github.com/storybookjs/storybook/pull/36071#discussion_r3879411169), with regression assertions in the test-only first commit.
</details>