### PR TITLE
Core: Make unit tests path-safe on Windows

### DIFF
--- a/code/core/src/common/presets.test.ts
+++ b/code/core/src/common/presets.test.ts
@@ -1,6 +1,7 @@
 import path, { dirname, join, normalize, relative } from 'node:path';
 import { fileURLToPath, pathToFileURL, resolve } from 'node:url';
 
+import { join as patheJoin } from 'pathe';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { logger } from 'storybook/internal/node-logger';
@@ -496,9 +497,9 @@ describe('resolveAddonName', () => {
       expect(resolveAddonName({} as any, addonDir, {})).toEqual({
         type: 'virtual',
         name: addonDir,
-        presets: [{ name: join(addonDir, 'lib', 'preset.js'), options: {} }],
-        managerEntries: [join(addonDir, 'lib', 'manager.js')],
-        previewAnnotations: [join(addonDir, 'lib', 'preview.js')],
+        presets: [{ name: patheJoin(addonDir, 'lib', 'preset.js'), options: {} }],
+        managerEntries: [patheJoin(addonDir, 'lib', 'manager.js')],
+        previewAnnotations: [patheJoin(addonDir, 'lib', 'preview.js')],
       });
     });
 
@@ -508,9 +509,9 @@ describe('resolveAddonName', () => {
       expect(resolveAddonName({} as any, addonDir, {})).toEqual({
         type: 'virtual',
         name: addonDir,
-        presets: [{ name: join(addonDir, 'preset.js'), options: {} }],
-        managerEntries: [join(addonDir, 'manager.js')],
-        previewAnnotations: [join(addonDir, 'preview.js')],
+        presets: [{ name: patheJoin(addonDir, 'preset.js'), options: {} }],
+        managerEntries: [patheJoin(addonDir, 'manager.js')],
+        previewAnnotations: [patheJoin(addonDir, 'preview.js')],
       });
     });
 

--- a/code/core/src/core-server/load.test.ts
+++ b/code/core/src/core-server/load.test.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
 import { Channel } from 'storybook/internal/channels';
 import {
   getProjectRoot,
@@ -8,6 +10,7 @@ import {
 } from 'storybook/internal/common';
 import { oneWayHash } from 'storybook/internal/telemetry';
 
+import { dirname, join } from 'pathe';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { resolvePackageDir, safeResolveModule } from '../shared/utils/module.ts';
@@ -20,6 +23,10 @@ vi.mock('../shared/utils/module.ts', { spy: true });
 vi.mock('./utils/apply-services-preset-once.ts', { spy: true });
 
 const secondPassPresets = () => vi.mocked(loadAllPresets).mock.calls[1][0].corePresets;
+
+const builderIndexPath = '/builder/dist/index.js';
+const builderFileUrl = pathToFileURL(builderIndexPath).href;
+const builderPresetPath = join(dirname(fileURLToPath(builderFileUrl)), 'preset.js');
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -36,24 +43,24 @@ beforeEach(() => {
 
   vi.mocked(loadAllPresets)
     .mockResolvedValueOnce({
-      apply: vi.fn().mockResolvedValue({ builder: 'file:///builder/dist/index.js' }),
+      apply: vi.fn().mockResolvedValue({ builder: builderFileUrl }),
     })
     .mockResolvedValueOnce({ apply: vi.fn().mockResolvedValue({}) });
 });
 
 describe('loadStorybook', () => {
   it('loads the builder preset when the builder ships one', async () => {
-    vi.mocked(safeResolveModule).mockReturnValue('/builder/dist/preset.js');
+    vi.mocked(safeResolveModule).mockReturnValue(builderPresetPath);
 
     await loadStorybook({ configDir: '/config', channel: new Channel({}) });
 
     expect(vi.mocked(safeResolveModule)).toHaveBeenCalledWith({
-      specifier: '/builder/dist/preset.js',
+      specifier: builderPresetPath,
     });
     expect(secondPassPresets()).toEqual([
       '/storybook/dist/core-server/presets/common-preset.js',
       '/framework/preset',
-      '/builder/dist/preset.js',
+      builderPresetPath,
     ]);
   });
 

--- a/code/core/src/telemetry/get-has-next-custom-webpack.test.ts
+++ b/code/core/src/telemetry/get-has-next-custom-webpack.test.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import { beforeEach, expect, it, vi } from 'vitest';
 
@@ -9,7 +10,7 @@ vi.mock(import('node:fs'), { spy: true });
 const projectRoot = '/project';
 
 const mockNextConfig = (fileName: string, content: string) => {
-  vi.mocked(existsSync).mockImplementation((path) => path === `${projectRoot}/${fileName}`);
+  vi.mocked(existsSync).mockImplementation((path) => path === join(projectRoot, fileName));
   vi.mocked(readFileSync).mockReturnValue(content);
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fix 7 failing unit tests on Windows (`tests-unit--windows` in the daily CircleCI workflow: https://app.circleci.com/pipelines/github/storybookjs/storybook/131891/workflows/22b6d98f-77a2-457c-a976-81c973d1508d/jobs/1982905).

The failures came from POSIX-only path assumptions in tests, not production code:

- `load.test.ts`: `file:///builder/dist/index.js` is not a valid Windows file URL. Build the builder URL with `pathToFileURL` and derive the expected preset path from it.
- `presets.test.ts`: `resolveAddonName` returns `pathe` paths (forward slashes). Compare against `pathe.join` instead of `node:path.join`.
- `get-has-next-custom-webpack.test.ts`: the `existsSync` stub compared against `` `${root}/${file}` ``, which does not match `node:path.join` on Windows. Use `join` from `node:path`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

No manual testing is needed. This is a unit-test-only change with no production code edits.

To verify locally:

1. From `code/`, run:
   ```
   yarn test load.test.ts
   yarn test presets.test.ts
   yarn test get-has-next-custom-webpack.test.ts
   ```
2. Confirm the 7 previously failing cases pass: `loadStorybook` builder preset load/skip, `resolveAddonName` exports-map and root-level entries, and the three `getHasNextCustomWebpack` detection cases.
3. On CI, confirm `tests-unit--windows` is green.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

Suggested labels: `build`, `ci:normal`, `qa:skip`.

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf535c4b-1473-4a41-989b-7b123193a370?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf535c4b-1473-4a41-989b-7b123193a370&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

