### PR TITLE
CLI: Serve the skills docs workflow whenever manifests are producible

### DIFF
--- a/code/addons/mcp/scripts/generate-tools-api-doc.ts
+++ b/code/addons/mcp/scripts/generate-tools-api-doc.ts
@@ -35,6 +35,7 @@ const availability = (reviewEnabled: boolean): ToolAvailability => ({
   reviewEnabled,
   reviewEnabledForCli: reviewEnabled,
   docsEnabled: true,
+  docsEnabledForCli: true,
   docsHasManifests: true,
   docsFeatureEnabled: true,
   testSupported: true,

--- a/code/addons/mcp/src/preset.test.ts
+++ b/code/addons/mcp/src/preset.test.ts
@@ -364,6 +364,7 @@ describe('experimental_devServer', () => {
       reviewEnabled: false,
       reviewEnabledForCli: false,
       docsEnabled: false,
+      docsEnabledForCli: false,
       docsHasManifests: false,
       docsFeatureEnabled: false,
       testSupported: false,

--- a/code/addons/mcp/src/storybook-ai-metadata.test.ts
+++ b/code/addons/mcp/src/storybook-ai-metadata.test.ts
@@ -549,6 +549,7 @@ function createAvailability(overrides: Partial<ToolAvailability> = {}): ToolAvai
     reviewEnabled: true,
     reviewEnabledForCli: true,
     docsEnabled: true,
+    docsEnabledForCli: true,
     docsHasManifests: true,
     docsFeatureEnabled: true,
     testSupported: true,

--- a/code/addons/mcp/src/tools/tool-registry.test.ts
+++ b/code/addons/mcp/src/tools/tool-registry.test.ts
@@ -57,6 +57,7 @@ function availabilityWith(overrides: Partial<ToolAvailability> = {}): ToolAvaila
     reviewEnabled: false,
     reviewEnabledForCli: false,
     docsEnabled: false,
+    docsEnabledForCli: false,
     docsHasManifests: false,
     docsFeatureEnabled: false,
     testSupported: false,

--- a/code/core/src/cli/skills/availability.test.ts
+++ b/code/core/src/cli/skills/availability.test.ts
@@ -82,12 +82,40 @@ describe('getToolAvailability', () => {
       reviewEnabled: true,
       reviewEnabledForCli: true,
       docsEnabled: true,
+      docsEnabledForCli: true,
       docsHasManifests: true,
       docsFeatureEnabled: true,
       testSupported: true,
       a11yEnabled: true,
       docgenServer: true,
     });
+  });
+
+  it('enables the CLI docs gate on manifests alone, without the component-manifest flag', async () => {
+    vi.mocked(getManifestStatus).mockResolvedValue({
+      available: false,
+      hasManifests: true,
+      hasFeatureFlag: false,
+      docgenServer: false,
+    });
+
+    const result = await getToolAvailability(createOptions());
+
+    expect(result.docsEnabled).toBe(false);
+    expect(result.docsEnabledForCli).toBe(true);
+  });
+
+  it('disables the CLI docs gate when no manifests can be produced', async () => {
+    vi.mocked(getManifestStatus).mockResolvedValue({
+      available: false,
+      hasManifests: false,
+      hasFeatureFlag: false,
+      docgenServer: false,
+    });
+
+    const result = await getToolAvailability(createOptions());
+
+    expect(result.docsEnabledForCli).toBe(false);
   });
 
   it('probes the module-graph service directly when no override is given', async () => {
@@ -115,6 +143,7 @@ describe('getEffectiveToolAvailability', () => {
     reviewEnabled: false,
     reviewEnabledForCli: false,
     docsEnabled: false,
+    docsEnabledForCli: false,
     docsHasManifests: false,
     docsFeatureEnabled: false,
     testSupported: false,
@@ -129,6 +158,7 @@ describe('getEffectiveToolAvailability', () => {
   it('forces docs availability on for multi-source composition', () => {
     expect(getEffectiveToolAvailability(base, { multiSource: true })).toMatchObject({
       docsEnabled: true,
+      docsEnabledForCli: true,
       docsHasManifests: true,
       docsFeatureEnabled: true,
     });

--- a/code/core/src/cli/skills/availability.ts
+++ b/code/core/src/cli/skills/availability.ts
@@ -23,6 +23,11 @@ export interface ToolAvailability {
   reviewEnabledForCli: boolean;
   /** Component-manifest feature is on AND manifests were found. Gates the `docs` toolset. */
   docsEnabled: boolean;
+  /**
+   * Docs gate for the `storybook tools` CLI channel, which reads manifests in-process and so only
+   * needs manifests to be producible — not the `componentsManifest` opt-in that gates MCP.
+   */
+  docsEnabledForCli: boolean;
   /** Any component manifests were found (drives the docs "why disabled" copy). */
   docsHasManifests: boolean;
   /** The component-manifest feature flag is enabled (drives the docs "why disabled" copy). */
@@ -71,6 +76,7 @@ export function getEffectiveToolAvailability(
   return {
     ...availability,
     docsEnabled: true,
+    docsEnabledForCli: true,
     docsHasManifests: true,
     docsFeatureEnabled: true,
   };
@@ -144,6 +150,7 @@ export async function getToolAvailability(
     reviewEnabled: reviewStatus.available,
     reviewEnabledForCli: reviewStatus.availableForCli,
     docsEnabled: manifestStatus.available,
+    docsEnabledForCli: manifestStatus.hasManifests,
     docsHasManifests: manifestStatus.hasManifests,
     docsFeatureEnabled: manifestStatus.hasFeatureFlag,
     testSupported: addonVitestEnabled,

--- a/code/core/src/cli/skills/run.test.ts
+++ b/code/core/src/cli/skills/run.test.ts
@@ -13,6 +13,7 @@ const deps = () => ({
     reviewEnabled: false,
     reviewEnabledForCli: true,
     docsEnabled: false,
+    docsEnabledForCli: false,
     docsHasManifests: false,
     docsFeatureEnabled: false,
     testSupported: true,
@@ -42,6 +43,30 @@ describe('runSkillsCommand', () => {
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain('npx storybook tools');
     expect(result.output).not.toContain('stories-preview** ');
+  });
+
+  it('serves the docs workflow on the CLI gate even when the MCP docs gate is off', async () => {
+    const d = deps();
+    d.resolveSkillInputs.mockResolvedValue({
+      ...(await d.resolveSkillInputs()),
+      docsEnabled: false,
+      docsEnabledForCli: true,
+    });
+
+    const stories = await runSkillsCommand({ subcommand: 'get', id: 'stories', target: {} }, d);
+    expect(stories.output).toContain('Documentation Workflow');
+
+    const writeStory = await runSkillsCommand(
+      { subcommand: 'get', id: 'write-story', target: {} },
+      d
+    );
+    expect(writeStory.output).toContain('npx storybook tools docs list');
+  });
+
+  it('omits the docs workflow when the CLI docs gate is off', async () => {
+    const d = deps();
+    const stories = await runSkillsCommand({ subcommand: 'get', id: 'stories', target: {} }, d);
+    expect(stories.output).not.toContain('Documentation Workflow');
   });
 
   it('get write-story assembles CLI-transport story instructions', async () => {

--- a/code/core/src/cli/skills/run.ts
+++ b/code/core/src/cli/skills/run.ts
@@ -105,7 +105,7 @@ function assemble(id: Exclude<SkillId, 'setup'>, inputs: SkillInputs): string {
       transport: 'cli',
       devEnabled: true,
       testSupported: inputs.testSupported,
-      docsEnabled: inputs.docsEnabled,
+      docsEnabled: inputs.docsEnabledForCli,
       changeDetectionEnabled: inputs.changeDetectionEnabled,
       moduleGraphSupported: inputs.moduleGraphSupported,
       reviewEnabled,
@@ -119,6 +119,6 @@ function assemble(id: Exclude<SkillId, 'setup'>, inputs: SkillInputs): string {
     reviewEnabled,
     testSupported: inputs.testSupported,
     a11yEnabled: inputs.a11yEnabled,
-    docsEnabled: inputs.docsEnabled,
+    docsEnabled: inputs.docsEnabledForCli,
   });
 }


### PR DESCRIPTION
<!-- No tracking issue; follows the decision in the internal 10.6 release thread (Slack: p1787860602088989). -->

## What I did

`storybook tools docs list|show|show-story` works via the in-process manifest fallback regardless of the `componentsManifest` feature flag — that flag only gates the dev-server manifest routes, static-build manifest output, and MCP tool registration. But `storybook skills get stories` / `get write-story` still gated the docs-workflow guidance on `docsEnabled` (`componentsManifest` on AND manifests found), so CLI agents were never told about docs tools that actually work.

This PR adds `docsEnabledForCli` to `ToolAvailability` — true whenever manifests can be produced (framework wires `experimental_manifests`, docgen-server mode, or the legacy generator), without requiring the `componentsManifest` opt-in — mirroring the existing `reviewEnabled` / `reviewEnabledForCli` channel split. The skills CLI now feeds this gate into both the `stories` and `write-story` builders.

The MCP channel is unchanged: addon-mcp, the `storybook ai` metadata path, and hosted MCP keep gating on `docsEnabled`.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Create a fresh React Vite project and run `npx storybook@canary init --yes` (or link this branch), then remove `@storybook/addon-mcp` from `.storybook/main.ts` (or set `features: { componentsManifest: false }`), and do not set `experimentalDocgenServer`.
2. Run `npx storybook skills get stories` — the output should now include the `## Documentation Workflow` section pointing at `npx storybook tools docs list`.
3. Run `npx storybook skills get write-story` — the output should include the "Using library components" guidance referencing `npx storybook tools docs list`.
4. Verify the MCP surface is unchanged: with addon-mcp installed and `features: { componentsManifest: false }`, start Storybook and check `tools/list` on `/mcp` still has no `docs-*` tools.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`