### PR TITLE
Addon MCP: Stop silently dropping composed refs from MCP composition

### DIFF
--- a/code/addons/mcp/src/auth/composition-auth.test.ts
+++ b/code/addons/mcp/src/auth/composition-auth.test.ts
@@ -201,6 +201,27 @@ describe('CompositionAuth', () => {
       );
     });
 
+    it('only rewrites a leading ./ in the manifest path, leaving inner ./ sequences intact', async () => {
+      const auth = new CompositionAuth();
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve('{"anything":"goes"}'),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      const provider = auth.createManifestProvider('http://localhost:6006');
+      const request = new Request('http://localhost:6006/mcp');
+      const source = { id: 'remote', title: 'Remote', url: 'http://remote.example.com' };
+
+      await provider(request, '/services/a./b.json', source);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://remote.example.com/services/a./b.json',
+        expect.any(Object)
+      );
+    });
+
     it('extracts token from request headers for auth-required sources', async () => {
       const auth = new CompositionAuth();
 
@@ -805,7 +826,7 @@ describe('CompositionAuth', () => {
       expect(auth.requiresAuth).toBe(false);
       expect(auth.authUrls).toHaveLength(0);
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to check auth for composed ref "Down Service"')
+        expect.stringContaining('Skipping composed ref "Down Service"')
       );
     });
 

--- a/code/addons/mcp/src/auth/composition-auth.ts
+++ b/code/addons/mcp/src/auth/composition-auth.ts
@@ -41,6 +41,8 @@ interface AuthRequirement {
   serverMetadata: OAuthServerMetadata;
 }
 
+type NoManifestReason = 'manifest-not-found' | 'manifest-invalid';
+
 export type ManifestProvider = (
   request: Request | undefined,
   path: string,
@@ -284,9 +286,7 @@ export class CompositionAuth {
    * 'manifest-not-found' for a non-OK or non-JSON response (SPA fallback pages land here),
    * 'manifest-invalid' for real JSON that fails the manifest schema.
    */
-  async #checkRef(
-    refUrl: string
-  ): Promise<'public' | 'manifest-not-found' | 'manifest-invalid' | AuthRequirement> {
+  async #checkRef(refUrl: string): Promise<'public' | NoManifestReason | AuthRequirement> {
     const response = await fetch(`${refUrl}/manifests/components.json`, {
       headers: { Accept: 'application/json' },
     });
@@ -295,7 +295,7 @@ export class CompositionAuth {
     const authReq = await this.#parseAuthFromResponse(response);
     if (authReq) return authReq;
 
-    let noManifestReason: 'manifest-not-found' | 'manifest-invalid' = 'manifest-not-found';
+    let noManifestReason: NoManifestReason = 'manifest-not-found';
 
     // 200 with valid manifest = public, has manifest
     if (response.ok) {

--- a/code/addons/mcp/src/auth/composition-auth.ts
+++ b/code/addons/mcp/src/auth/composition-auth.ts
@@ -77,7 +77,18 @@ export class CompositionAuth {
     for (const ref of refs) {
       try {
         const result = await this.#checkRef(ref.url);
-        if (result === 'no-manifest') continue;
+        if (result === 'manifest-not-found') {
+          logger.warn(
+            `[addon-mcp] Skipping composed ref "${ref.title}" (${ref.url}): components manifest not found at ${ref.url}/manifests/components.json. Enable the \`componentsManifest\` feature on that Storybook to compose it into MCP.`
+          );
+          continue;
+        }
+        if (result === 'manifest-invalid') {
+          logger.warn(
+            `[addon-mcp] Skipping composed ref "${ref.title}" (${ref.url}): its components manifest failed validation. This usually means a version mismatch between the composed Storybook and this one — upgrade the older side.`
+          );
+          continue;
+        }
 
         this.#refsWithManifests.push(ref);
 
@@ -98,7 +109,7 @@ export class CompositionAuth {
         }
       } catch (error) {
         logger.warn(
-          `[addon-mcp] Failed to check auth for composed ref "${ref.title}" (${ref.url}): ${error instanceof Error ? error.message : String(error)}. Skipping this ref.`
+          `[addon-mcp] Skipping composed ref "${ref.title}" (${ref.url}): the ref could not be reached (${error instanceof Error ? error.message : String(error)}). Refs are only checked at dev-server boot — restart Storybook once the ref is reachable.`
         );
       }
     }
@@ -164,7 +175,7 @@ export class CompositionAuth {
         : undefined;
 
       const baseUrl = remoteSource?.url ?? localOrigin;
-      const manifestUrl = `${baseUrl}${path.replace('./', '/')}`;
+      const manifestUrl = `${baseUrl}${path.replace(/^\.\//, '/')}`;
       const isRemote = !!remoteSource;
       const needsAuth = isRemote && this.#isAuthRequiredUrl(baseUrl);
       const tokenForRequest = needsAuth ? token : null;
@@ -269,9 +280,13 @@ export class CompositionAuth {
   /**
    * Check a ref to determine if it has a manifest and whether it requires auth.
    * Returns 'public' if the ref has a valid manifest without auth,
-   * 'no-manifest' if no manifest is available, or an AuthRequirement if auth is needed.
+   * an AuthRequirement if auth is needed, or the reason the ref has no usable manifest:
+   * 'manifest-not-found' for a non-OK or non-JSON response (SPA fallback pages land here),
+   * 'manifest-invalid' for real JSON that fails the manifest schema.
    */
-  async #checkRef(refUrl: string): Promise<'public' | 'no-manifest' | AuthRequirement> {
+  async #checkRef(
+    refUrl: string
+  ): Promise<'public' | 'manifest-not-found' | 'manifest-invalid' | AuthRequirement> {
     const response = await fetch(`${refUrl}/manifests/components.json`, {
       headers: { Accept: 'application/json' },
     });
@@ -280,11 +295,17 @@ export class CompositionAuth {
     const authReq = await this.#parseAuthFromResponse(response);
     if (authReq) return authReq;
 
+    let noManifestReason: 'manifest-not-found' | 'manifest-invalid' = 'manifest-not-found';
+
     // 200 with valid manifest = public, has manifest
     if (response.ok) {
       const text = await response.text();
-      if (v.safeParse(v.pipe(v.string(), v.parseJson(), ComponentManifestMap), text).success) {
-        return 'public';
+      const json = v.safeParse(v.pipe(v.string(), v.parseJson()), text);
+      if (json.success) {
+        if (v.safeParse(ComponentManifestMap, json.output).success) {
+          return 'public';
+        }
+        noManifestReason = 'manifest-invalid';
       }
     }
 
@@ -292,8 +313,7 @@ export class CompositionAuth {
     const mcpAuth = await this.#checkMcpAuth(refUrl);
     if (mcpAuth) return mcpAuth;
 
-    // No manifest and no auth — this ref doesn't have manifests
-    return 'no-manifest';
+    return noManifestReason;
   }
 
   /** Check /mcp endpoint for 401 auth requirement. */

--- a/code/addons/mcp/src/auth/get-refs-from-config.ts
+++ b/code/addons/mcp/src/auth/get-refs-from-config.ts
@@ -18,8 +18,12 @@ export async function getRefsFromConfig(options: Options): Promise<ComposedRef[]
         return [];
       }
 
-      const { title, url } = value as { title?: unknown; url?: unknown };
-      if (typeof url !== 'string' || url.length === 0) {
+      const { title, url, disable } = value as {
+        title?: unknown;
+        url?: unknown;
+        disable?: unknown;
+      };
+      if (disable || typeof url !== 'string' || url.length === 0) {
         return [];
       }
 
@@ -27,7 +31,7 @@ export async function getRefsFromConfig(options: Options): Promise<ComposedRef[]
         {
           id: key,
           title: typeof title === 'string' && title.length > 0 ? title : key,
-          url,
+          url: url.replace(/\/$/, ''),
         },
       ];
     });

--- a/code/addons/mcp/src/auth/resolve-composition-sources.test.ts
+++ b/code/addons/mcp/src/auth/resolve-composition-sources.test.ts
@@ -1,0 +1,223 @@
+import { logger } from 'storybook/internal/node-logger';
+import type { Options } from 'storybook/internal/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resolveCompositionSources } from './resolve-composition-sources.ts';
+
+const VALID_MANIFEST =
+  '{"v":1,"components":{"button":{"id":"button","name":"Button","path":"src/Button.tsx"}}}';
+
+function optionsWithRefs(refs: unknown): Options {
+  return { presets: { apply: vi.fn().mockResolvedValue(refs) } } as unknown as Options;
+}
+
+describe('resolveCompositionSources', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(logger, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('strips a trailing slash from ref URLs before probing and in the resolved source', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(VALID_MANIFEST),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await resolveCompositionSources(
+      optionsWithRefs({
+        'design-system': { title: 'Design System', url: 'https://ds.example.com/' },
+      })
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://ds.example.com/manifests/components.json',
+      expect.any(Object)
+    );
+    expect(result.sources).toEqual([
+      { id: 'local', title: 'Local' },
+      { id: 'design-system', title: 'Design System', url: 'https://ds.example.com' },
+    ]);
+    expect(result.multiSource).toBe(true);
+  });
+
+  it('excludes refs with disable: true, matching the UI', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(VALID_MANIFEST),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await resolveCompositionSources(
+      optionsWithRefs({
+        enabled: { title: 'Enabled', url: 'https://enabled.example.com' },
+        disabled: { title: 'Disabled', url: 'https://disabled.example.com', disable: true },
+      })
+    );
+
+    expect(mockFetch).not.toHaveBeenCalledWith(
+      'https://disabled.example.com/manifests/components.json',
+      expect.any(Object)
+    );
+    expect(result.sources?.map((source) => source.id)).toEqual(['local', 'enabled']);
+  });
+
+  it('skips a ref whose manifest probe 404s and warns that the manifest was not found', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        // manifest probe: 404
+        .mockResolvedValueOnce({ ok: false, status: 404 })
+        // /mcp auth fallback: 200 (no auth either)
+        .mockResolvedValueOnce({ status: 200 })
+    );
+
+    const result = await resolveCompositionSources(
+      optionsWithRefs({ ds: { title: 'Design System', url: 'https://ds.example.com' } })
+    );
+
+    expect(result.sources?.map((source) => source.id)).toEqual(['local']);
+    expect(result.multiSource).toBe(false);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/"Design System".*manifest.*not found.*componentsManifest/s)
+    );
+  });
+
+  it('classifies a 200 HTML response (SPA fallback) as manifest not found, not a version mismatch', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        // manifest probe: SPA fallback rewrites serve the app shell with a 200
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve('<!doctype html><html><body>App</body></html>'),
+        })
+        // /mcp auth fallback: 200 (no auth)
+        .mockResolvedValueOnce({ status: 200 })
+    );
+
+    const result = await resolveCompositionSources(
+      optionsWithRefs({ ds: { title: 'Design System', url: 'https://ds.example.com' } })
+    );
+
+    expect(result.sources?.map((source) => source.id)).toEqual(['local']);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/"Design System".*manifest.*not found/s)
+    );
+    expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('version mismatch'));
+  });
+
+  it('skips a ref whose manifest is JSON but fails validation and warns about a version mismatch', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        // manifest probe: real JSON in a shape this reader does not understand
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve('{"v":99,"unknown":"format"}'),
+        })
+        // /mcp auth fallback: 200 (no auth)
+        .mockResolvedValueOnce({ status: 200 })
+    );
+
+    const result = await resolveCompositionSources(
+      optionsWithRefs({ ds: { title: 'Design System', url: 'https://ds.example.com' } })
+    );
+
+    expect(result.sources?.map((source) => source.id)).toEqual(['local']);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/"Design System".*failed validation.*version mismatch/s)
+    );
+  });
+
+  it('skips an unreachable ref and warns with the network error and a restart hint', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+
+    const result = await resolveCompositionSources(
+      optionsWithRefs({ ds: { title: 'Design System', url: 'https://ds.example.com' } })
+    );
+
+    expect(result.sources?.map((source) => source.id)).toEqual(['local']);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/"Design System".*could not be reached.*ECONNREFUSED.*restart/s)
+    );
+  });
+
+  it('includes a valid ref without any warning', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(VALID_MANIFEST),
+      })
+    );
+
+    const result = await resolveCompositionSources(
+      optionsWithRefs({ ds: { title: 'Design System', url: 'https://ds.example.com' } })
+    );
+
+    expect(result.sources?.map((source) => source.id)).toEqual(['local', 'ds']);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('keeps the auth-required flow for private refs unchanged', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        // manifest probe: 401 with OAuth challenge
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 401,
+          headers: new Headers({
+            'WWW-Authenticate':
+              'Bearer resource_metadata="https://private.example.com/.well-known/oauth-protected-resource"',
+          }),
+        })
+        // resource metadata
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              resource: 'https://private.example.com/mcp',
+              authorization_servers: ['https://auth.example.com'],
+            }),
+        })
+        // server metadata
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              issuer: 'https://auth.example.com',
+              authorization_endpoint: 'https://auth.example.com/authorize',
+              token_endpoint: 'https://auth.example.com/token',
+            }),
+        })
+    );
+
+    const result = await resolveCompositionSources(
+      optionsWithRefs({ private: { title: 'Private', url: 'https://private.example.com/' } })
+    );
+
+    expect(result.sources?.map((source) => source.id)).toEqual(['local', 'private']);
+    expect(result.compositionAuth.requiresAuth).toBe(true);
+    expect(result.compositionAuth.authUrls).toEqual(['https://private.example.com']);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #36073

