### PR TITLE
Nextjs-Vite: Unwrap CJS loadJsConfig on Vite 7

### DIFF
--- a/code/lib/vite-plugin-storybook-nextjs/src/index.test.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/index.test.ts
@@ -5,6 +5,9 @@ import type { NextConfigComplete } from 'next/dist/server/config-shared.js';
 const requireResolveMock = vi.hoisted(() => vi.fn((id: string) => `/resolved/${id}`));
 const loadConfigMock = vi.hoisted(() => vi.fn());
 const loadJsConfigMock = vi.hoisted(() => vi.fn());
+const loadJsConfigModule = vi.hoisted(() => ({
+  defaultExport: { default: loadJsConfigMock } as unknown,
+}));
 const tsconfigPathsMock = vi.hoisted(() => vi.fn());
 const getExecutionEnvironmentMock = vi.hoisted(() => vi.fn());
 const getNextjsMajorVersionMock = vi.hoisted(() => vi.fn());
@@ -17,7 +20,9 @@ vi.mock('node:module', () => ({
 }));
 
 vi.mock('next/dist/build/load-jsconfig.js', () => ({
-  default: { default: loadJsConfigMock },
+  get default() {
+    return loadJsConfigModule.defaultExport;
+  },
 }));
 
 vi.mock('next/dist/server/config.js', () => ({
@@ -77,6 +82,7 @@ describe('VitePlugin', () => {
 
     process.env.VITEST = 'false';
 
+    loadJsConfigModule.defaultExport = { default: loadJsConfigMock };
     loadConfigMock.mockResolvedValue(nextConfig);
     loadJsConfigMock.mockResolvedValue({
       jsConfigPath: '/root/tsconfig.json',
@@ -90,7 +96,7 @@ describe('VitePlugin', () => {
     getViteMajorVersionMock.mockReturnValue(7);
   });
 
-  it('injects vite-tsconfig-paths on Vite 7 and older', async () => {
+  it('injects vite-tsconfig-paths on Vite 7 when load-jsconfig is a nested default export', async () => {
     const { default: VitePlugin } = await import('./index.ts');
 
     const plugins = VitePlugin({ dir: '/root' });
@@ -109,6 +115,21 @@ describe('VitePlugin', () => {
       },
     });
     expect((await configPlugin?.config?.({}))?.resolve).not.toHaveProperty('tsconfigPaths');
+  });
+
+  it('injects vite-tsconfig-paths when load-jsconfig is a function export', async () => {
+    loadJsConfigModule.defaultExport = loadJsConfigMock;
+
+    const { default: VitePlugin } = await import('./index.ts');
+
+    const plugins = VitePlugin({ dir: '/root' });
+    await plugins[0];
+
+    expect(loadJsConfigMock).toHaveBeenCalledWith('/root', nextConfig);
+    expect(tsconfigPathsMock).toHaveBeenCalledWith({
+      projects: ['/root/tsconfig.json'],
+      root: '/root',
+    });
   });
 
   it('uses native tsconfig paths support on Vite 8 and newer', async () => {

--- a/code/lib/vite-plugin-storybook-nextjs/src/index.test.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/index.test.ts
@@ -17,7 +17,7 @@ vi.mock('node:module', () => ({
 }));
 
 vi.mock('next/dist/build/load-jsconfig.js', () => ({
-  default: loadJsConfigMock,
+  default: { default: loadJsConfigMock },
 }));
 
 vi.mock('next/dist/server/config.js', () => ({
@@ -97,6 +97,7 @@ describe('VitePlugin', () => {
     const tsconfigPlugin = await plugins[0];
     const configPlugin = plugins[1];
 
+    expect(loadJsConfigMock).toHaveBeenCalledWith('/root', nextConfig);
     expect(tsconfigPathsMock).toHaveBeenCalledWith({
       projects: ['/root/tsconfig.json'],
       root: '/root',

--- a/code/lib/vite-plugin-storybook-nextjs/src/index.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/index.ts
@@ -10,7 +10,7 @@ import { vitePluginNextFont } from './plugins/next-font/plugin.ts';
 import { vitePluginNextSwc } from './plugins/next-swc/plugin.ts';
 
 import './polyfills/promise-with-resolvers.ts';
-import loadJsConfig from 'next/dist/build/load-jsconfig.js';
+import nextLoadJsConfig from 'next/dist/build/load-jsconfig.js';
 import {
   PHASE_DEVELOPMENT_SERVER,
   PHASE_PRODUCTION_BUILD,
@@ -30,6 +30,10 @@ import { loadNextConfig } from './utils/next-config.ts';
 const require = createRequire(import.meta.url);
 const compiledReactDir = dirname(require.resolve('next/dist/compiled/react'));
 const compiledReactDomDir = dirname(require.resolve('next/dist/compiled/react-dom'));
+
+const loadJsConfig: typeof nextLoadJsConfig =
+  // biome-ignore lint/suspicious/noExplicitAny: CJS support
+  (nextLoadJsConfig as any).default || nextLoadJsConfig;
 
 export type PluginOptions = {
   /**


### PR DESCRIPTION
Closes #35876

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

On Next 14, Node ESM default-imports of `next/dist/build/load-jsconfig.js` are `{ default: fn }`, not a function. `vite-plugin-storybook-nextjs` called that value on the Vite &lt; 8 tsconfig-paths path, so `storybook dev` and `storybook tools test run` died with `TypeError: loadJsConfig2 is not a function`.

This unwraps `.default` the same way the webpack Next framework and the plugin's SWC transform already do. The call is skipped on Vite 8+, which is why fresh inits that pulled Vite 8 looked fine.


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] e2e tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in the browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

Reproduce on Next **14.2.35** + Vite **7.3.2**. Do not use a Chromatic checkout. After this change, preview should listen; before it, `loadJsConfig2 is not a function`.

```bash
export STORYBOOK_DISABLE_TELEMETRY=1
DIR=$(mktemp -d) && cd "$DIR"
npx --yes create-next-app@14.2.35 . --typescript --eslint --no-tailwind --no-src-dir --app --no-import-alias --use-npm --yes --disable-git
npx --yes storybook@10.6.0-beta.0 init --yes --no-dev
npm install vite@7.3.2 --save-exact
# then install this PR's canary / linked vite-plugin-storybook-nextjs in place of the published one
npx storybook dev -p 6006 --ci
```

Pass: something listens on 6006 and the preview starts. Fail: `TypeError: loadJsConfig2 is not a function`.

Worth extra scrutiny: Next 15/16 + Vite 7 still start (ESM default is already a function), and Vite 8 still skips this branch (`resolve.tsconfigPaths`).

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
