### PR TITLE
Core: Skip builder preset in headless loading if non-existing

### DIFF
--- a/code/core/src/core-server/load.test.ts
+++ b/code/core/src/core-server/load.test.ts
@@ -1,0 +1,70 @@
+import { Channel } from 'storybook/internal/channels';
+import {
+  getProjectRoot,
+  loadAllPresets,
+  loadMainConfig,
+  resolveAddonName,
+  validateFrameworkName,
+} from 'storybook/internal/common';
+import { oneWayHash } from 'storybook/internal/telemetry';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resolvePackageDir, safeResolveModule } from '../shared/utils/module.ts';
+import { loadStorybook } from './load.ts';
+import { applyServicesPresetOnce } from './utils/apply-services-preset-once.ts';
+
+vi.mock('storybook/internal/common', { spy: true });
+vi.mock('storybook/internal/telemetry', { spy: true });
+vi.mock('../shared/utils/module.ts', { spy: true });
+vi.mock('./utils/apply-services-preset-once.ts', { spy: true });
+
+const secondPassPresets = () => vi.mocked(loadAllPresets).mock.calls[1][0].corePresets;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(getProjectRoot).mockReturnValue('/project');
+  vi.mocked(oneWayHash).mockReturnValue('cache-key');
+  vi.mocked(loadMainConfig).mockResolvedValue({ framework: '/framework', stories: [] });
+  vi.mocked(validateFrameworkName).mockImplementation(() => {});
+  vi.mocked(resolveAddonName).mockReturnValue(undefined);
+  vi.mocked(resolvePackageDir).mockImplementation((packageName) =>
+    packageName === 'storybook' ? '/storybook' : '/builder'
+  );
+  vi.mocked(applyServicesPresetOnce).mockResolvedValue();
+
+  vi.mocked(loadAllPresets)
+    .mockResolvedValueOnce({
+      apply: vi.fn().mockResolvedValue({ builder: 'file:///builder/dist/index.js' }),
+    })
+    .mockResolvedValueOnce({ apply: vi.fn().mockResolvedValue({}) });
+});
+
+describe('loadStorybook', () => {
+  it('loads the builder preset when the builder ships one', async () => {
+    vi.mocked(safeResolveModule).mockReturnValue('/builder/dist/preset.js');
+
+    await loadStorybook({ configDir: '/config', channel: new Channel({}) });
+
+    expect(vi.mocked(safeResolveModule)).toHaveBeenCalledWith({
+      specifier: '/builder/dist/preset.js',
+    });
+    expect(secondPassPresets()).toEqual([
+      '/storybook/dist/core-server/presets/common-preset.js',
+      '/framework/preset',
+      '/builder/dist/preset.js',
+    ]);
+  });
+
+  it('skips the builder preset when the builder ships none', async () => {
+    vi.mocked(safeResolveModule).mockReturnValue(undefined);
+
+    await loadStorybook({ configDir: '/config', channel: new Channel({}) });
+
+    expect(secondPassPresets()).toEqual([
+      '/storybook/dist/core-server/presets/common-preset.js',
+      '/framework/preset',
+    ]);
+  });
+});

--- a/code/core/src/core-server/load.ts
+++ b/code/core/src/core-server/load.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url';
+
 import { Channel, setChannel } from 'storybook/internal/channels';
 import {
   getProjectRoot,
@@ -14,7 +16,7 @@ import { global } from '@storybook/global';
 
 import { dirname, isAbsolute, join, relative, resolve } from 'pathe';
 
-import { resolvePackageDir } from '../shared/utils/module.ts';
+import { resolvePackageDir, safeResolveModule } from '../shared/utils/module.ts';
 
 export async function loadStorybook(
   options: CLIOptions &
@@ -80,9 +82,17 @@ export async function loadStorybook(
        file URL / absolute path (e.g. 'file:///.../.../dist/index.js'). For bare package names, we
        need to resolve the package directory first; for already-resolved paths, dirname works directly.
     */
-    const isResolved = builderName.startsWith('file:') || isAbsolute(builderName);
-    const builderPresetDir = isResolved ? dirname(builderName) : resolvePackageDir(builderName);
-    corePresets.push(join(builderPresetDir, 'preset.js'));
+    const builderEntry = builderName.startsWith('file:') ? fileURLToPath(builderName) : builderName;
+    const builderPresetDir = isAbsolute(builderEntry)
+      ? dirname(builderEntry)
+      : resolvePackageDir(builderEntry);
+    // Not every builder ships this preset: builder-webpack5 declares its presets on its main module
+    // instead, and only the dev server and static build load a builder module to reach them.
+    const builderPreset = safeResolveModule({ specifier: join(builderPresetDir, 'preset.js') });
+
+    if (builderPreset) {
+      corePresets.push(builderPreset);
+    }
   }
 
   // Load second pass: all presets are applied in order


### PR DESCRIPTION
<!-- No linked issue; reported internally. -->

## What I did

Running any `storybook tools` command against a Webpack project printed an `ERR_MODULE_NOT_FOUND` for `@storybook/builder-webpack5/dist/preset.js` on every invocation, and then carried on working.

`loadStorybook` (the headless loader behind `storybook tools` and `experimental_loadStorybook`) assumed every builder ships a root `preset.js` and pushed that guessed path into `corePresets` unconditionally. `@storybook/builder-vite` does ship one, so Vite projects were fine. `@storybook/builder-webpack5` does not — it declares `corePresets` / `overridePresets` on its main module instead, and only `storybook dev` / `storybook build` import the builder module to reach them. The guessed path therefore never existed for Webpack, and `loadAllPresets` logged the failure while continuing.

This PR resolves the path first and only adds the preset when it actually exists, so nothing is logged when a builder legitimately has no root preset.

Notes on the shape of the fix:

- The builder name reaches this code either as a bare package name (`@storybook/builder-vite`) or as an already-resolved `file:` URL (frameworks use `import.meta.resolve`). The `file:` URL is now converted with `fileURLToPath` before resolution — without that conversion the existence check would fail for every Vite framework and silently drop Vite's preset.
- I also prototyped the fuller fix of importing the builder module and consuming its declared `corePresets` / `overridePresets`, mirroring `storybook dev`. It removes the error too, but importing `@storybook/builder-webpack5` costs roughly 4x the `tools` CLI startup time (median ~419ms → ~2s), which is not worth paying for presets that the headless consumers (docs/story/test toolsets) do not use. Webpack's build-time presets stay out of the headless path, exactly as they were before this PR — the only change is that we no longer log about them.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`code/core/src/core-server/load.test.ts` covers both branches: the builder preset is loaded when it resolves, and omitted when it does not.

#### Manual testing

1. Create a Webpack sandbox: `yarn task sandbox --template nextjs/default-ts --start-from auto`
2. From the repo root, run the tools CLI against it: `node code/core/dist/bin/dispatcher.js tools --no-attach --config-dir <sandbox>/.storybook docs list`
3. On `next` this prints `Failed to load preset: .../builder-webpack5/dist/preset.js` with an `ERR_MODULE_NOT_FOUND` stack before the output; with this PR the output appears with no error.
4. Repeat against a Vite sandbox (`react-vite/default-ts`) and confirm it is unchanged — Vite's preset must still load. `yarn storybook` and `yarn build-storybook` should behave identically for both templates.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->