### PR TITLE
Core: Warn when CSF file has no stories

### DIFF
--- a/code/core/src/core-server/presets/common-preset.ts
+++ b/code/core/src/core-server/presets/common-preset.ts
@@ -265,7 +265,13 @@ export const csfIndexer: Indexer = {
       logger.debug(`The file ${fileName} is empty. Skipping indexing.`);
       return [];
     }
-    return loadCsf(code, { ...options, fileName }).parse().indexInputs;
+    const indexInputs = loadCsf(code, { ...options, fileName }).parse().indexInputs;
+
+    if (indexInputs.length === 0) {
+      logger.warn(`No stories found in ${fileName}`);
+    }
+
+    return indexInputs;
   },
 };
 

--- a/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
+++ b/code/core/src/core-server/utils/StoryIndexGenerator.test.ts
@@ -231,6 +231,7 @@ describe('StoryIndexGenerator', () => {
         await generator.initialize();
 
         const { storyIndex } = await generator.getIndexAndStats();
+        expect(logger.warn).not.toHaveBeenCalled();
         expect(storyIndex).toMatchInlineSnapshot(`
           {
             "entries": {},
@@ -2112,6 +2113,18 @@ describe('StoryIndexGenerator', () => {
         expect(once.warn).toHaveBeenCalledTimes(1);
         const logMessage = vi.mocked(once.warn).mock.calls[0][0];
         expect(logMessage).toContain(`No story files found for the specified pattern`);
+      });
+
+      it('warns when a CSF file has no stories', async () => {
+        const generator = new StoryIndexGenerator(
+          [normalizeStoriesEntry('./errors/MetaOnly.stories.ts', options)],
+          options
+        );
+        await generator.initialize();
+
+        await generator.getIndex();
+
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('MetaOnly.stories.ts'));
       });
     });
 

--- a/code/core/src/core-server/utils/__mockdata__/errors/MetaOnly.stories.ts
+++ b/code/core/src/core-server/utils/__mockdata__/errors/MetaOnly.stories.ts
@@ -1,0 +1,3 @@
+export default {
+  title: 'Hello',
+};


### PR DESCRIPTION
Closes #21375

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->


<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

1. Added a warning when a non-empty CSF story file is matched by Storybook but contains no story exports.
2. Empty/whitespace-only story files continue to be ignored without a warning.
3. Added a regression test and fixture covering the metadata-only CSF case.

I used Codex while working on this contribution to help with code exploration and debugging. I reviewed and tested the final changes myself.
<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run a React Vite Storybook sandbox from the `next` branch.
2. Open the sandbox Storybook project.
3. Modify a matched `*.stories.ts` file so it contains only a default export:
   ```ts
   export default {
     title: 'Hello',
   };

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
