### PR TITLE
Core: Fix module resolution for packages with conditional-only exports maps

### DIFF
--- a/code/core/src/common/utils/interpret-files.test.ts
+++ b/code/core/src/common/utils/interpret-files.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { resolveImport } from './interpret-files.ts';
+
+// oxc-resolver is a native binding that reads the real filesystem, so memfs cannot intercept it.
+const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), 'sb-module-resolver-')));
+
+afterAll(() => {
+  rmSync(fixtureRoot, { recursive: true, force: true });
+});
+
+const writePackage = (name: string, packageJson: object, files: Record<string, string>) => {
+  const packageDir = join(fixtureRoot, 'node_modules', name);
+  mkdirSync(packageDir, { recursive: true });
+  writeFileSync(join(packageDir, 'package.json'), JSON.stringify(packageJson));
+  for (const [file, content] of Object.entries(files)) {
+    writeFileSync(join(packageDir, file), content);
+  }
+};
+
+describe('resolveImport', () => {
+  it('resolves a package whose exports map has only conditional entries', () => {
+    writePackage(
+      'conditional-exports-only',
+      {
+        name: 'conditional-exports-only',
+        main: './main.cjs',
+        exports: { '.': { import: './entry.mjs', require: './entry.cjs' } },
+      },
+      { 'entry.mjs': 'export {};', 'entry.cjs': 'module.exports = {};', 'main.cjs': '' }
+    );
+
+    expect(resolveImport('conditional-exports-only', { basedir: fixtureRoot })).toBe(
+      join(fixtureRoot, 'node_modules', 'conditional-exports-only', 'entry.mjs')
+    );
+  });
+
+  it('resolves a package without an exports map through its main fields', () => {
+    writePackage(
+      'main-only',
+      { name: 'main-only', module: './entry.mjs', main: './main.cjs' },
+      { 'entry.mjs': 'export {};', 'main.cjs': '' }
+    );
+
+    expect(resolveImport('main-only', { basedir: fixtureRoot })).toBe(
+      join(fixtureRoot, 'node_modules', 'main-only', 'entry.mjs')
+    );
+  });
+});

--- a/code/core/src/common/utils/module-resolver.ts
+++ b/code/core/src/common/utils/module-resolver.ts
@@ -19,8 +19,20 @@ export interface ModuleResolver {
   resolveSync(fromDirectory: string, specifier: string): string;
 }
 
+/**
+ * Resolve the same files the preview bundles: the browser build's resolve conditions, trimmed to
+ * what oxc-resolver understands.
+ *
+ * oxc-resolver defaults to no conditions at all, which would make exports maps without an
+ * unconditional entry unresolvable.
+ */
+export const defaultResolveConditionNames = ['storybook', 'import', 'module', 'default'];
+
 export function createModuleResolver(options: ModuleResolverOptions = {}): ModuleResolver {
-  const factory = new ResolverFactory(options);
+  const factory = new ResolverFactory({
+    ...options,
+    conditionNames: options.conditionNames ?? defaultResolveConditionNames,
+  });
 
   const unwrap = (
     result: { path?: string | null; error?: string | null },

--- a/code/core/src/shared/open-service/services/module-graph/engine/dependency-graph/resolver-factory.ts
+++ b/code/core/src/shared/open-service/services/module-graph/engine/dependency-graph/resolver-factory.ts
@@ -2,12 +2,12 @@ import { join } from 'pathe';
 
 import { ResolverFactory as OxcResolverFactory } from 'oxc-resolver';
 
+import { defaultResolveConditionNames } from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
 
 import type { ModuleResolveConfig } from '../adapters/types.ts';
 
 const DEFAULT_EXTENSIONS = ['.tsx', '.ts', '.d.ts', '.jsx', '.js', '.mjs', '.cjs', '.json'];
-const DEFAULT_CONDITIONS = ['storybook', 'import', 'module', 'default'];
 
 /**
  * `ModuleResolveConfig.alias` accepts both Vite shapes:
@@ -95,7 +95,7 @@ export class ChangeDetectionResolverFactory {
 
   constructor(config: ModuleResolveConfig) {
     const alias = this.aliasNormalizer.normalize(config.alias);
-    const conditionNames = config.conditions ?? DEFAULT_CONDITIONS;
+    const conditionNames = config.conditions ?? defaultResolveConditionNames;
 
     this.factory = new OxcResolverFactory({
       tsconfig: 'auto',


### PR DESCRIPTION
<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

### The symptom

`storybook tools docs show --id core-button` (and the MCP docs tool) dumped **every story in full** instead of showing the first 3 and listing the rest — and the `## Props` section was missing entirely.

### The root cause

When #34692 replaced the legacy `resolve` package with `oxc-resolver`, the resolver in `createModuleResolver` was constructed without `conditionNames`. That difference matters for packages with an `exports` map:

- The old `resolve` package **ignored** `exports` maps and fell back to `main`/`module` — everything resolved.
- oxc-resolver **enforces** `exports` maps, matching them against `conditionNames`. With no conditions configured, any package whose exports carry only conditional entries fails with `"." is not exported under no conditions`.

`@stylexjs/stylex` is exactly such a package (`types`/`import`/`require`, no `default`). So when react-docgen followed a type-only import like `StyleXStyles` in a design system's shared props interface, the resolver threw, docgen for the whole component silently died, and the component manifest lost its props.

The missing props then triggered a deliberate formatter fallback: components without props show *all* their stories in full. Two correct behaviors chained into one confusing bug — and it was invisible, because top-level docgen errors are never rendered in the docs output.

### The fix

`createModuleResolver` now defaults to:

```ts
export const defaultResolveConditionNames = ['storybook', 'import', 'module', 'default'];
```

This is the browser build's resolve conditions (builder-vite) trimmed to what oxc-resolver understands, so static analysis resolves the same files the preview actually bundles. The module-graph resolver already used this exact list — it now imports the shared constant instead of keeping its own copy.

- All four call sites that omitted conditions are covered by the shared default: `interpret-files.ts` (docgen / `resolveImport`), `resolve-meta-component.ts`, `story-shape/reference-context.ts`, and angular-vite's `resolve-component.ts`.
- Callers that pass explicit `conditionNames` (like the mocking-utils browser resolver) keep their own behavior.

### How I verified it

- New regression tests exercise the real `resolveImport`: a fixture package with a conditional-only exports map must resolve, and the `main`/`module` fallback for packages without an exports map keeps working. (The tests use a real temp-dir fixture — oxc-resolver is a native binding that memfs cannot intercept.)
- Verified end-to-end against the reported repro (`storybook-tmp/astryx`): react-docgen extracts all 23 props of the affected Button component again, restoring the `## Props` section and the 3-story truncation.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Clone the repro: `storybook-tmp/astryx`, branch `shilman/codex-10-6-beta-0`, and `pnpm install`.
2. In `apps/storybook`, run `pnpm exec storybook tools docs show --id core-button`.
3. **Before this fix:** no `## Props` section, and every story rendered in full.
4. **After:** a `## Props` section is present, only the first 3 stories are shown in detail, and the rest appear under "Other Stories". The MCP docs tool shows the same output (same shared formatter).

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