## What I did

A Storybook composed via `refs` could show up fine in the sidebar and still be missing from the MCP docs tools, with nothing in the logs to explain why. The most common trigger was a trailing slash in the ref URL: the addon would probe `https://host//manifests/components.json`, the CDN would 404 the double slash, and the ref was dropped without a word.

The addon now reads `refs` the way the UI does: trailing slashes are stripped before any fetch, and refs with `disable: true` stay out of MCP composition, same as they stay out of the sidebar.

And skipped refs are no longer silent. When a ref doesn't make it into composition, the dev server logs a warning at boot naming the ref and the reason:

- "manifest not found", for a 404 or a 200 that isn't JSON. SPA hosts that answer every path with their fallback page land here deliberately. The hint: enable `componentsManifest` on the ref's Storybook.
- "manifest failed validation", for real JSON that doesn't match the schema. That usually means the two Storybooks are on different versions, so the hint is to upgrade the older side.
- "ref unreachable", for a network error. Refs are only checked at boot, so the hint is to restart once the ref is back up.

Working refs log the same sources line as before, and the OAuth fallback for private refs is untouched. While in the manifest provider I also fixed its path joining: it replaced the first `./` found anywhere in the path, which could mangle a path with `./` in the middle; now only a leading `./` is touched.

Not in this PR (per the issue): auto-refs, re-checking refs after boot, manifest schema changes, ref id lowercasing.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`resolve-composition-sources.test.ts` covers each case above: trailing-slash normalization, `disable: true`, the three warning reasons (including the SPA-fallback 200 classifying as "not found"), a valid ref logging nothing, and the unchanged auth-required flow.

#### Manual testing

Add a ref with a trailing slash to a sandbox `.storybook/main.ts`:

```ts
refs: {
  'design-system': {
    title: 'Design System',
    url: 'https://next--635781f3500dd2c49e189caf.chromatic.com/', // trailing slash
  },
},
```

Before this PR the MCP endpoint boots in local-only mode; now the composed source shows up in `docs-list`. Point the ref at a site without manifests, or at an unreachable host, and the boot log names the ref with the matching warning.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No docs changes: the new behavior matches what the composition docs already describe, and the new output is log-only.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
