### PR TITLE
Addon Vitest: Report test runs with failures as failed tool outcomes

### DIFF
--- a/code/addons/vitest/src/node/toolset/definition.test.ts
+++ b/code/addons/vitest/src/node/toolset/definition.test.ts
@@ -162,6 +162,66 @@ describe('test API', () => {
     expect(runStoryTests).toHaveBeenCalledTimes(2);
   });
 
+  describe('run outcome', () => {
+    it('flags a completed run with failing tests as a failure', async () => {
+      vi.mocked(runStoryTests).mockResolvedValue(
+        completed({
+          componentTestCount: { success: 1, error: 1 },
+          componentTestStatuses: [
+            componentTest('button--primary', 'status-value:success'),
+            componentTest('button--secondary', 'status-value:error', 'Assertion failed'),
+          ],
+        })
+      );
+
+      expect((await runTests()).ok).toBe(false);
+    });
+
+    it('flags a completed run with unhandled errors as a failure', async () => {
+      vi.mocked(runStoryTests).mockResolvedValue(
+        completed({
+          componentTestCount: { success: 1, error: 0 },
+          unhandledErrors: [{ name: 'ReferenceError', message: 'foo is not defined' }],
+        })
+      );
+
+      expect((await runTests()).ok).toBe(false);
+    });
+
+    it('flags error-level accessibility results as a failure', async () => {
+      vi.mocked(runStoryTests).mockResolvedValue(
+        completed({
+          componentTestCount: { success: 1, error: 0 },
+          a11yCount: { success: 0, warning: 0, error: 1 },
+        })
+      );
+
+      expect((await runTests()).ok).toBe(false);
+    });
+
+    it('passes a run whose accessibility results only carry warnings', async () => {
+      vi.mocked(runStoryTests).mockResolvedValue(
+        completed({
+          componentTestCount: { success: 1, error: 0 },
+          a11yCount: { success: 0, warning: 2, error: 0 },
+        })
+      );
+
+      expect((await runTests()).ok).toBe(true);
+    });
+
+    it('ignores error-level accessibility results when the run disabled a11y', async () => {
+      vi.mocked(runStoryTests).mockResolvedValue(
+        completed({
+          componentTestCount: { success: 1, error: 0 },
+          a11yCount: { success: 0, warning: 0, error: 1 },
+        })
+      );
+
+      expect((await runTests({ a11y: false })).ok).toBe(true);
+    });
+  });
+
   describe('description', () => {
     it('promises accessibility reports when a11y is enabled', () => {
       expect(toolset.methods.run.description).toContain(

--- a/code/addons/vitest/src/node/toolset/definition.ts
+++ b/code/addons/vitest/src/node/toolset/definition.ts
@@ -96,11 +96,9 @@ export type TestRunOutput = v.InferOutput<typeof testRunOutputSchema>;
 export type TestRunData = TestRunOutput & { a11y: boolean };
 
 /**
- * The outcome split for `test.run`, following the Vitest convention: a run only succeeds when it
- * completes without failing tests. Crashes, cancellations, and completed runs with failing tests,
- * error-level accessibility results, or unhandled errors are failures that still carry their full
- * report, so clients keying on `ok` cannot count them as a pass while agents keep the diagnostic
- * detail.
+ * The outcome split for `test.run`, following the Vitest convention: only a run that completes
+ * without failures succeeds. A failed outcome still carries its full report, so clients keying on
+ * `ok` cannot count it as a pass while agents keep the diagnostic detail.
  */
 export type TestRunSuccessData = Extract<TestRunOutput, { status: 'completed' | 'no-stories' }> & {
   a11y: boolean;
@@ -205,8 +203,13 @@ function isFailedRun(data: TestRunData): data is TestRunFailureData {
         (data.a11y && data.result.a11yCount.error > 0) ||
         data.result.unhandledErrors.length > 0
       );
-    default:
+    case 'no-stories':
       return false;
+    default: {
+      // Type-only: a new status must decide its own pass/fail rather than falling through.
+      const _exhaustive: never = data;
+      return _exhaustive;
+    }
   }
 }
 

--- a/code/addons/vitest/src/node/toolset/definition.ts
+++ b/code/addons/vitest/src/node/toolset/definition.ts
@@ -96,15 +96,20 @@ export type TestRunOutput = v.InferOutput<typeof testRunOutputSchema>;
 export type TestRunData = TestRunOutput & { a11y: boolean };
 
 /**
- * The outcome split for `test.run`: a crashed or cancelled run is a failure that still carries its
- * full report, so clients keying on the tag cannot count it as a pass while agents keep the
- * diagnostic detail.
+ * The outcome split for `test.run`, following the Vitest convention: a run only succeeds when it
+ * completes without failing tests. Crashes, cancellations, and completed runs with failing tests,
+ * error-level accessibility results, or unhandled errors are failures that still carry their full
+ * report, so clients keying on `ok` cannot count them as a pass while agents keep the diagnostic
+ * detail.
  */
 export type TestRunSuccessData = Extract<TestRunOutput, { status: 'completed' | 'no-stories' }> & {
   a11y: boolean;
 };
 
-export type TestRunFailureData = Extract<TestRunOutput, { status: 'error' | 'cancelled' }> & {
+export type TestRunFailureData = Extract<
+  TestRunOutput,
+  { status: 'completed' | 'error' | 'cancelled' }
+> & {
   a11y: boolean;
 };
 
@@ -189,6 +194,22 @@ async function reportRunTelemetry(data: TestRunData, input: RunInput, ctx: Tools
   });
 }
 
+function isFailedRun(data: TestRunData): data is TestRunFailureData {
+  switch (data.status) {
+    case 'error':
+    case 'cancelled':
+      return true;
+    case 'completed':
+      return (
+        data.result.componentTestCount.error > 0 ||
+        (data.a11y && data.result.a11yCount.error > 0) ||
+        data.result.unhandledErrors.length > 0
+      );
+    default:
+      return false;
+  }
+}
+
 export type CreateTestToolsetOptions = {
   channel: TestChannel;
   storyIndex: StoryIndexAccess;
@@ -228,9 +249,7 @@ export function createTestToolset({ channel, storyIndex, a11yEnabled }: CreateTe
             await reportRunTelemetry(data, input, ctx);
 
             const markdown = formatTestRun(data, ctx);
-            return data.status === 'error' || data.status === 'cancelled'
-              ? { ok: false, data, markdown }
-              : { ok: true, data, markdown };
+            return isFailedRun(data) ? { ok: false, data, markdown } : { ok: true, data, markdown };
           } finally {
             done();
           }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

`storybook tools test run` exited 0 even when the run contained failing tests, because the `test.run` toolset only returned `ok: false` for crashed (`error`) or `cancelled` runs. Agents were confused by a "successful" failing run, and CI pipelines built on the command could never go red.

Following the Vitest convention (0 = successful run, 1 = test failures or any other error), a completed run now counts as a failed outcome when it has:

- failing component tests,
- error-level accessibility results (only when the run included a11y), or
- unhandled errors.

Because MCP `isError` and the CLI exit code both derive mechanically from the outcome's `ok` flag (see `toolset-definition.ts`), this one change makes the CLI exit 1 and flags the MCP tool result as an error for failing runs, on both transports. Accessibility warnings and `no-stories` results still count as successful outcomes.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Run a sandbox, e.g. `yarn task sandbox --template react-vite/default-ts --start-from auto`
2. In the sandbox, make a story test fail (e.g. break an assertion in a `play` function)
3. Run `npx storybook tools test run` and check the exit code (`echo $?`) — it should be `1`, with the failing story reported in the output
4. Fix the test, run it again — the exit code should be `0`
5. Via MCP (addon-mcp), the `test-run` tool result should carry `isError: true` for the failing run

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->