### PR TITLE
Core: Always show warning in story-docs if available

### DIFF
--- a/code/core/src/shared/open-service/services/story-docs/story-docs-source-before-each.test.ts
+++ b/code/core/src/shared/open-service/services/story-docs/story-docs-source-before-each.test.ts
@@ -34,6 +34,7 @@ const payload: StoryDocsPayload = {
 };
 const warning =
   'Label is declared in the story file, so the snippet references it without importing it.';
+const fallbackWarning = `${warning} Showing the story source instead.`;
 const payloadWithWarning: StoryDocsPayload = {
   ...payload,
   stories: { [storyId]: { ...payload.stories[storyId]!, warning } },
@@ -139,9 +140,67 @@ describe('storyDocsSourceBeforeEach', () => {
     await cleanup?.();
   });
 
-  it('emits no warning when it falls back to the CSF source', async () => {
+  it('emits the story warning with fallback context when it falls back to the CSF source', async () => {
     mockStoryDocsService(() =>
-      Promise.resolve({ ...payloadWithWarning, stories: {} } as StoryDocsPayload)
+      Promise.resolve({
+        ...payloadWithWarning,
+        stories: { [storyId]: { id: storyId, name: 'Primary', warning } },
+      })
+    );
+    const context = {
+      id: storyId,
+      parameters: {
+        __isArgsStory: true,
+        docs: { source: { originalSource: 'export const Primary = {};' } },
+      },
+    } as unknown as StoryContext;
+
+    const cleanup = storyDocsSourceBeforeEach(context);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockedEmitTransformCode).toHaveBeenCalledWith(
+      'export const Primary = {};',
+      context,
+      fallbackWarning
+    );
+    await cleanup?.();
+  });
+
+  it('keeps the fallback warning in production builds', async () => {
+    vi.stubGlobal('CONFIG_TYPE', 'PRODUCTION');
+    mockStoryDocsService(() =>
+      Promise.resolve({
+        ...payloadWithWarning,
+        stories: { [storyId]: { id: storyId, name: 'Primary', warning } },
+      })
+    );
+    const context = {
+      id: storyId,
+      parameters: {
+        __isArgsStory: true,
+        docs: { source: { originalSource: 'export const Primary = {};' } },
+      },
+    } as unknown as StoryContext;
+
+    const cleanup = storyDocsSourceBeforeEach(context);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockedEmitTransformCode).toHaveBeenCalledWith(
+      'export const Primary = {};',
+      context,
+      fallbackWarning
+    );
+    await cleanup?.();
+  });
+
+  it('emits no warning for the CSF source fallback without a story warning', async () => {
+    mockStoryDocsService(() =>
+      Promise.resolve({
+        ...payload,
+        stories: { [storyId]: { id: storyId, name: 'Primary' } },
+      })
     );
     const context = {
       id: storyId,

--- a/code/core/src/shared/open-service/services/story-docs/story-docs-source-before-each.ts
+++ b/code/core/src/shared/open-service/services/story-docs/story-docs-source-before-each.ts
@@ -49,9 +49,13 @@ export function storyDocsSourceBeforeEach(context: StoryContext): CleanupCallbac
       if (source === undefined) {
         return;
       }
-      // The warning describes the service snippet, so it must not survive the fall back to raw CSF.
-      const warning = snippet === undefined ? undefined : selectWarningForStory(payload, storyId);
-      return emitTransformCode(source, context, warning);
+      const warning = selectWarningForStory(payload, storyId);
+
+      return emitTransformCode(
+        source,
+        context,
+        snippet === undefined && warning ? `${warning} Showing the story source instead.` : warning
+      );
     });
 
   return () => {


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

When the story-docs provider cannot synthesize a static snippet, the docs Code panel falls back to raw CSF source with no explanation:

<img width="1440" height="1100" alt="image" src="https://github.com/user-attachments/assets/a5dd2de2-d9c2-41e0-ab92-379de97a0de2" />


This PR keeps the warning on the fallback path, CSF fallback or not because it would be strange to have CSF source as a code snippet:

<img width="1611" height="406" alt="image" src="https://github.com/user-attachments/assets/e0e95648-967d-454d-94f6-2d4220292ae0" />

 
<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
