### PR TITLE
Docs: Scroll to the heading when its anchor is clicked

### DIFF
--- a/code/addons/docs/src/blocks/blocks/mdx.test.tsx
+++ b/code/addons/docs/src/blocks/blocks/mdx.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import React from 'react';
+
+import { NAVIGATE_URL } from 'storybook/internal/core-events';
+
+import { ThemeProvider, convert, themes } from 'storybook/theming';
+
+import type { DocsContextProps } from './DocsContext';
+import { DocsContext } from './DocsContext';
+import { HeaderMdx } from './mdx';
+
+const HEADING_ID = 'my-heading';
+
+const renderHeading = () => {
+  const emit = vi.fn();
+
+  render(
+    <ThemeProvider theme={convert(themes.light)}>
+      <DocsContext.Provider value={{ channel: { emit } } as unknown as DocsContextProps}>
+        <HeaderMdx as="h2" id={HEADING_ID}>
+          Heading
+        </HeaderMdx>
+      </DocsContext.Provider>
+    </ThemeProvider>
+  );
+
+  const heading = document.getElementById(HEADING_ID)!;
+  // happy-dom does not implement scrollIntoView.
+  heading.scrollIntoView = vi.fn();
+
+  return {
+    emit,
+    heading,
+    anchor: screen.getByRole('link', { name: 'Copy heading URL to address bar' }),
+  };
+};
+
+describe('HeaderMdx anchor', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  it('scrolls to the heading the anchor points at', () => {
+    const { heading, anchor } = renderHeading();
+
+    fireEvent.click(anchor);
+
+    expect(heading.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+  });
+
+  it('emits NAVIGATE_URL so the manager URL follows the heading', () => {
+    const { emit, anchor } = renderHeading();
+
+    fireEvent.click(anchor);
+
+    expect(emit).toHaveBeenCalledWith(NAVIGATE_URL, `#${HEADING_ID}`);
+  });
+
+  it('prevents the browser from jumping to the anchor itself', () => {
+    const { anchor } = renderHeading();
+
+    const defaultWasAllowed = fireEvent.click(anchor);
+
+    expect(defaultWasAllowed).toBe(false);
+  });
+
+  it('does nothing when no element carries the heading id', () => {
+    const { emit, heading, anchor } = renderHeading();
+    vi.spyOn(document, 'getElementById').mockReturnValue(null);
+
+    fireEvent.click(anchor);
+
+    expect(heading.scrollIntoView).not.toHaveBeenCalled();
+    expect(emit).not.toHaveBeenCalled();
+  });
+});

--- a/code/addons/docs/src/blocks/blocks/mdx.tsx
+++ b/code/addons/docs/src/blocks/blocks/mdx.tsx
@@ -221,6 +221,7 @@ const HeaderWithOcticonAnchor: FC<PropsWithChildren<HeaderWithOcticonAnchorProps
                 const element = document.getElementById(id);
                 if (element) {
                   navigate(context, hash);
+                  element.scrollIntoView({ behavior: 'smooth' });
                 }
               }}
             >


### PR DESCRIPTION
Closes #36058

## What I did

Clicking the copy button next to a docs heading stopped scrolling to that heading in 10.5.0. The handler calls `event.preventDefault()`, which I added in #34368, and on the 10.5 line nothing replaced the browser scroll it removed.

This adds the scroll to the handler itself:

```diff
 const element = document.getElementById(id);
 if (element) {
   navigate(context, hash);
+  element.scrollIntoView({ behavior: 'smooth' });
 }
```

`preventDefault()` stays, so the block does not change the preview iframe URL directly and the manager still updates the URL through the router, which is what the comment in `useNavigate` asks for. `behavior: 'smooth'` is the same option `WebView.scrollToAnchor` uses.

**This only helps the reporter if it is cherry-picked into 10.5.x.** On `next` the preview already scrolls without this change: `PreviewWithSelection` binds `NAVIGATE_URL` to `onNavigateUrl`, which calls `WebView.scrollToAnchor`, and `Channel.emit` also runs listeners on the instance that emitted. That binding arrived with d4be890e on 16 Jul, six days after v10.5.0 was released, and was never cherry-picked. On 10.5.x nothing in the preview listens for `NAVIGATE_URL` at all, so the click does nothing.

`AnchorInPage` in the same file is left alone. It never calls `preventDefault()`, so in-page MDX links keep scrolling natively on both lines.

One gap I am not closing here: `scrollIntoView({ behavior: 'smooth' })` does not check `prefers-reduced-motion`. `WebView.scrollToAnchor` has the same gap, so this keeps the two consistent rather than fixing one side only. Happy to handle both in this PR if you want it.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

New file `code/addons/docs/src/blocks/blocks/mdx.test.tsx`. With the added line removed, `scrolls to the heading the anchor points at` fails while the other three cases still pass, so the test covers the new behaviour and not just the absence of the bug.

#### Manual testing

Because `next` already scrolls, a sandbox on `next` cannot show a before/after difference. There it can only confirm nothing regressed:

1. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open any docs page and hover a heading
3. Click the link button next to it. The page scrolls to that heading and the address bar gains the hash.

To see the fix itself, the reporter's repro on 10.5.0 is needed:

1. Clone https://github.com/askoufis/storybook-issue-repro, then `pnpm install && pnpm storybook`
2. Open Button/Docs and click the copy button next to a heading. Nothing scrolls.
3. In `node_modules/@storybook/addon-docs`, find the bundled handler next to the string `Copy heading URL to address bar` and add the `scrollIntoView` call after the `navigate` call
4. Reload. The page now scrolls to the heading.

### Documentation

- [ ] Add or update documentation reflecting your changes

No documentation change. The behaviour described in the docs is the one being restored.
