### PR TITLE
CLI: Label the tools help `Output` block as the `--json` shape

### DIFF
--- a/code/core/src/cli/tools/help.test.ts
+++ b/code/core/src/cli/tools/help.test.ts
@@ -64,6 +64,7 @@ describe('tools help rendering', () => {
 
       [local] tools run without a running Storybook.
       [requires running Storybook] tools need a running Storybook dev server; start it first.
+      Tool results print as markdown; the Output blocks below describe the \`--json\` data.
       Individual \`--key value\` flags override entries of \`--input\`.
 
       Tool reference — every command in full (\`npx storybook tools <toolset> <tool> --help\` shows one alone):
@@ -84,7 +85,7 @@ describe('tools help rendering', () => {
           Arguments:
           - \`--id\` (string, required): Example identifier
 
-          Output:
+          Output (\`--json\`):
           - \`url\` (string, required): Preview URL"
     `);
   });
@@ -109,7 +110,7 @@ describe('tools help rendering', () => {
           Arguments:
           - \`--id\` (string, required): Example identifier
 
-          Output:
+          Output (\`--json\`):
           - \`url\` (string, required): Preview URL"
     `);
   });
@@ -126,7 +127,7 @@ describe('tools help rendering', () => {
       Arguments:
       - \`--id\` (string, required): Example identifier
 
-      Output:
+      Output (\`--json\`):
       - \`url\` (string, required): Preview URL"
     `);
   });

--- a/code/core/src/cli/tools/help.ts
+++ b/code/core/src/cli/tools/help.ts
@@ -59,7 +59,7 @@ function methodBodyLines(method: ToolsetCatalogMethod): string[] {
   }
   const outputLines = argumentLines(method.output, false);
   if (outputLines && outputLines.length > 0) {
-    lines.push('', 'Output:', ...outputLines);
+    lines.push('', 'Output (`--json`):', ...outputLines);
   }
   return lines;
 }
@@ -123,6 +123,7 @@ export function renderToolsHelpFromCatalog(catalog: ToolsetCatalog): string {
   const notes = [
     `${LOCAL_BADGE} tools run without a running Storybook.`,
     `${DEV_SERVER_BADGE} tools need a running Storybook dev server; start it first.`,
+    'Tool results print as markdown; the Output blocks below describe the `--json` data.',
     'Individual `--key value` flags override entries of `--input`.',
   ].join('\n');
   const referenceIntro =
@@ -161,8 +162,8 @@ export function renderMethodHelpFromCatalog(
  * The complete agent discovery surface, in commander's conventional shape — Usage, Options, and a
  * `Commands:` listing with one-line summaries — followed by a full reference for every tool
  * (description, input schema, declared output schema) so agents learn the surface from this single
- * invocation instead of paying a project load per lookup. The Options block is the flags' only
- * documentation, since commander's own help is disabled in favor of this runtime-derived one.
+ * invocation instead of paying a project load per lookup. The flags are documented here and nowhere
+ * else, since commander's own help is disabled in favor of this runtime-derived one.
  */
 export function renderToolsHelp(
   configDir: string,

--- a/code/core/src/cli/tools/run.test.ts
+++ b/code/core/src/cli/tools/run.test.ts
@@ -585,7 +585,7 @@ describe('help', () => {
     // Input schemas come from the valibot definitions.
     expect(result.output).toContain('`--componentPaths`');
     // Declared output schemas are part of the dump.
-    expect(result.output).toContain('Output:');
+    expect(result.output).toContain('Output (`--json`):');
   });
 
   it('renders one toolset’s section with a usage line on a bare toolset name', async () => {


### PR DESCRIPTION
Closes #36087

## What I did

`storybook tools stories preview --help` documents an output the command doesn't print.

What you run:

```
$ storybook tools stories preview --stories '[{"storyId":"core-button--docs"}]'
http://localhost:6007/?path=/story/core-button--docs
```

What its help promised:

```
Output:
- `stories` (array, required)
    - `title` (string, required)
    - `name` (string, required)
    - `previewUrl` (string, required)
```

Three fields documented, one bare URL delivered. It reads as a broken tool.

It isn't. Every tool produces two renderings of one run: markdown for stdout, structured `data` for `--json`. The `Output:` block is generated from the output schema, so it has always described the `--json` half — it just never said so.

### The fix

The heading now names the flag:

```diff
- Output:
+ Output (`--json`):
```

One line in `methodBodyLines`, which all three help views compose, so the root reference, the per-toolset view and the per-method view are covered at once.

It has to be the heading rather than a footnote somewhere: `--help` on a single tool prints no notes block, and that is the view you reach for right after a surprising result.

Two smaller things:

- The root help's notes block gains a line: `Tool results print as markdown; the Output blocks below describe the --json data.`
- The `renderToolsHelp` docblock claimed the Options block is the flags' only documentation. The notes block documents flag behaviour too, so that stopped being true.

### What I left alone

`formatPreviewStories` still emits a bare URL per story. Over MCP, `title` and `name` already travel in `structuredContent` next to the text blocks, so repeating them in the markdown would duplicate what the structured half exists to carry.

Why this surfaced now: the two-rendering split is a straight port from the standalone MCP repo, which shipped no CLI. Over MCP both halves always arrive in the same reply, so the mismatch was invisible. `storybook tools` is the first surface that shows one and puts the other behind a flag.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`help.test.ts` asserts all three renderings as full inline snapshots, so the new wording is readable straight from the diff. `run.test.ts` covers the run-level path to the help dump. No new test seam was needed.

#### Manual testing

Build once, then run each command from `code/`:

```
yarn nx compile core
```

1. `node core/dist/bin/dispatcher.js tools stories preview --help` — the schema block is headed ``Output (`--json`):``
2. `node core/dist/bin/dispatcher.js tools --help` — the notes block under `Commands:` carries the new markdown/`--json` line
3. `node core/dist/bin/dispatcher.js tools docs list --help` — a tool with no output schema still prints no `Output` section at all
4. Against a running Storybook, run `stories preview` for real: stdout is a bare URL, and `--json` returns the shape the help documents

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

The changed text is itself the documentation — the tools help is generated at runtime and has no separate docs page.