### PR TITLE
Tools: Treat instance cwd as a directory or a Storybook bin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,8 @@ AST indexing keeps the sidebar fast and prevents one broken story file from brea
   failure. `--attach` requires attachment; `--no-attach` forces local. When several running
   instances match the project, attach picks the invoking agent's most recently started one and
   warns on stderr; `-p, --port` targets a specific instance. Local `createTools` never
-  `chdir`s: a foreign `cwd` starts a project-local child host.
+  `chdir`s: a foreign `cwd` (project directory or `storybook` binary) starts a project-local child
+  host.
 - Read `code/core/src/shared/open-service/README.md` before changing the contract, adapters,
   registration, docs access, or transport rendering. Read `code/core/src/cli/tools/README.md` and
   `code/core/src/cli/tools/architecture.md` before changing attachment, the SDK, or the tools CLI.

--- a/code/core/src/cli/tools/README.md
+++ b/code/core/src/cli/tools/README.md
@@ -15,7 +15,7 @@ instance.
 import { createTools } from 'storybook/internal/tools';
 
 const tools = await createTools({
-  cwd, // which project; defaults to process.cwd()
+  cwd, // project directory or storybook binary; defaults to process.cwd()
   configDir, // --config-dir equivalent; disambiguates monorepos
   port, // --port equivalent; a known port targets that running instance on its own
   mode: 'auto', // 'auto' | 'attached' | 'local'
@@ -69,6 +69,7 @@ npx storybook tools docs list
 npx storybook tools --attach docs list
 npx storybook tools --no-attach docs list
 npx storybook tools --cwd /apps/web --config-dir /apps/web/.storybook docs list
+npx storybook tools --cwd /apps/web/node_modules/.bin/storybook docs list
 npx storybook tools --port 6007 stories preview --stories '[{"storyId":"example-button--primary"}]'
 ```
 
@@ -80,14 +81,16 @@ npx storybook tools --port 6007 stories preview --stories '[{"storyId":"example-
 `chdir`s the host process.
 
 **Child host.** When `process.cwd()` or the resolved `storybook` version does not match the
-record, `createTools` spawns a child from the `storybook` package under `record.cwd` and proxies
-`describe` / `call` / `close` over IPC. `autoSpawn: false` throws `EnvironmentMismatchError`
-instead. A child never spawns another child (`STORYBOOK_TOOLS_CHILD_HOST`).
+record, `createTools` spawns a child from the `storybook` package under `record.cwd` (or from that
+path when it is a `storybook` binary) and proxies `describe` / `call` / `close` over IPC.
+`autoSpawn: false` throws `EnvironmentMismatchError` instead. A child never spawns another child
+(`STORYBOOK_TOOLS_CHILD_HOST`).
 
 **Local.** Load the target configuration in this process when `cwd` already matches. This path
 never `chdir`s. A foreign `--cwd` starts a child host from the `storybook` package under that
-directory. Do not set `STORYBOOK_ATTACHED_TOOLS` on this path: that env is how the dispatcher
-makes UniversalStore a follower before core loads, and local bootstrap must be a leader.
+directory, or from that path when it is a `storybook` binary. Do not set
+`STORYBOOK_ATTACHED_TOOLS` on this path: that env is how the dispatcher makes UniversalStore a
+follower before core loads, and local bootstrap must be a leader.
 
 ## Tests
 

--- a/code/core/src/cli/tools/architecture.md
+++ b/code/core/src/cli/tools/architecture.md
@@ -55,27 +55,31 @@ fallback deletes that env before loading the local runtime, which must be a lead
 
 ## Environment match
 
-Attached mode needs the same version, config, and cwd as the instance. When this process cannot be
-that environment, `createTools` spawns a child from the `storybook` package under `record.cwd` and
-proxies `describe` / `call` / `close` over Node parent-child IPC. The parent `Tools` object is the
-proxy.
+Attached mode needs the same version, config, and Storybook install as the instance. When this
+process cannot be that environment, `createTools` spawns a child from the `storybook` package
+under `record.cwd` (or from that path when it is a `storybook` binary) and proxies `describe` /
+`call` / `close` over Node parent-child IPC. The parent `Tools` object is the proxy.
 
 The child is used whenever `process.cwd() !== record.cwd`, even when versions match, so module
-resolution, `.env`, and relative paths match the instance. A version mismatch with the invoked
-package (for example `npx storybook@latest` from the right directory) also triggers the child via
-project-local resolution. When the package resolved under the instance cwd also mismatches the
-record (server started before a dependency upgrade), the error is "restart your Storybook".
+resolution, `.env`, and relative paths match the instance. If `record.cwd` is a file, fidelity
+treats this process as matching when it resolves the same `storybook` package as that binary. A
+version mismatch with the invoked package (for example `npx storybook@latest` from the right
+directory) also triggers the child via project-local resolution. When the package resolved from
+the instance cwd or binary also mismatches the record (server started before a dependency
+upgrade), the error is "restart your Storybook".
 
 Neither attached nor local mode `chdir`s this process. A foreign `cwd` in local mode starts a
 child host instead.
 
 `autoSpawn: false` throws `EnvironmentMismatchError { instanceCwd, resolvedBinPath, reason }`.
 
-The child is the instance-cwd-resolved `storybook` package's host entry, `cwd = record.cwd`,
-resolved with `createRequire(join(record.cwd, 'package.json'))`. A child does not spawn another
-child; residual mismatch is a prescriptive error. Resolution failure is `SpawnFailedError`. The
-fidelity check runs before config load. `close()` kills the child. The child exits when the parent
-IPC channel closes. Child logs are piped and re-emitted by the parent.
+The child is the instance-resolved `storybook` package's host entry. When `record.cwd` is a
+directory it is resolved with `createRequire(join(record.cwd, 'package.json'))` and the child
+runs with `cwd = record.cwd`. When `record.cwd` is a `storybook` binary it is resolved from that
+file and the child runs with `cwd = dirname(configDir)` (or this process's cwd). A child does not
+spawn another child; residual mismatch is a prescriptive error. Resolution failure is
+`SpawnFailedError`. The fidelity check runs before config load. `close()` kills the child. The
+child exits when the parent IPC channel closes. Child logs are piped and re-emitted by the parent.
 
 IPC is the serialized SDK API plus a version field in the child's hello. Cancellation is a
 message keyed by call id.
@@ -136,7 +140,7 @@ Messages name the exact corrective command.
 | Old server                        | Token absent                          | Restart Storybook (vX.Y+) to enable attach                                                       |
 | Stale record / connection refused | WS connect fails                      | Registry cleanup; fallback note                                                                  |
 | Server started before upgrade     | Instance-cwd package ≠ record version | Both version strings; restart Storybook                                                          |
-| Spawn resolution failure          | No `storybook` under `record.cwd`     | `SpawnFailedError` remediation; local fallback                                                   |
+| Spawn resolution failure          | No `storybook` under `record.cwd` or its binary | `SpawnFailedError` remediation; local fallback                                                   |
 | Config drift                      | Remote command ack timeout            | Running Storybook was started with a different configuration — restart it                        |
 
 Rows other than config drift are factory-time attach gates. In `auto`, those return a local host

--- a/code/core/src/cli/tools/config-dir.test.ts
+++ b/code/core/src/cli/tools/config-dir.test.ts
@@ -1,8 +1,11 @@
 import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
 import { resolveStorybookConfigDir } from './config-dir.ts';
+
+const storybookFile = fileURLToPath(import.meta.url);
 
 describe('resolveStorybookConfigDir', () => {
   it('defaults to .storybook under the target cwd', () => {
@@ -18,6 +21,15 @@ describe('resolveStorybookConfigDir', () => {
   it('keeps absolute config dirs unchanged', () => {
     expect(resolveStorybookConfigDir({ cwd: '/repo', configDir: '/custom/.storybook' })).toBe(
       '/custom/.storybook'
+    );
+  });
+
+  it('defaults relative config dirs from process.cwd() when cwd is a storybook binary', () => {
+    expect(resolveStorybookConfigDir({ cwd: storybookFile })).toBe(
+      resolve(process.cwd(), '.storybook')
+    );
+    expect(resolveStorybookConfigDir({ cwd: storybookFile, configDir: 'config/storybook' })).toBe(
+      resolve(process.cwd(), 'config/storybook')
     );
   });
 });

--- a/code/core/src/cli/tools/config-dir.ts
+++ b/code/core/src/cli/tools/config-dir.ts
@@ -1,15 +1,19 @@
 import { isAbsolute, resolve } from 'node:path';
 
+import { inspectCwdOrBin } from '../../common/utils/cwd-or-bin.ts';
+
 /**
  * Resolve the config directory of the Storybook a CLI invocation targets: `--config-dir` when
  * given (relative paths resolve from the target project directory), `.storybook` under it
- * otherwise.
+ * otherwise. A `--cwd` that points at a Storybook bin uses `process.cwd()` as the project
+ * directory for those defaults.
  */
 export function resolveStorybookConfigDir({
   cwd,
   configDir,
 }: { cwd?: string; configDir?: string } = {}) {
-  const projectCwd = resolve(cwd ?? process.cwd());
+  const rawCwd = resolve(cwd ?? process.cwd());
+  const projectCwd = inspectCwdOrBin(rawCwd).kind === 'file' ? process.cwd() : rawCwd;
   if (configDir) {
     return isAbsolute(configDir) ? configDir : resolve(projectCwd, configDir);
   }

--- a/code/core/src/cli/tools/discover-instance.ts
+++ b/code/core/src/cli/tools/discover-instance.ts
@@ -7,7 +7,7 @@ import { selectInstances } from './instances/resolve.ts';
 import type { StorybookInstanceRecord } from './instances/types.ts';
 
 export type ToolsTarget = {
-  /** Project directory of the target Storybook; defaults to `process.cwd()`. */
+  /** Project directory of the target Storybook, or a path to its `storybook` binary; defaults to `process.cwd()`. */
   cwd?: string;
   /** Directory where to load Storybook configuration from; relative paths resolve from `cwd`. */
   configDir?: string;

--- a/code/core/src/cli/tools/help.test.ts
+++ b/code/core/src/cli/tools/help.test.ts
@@ -48,7 +48,7 @@ describe('tools help rendering', () => {
       Storybook tools from the Storybook configuration at /repo/.storybook.
 
       Options:
-        --cwd <path>                 Project directory of the target Storybook
+        --cwd <path>                 Project directory of the target Storybook, or a path to its storybook binary
         -c, --config-dir <dir-name>  Storybook config directory of the target Storybook
         -p, --port <number>          Port of a running Storybook; targets that instance directly, no --cwd or --config-dir needed
         --attach                     Require attaching to a running Storybook; gate failures are errors instead of a local fallback

--- a/code/core/src/cli/tools/instances/types.ts
+++ b/code/core/src/cli/tools/instances/types.ts
@@ -22,6 +22,7 @@ export const StorybookInstanceRecordSchema = v.object({
   schemaVersion: v.literal(1),
   instanceId: v.string(),
   pid: v.pipe(v.number(), v.minValue(1), v.integer()),
+  /** Project directory of the running Storybook, or the `storybook` binary that started it. */
   cwd: v.string(),
   /**
    * Resolved config directory of the running Storybook, used as a second matching key so

--- a/code/core/src/cli/tools/sdk/attach-messages.test.ts
+++ b/code/core/src/cli/tools/sdk/attach-messages.test.ts
@@ -2,8 +2,6 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-const storybookFile = fileURLToPath(import.meta.url);
-
 import type { StorybookInstanceRecord } from '../instances/types.ts';
 import {
   formatAttachFallback,
@@ -15,7 +13,10 @@ import {
   formatPortMismatch,
   formatRestartRequired,
   formatVersionMismatch,
+  quoteShellArg,
 } from './attach-messages.ts';
+
+const storybookFile = fileURLToPath(import.meta.url);
 
 const other: StorybookInstanceRecord = {
   schemaVersion: 1,
@@ -122,10 +123,11 @@ describe('attach failure messages', () => {
   });
 
   it('points at --cwd when the instance recorded a storybook binary', () => {
-    expect(formatCwdMismatch('/tmp/agent', storybookFile)).toContain(`--cwd ${storybookFile}`);
+    const cwdFlag = `--cwd ${quoteShellArg(storybookFile)}`;
+    expect(formatCwdMismatch('/tmp/agent', storybookFile)).toContain(cwdFlag);
     expect(formatCwdMismatch('/tmp/agent', storybookFile)).not.toContain(`cd ${storybookFile}`);
     expect(formatNoInstance([{ ...other, cwd: storybookFile }])).toContain(
-      `npx storybook tools --attach --cwd ${storybookFile}`
+      `npx storybook tools --attach ${cwdFlag}`
     );
     expect(formatNoInstance([{ ...other, cwd: storybookFile }])).not.toContain(
       `cd ${storybookFile} &&`

--- a/code/core/src/cli/tools/sdk/attach-messages.test.ts
+++ b/code/core/src/cli/tools/sdk/attach-messages.test.ts
@@ -1,4 +1,8 @@
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
+
+const storybookFile = fileURLToPath(import.meta.url);
 
 import type { StorybookInstanceRecord } from '../instances/types.ts';
 import {
@@ -114,6 +118,17 @@ describe('attach failure messages', () => {
   it('tells the caller to move into the instance directory', () => {
     expect(formatCwdMismatch('/tmp/agent', '/apps/web')).toMatchInlineSnapshot(
       `"This process is running from /tmp/agent, but the Storybook instance is running from /apps/web. \`cd /apps/web\` and retry, or pass \`--cwd /apps/web\`."`
+    );
+  });
+
+  it('points at --cwd when the instance recorded a storybook binary', () => {
+    expect(formatCwdMismatch('/tmp/agent', storybookFile)).toContain(`--cwd ${storybookFile}`);
+    expect(formatCwdMismatch('/tmp/agent', storybookFile)).not.toContain(`cd ${storybookFile}`);
+    expect(formatNoInstance([{ ...other, cwd: storybookFile }])).toContain(
+      `npx storybook tools --attach --cwd ${storybookFile}`
+    );
+    expect(formatNoInstance([{ ...other, cwd: storybookFile }])).not.toContain(
+      `cd ${storybookFile} &&`
     );
   });
 

--- a/code/core/src/cli/tools/sdk/attach-messages.ts
+++ b/code/core/src/cli/tools/sdk/attach-messages.ts
@@ -2,7 +2,7 @@ import { inspectCwdOrBin } from '../../../common/utils/cwd-or-bin.ts';
 import type { StorybookInstanceRecord } from '../instances/types.ts';
 import type { ToolsStorybookInfo } from './types.ts';
 
-function quoteShellArg(value: string): string {
+export function quoteShellArg(value: string): string {
   if (!/[\s'"$`\\]/.test(value)) {
     return value;
   }

--- a/code/core/src/cli/tools/sdk/attach-messages.ts
+++ b/code/core/src/cli/tools/sdk/attach-messages.ts
@@ -1,3 +1,4 @@
+import { inspectCwdOrBin } from '../../../common/utils/cwd-or-bin.ts';
 import type { StorybookInstanceRecord } from '../instances/types.ts';
 import type { ToolsStorybookInfo } from './types.ts';
 
@@ -26,7 +27,11 @@ export function formatNoInstance(records: StorybookInstanceRecord[]): string {
     for (const record of records) {
       const configDir = record.configDir ? `; configDir \`${record.configDir}\`` : '';
       lines.push(`- ${record.url} (cwd \`${record.cwd}\`${configDir})`);
-      lines.push(`  cd ${quoteShellArg(record.cwd)} && ${attachCommand(record)}`);
+      lines.push(
+        inspectCwdOrBin(record.cwd).kind === 'file'
+          ? `  ${attachCommand(record)}`
+          : `  cd ${quoteShellArg(record.cwd)} && ${attachCommand(record)}`
+      );
     }
   }
   return lines.join('\n');
@@ -51,6 +56,9 @@ export function formatConnectionFailed(record: StorybookInstanceRecord): string 
 }
 
 export function formatCwdMismatch(processCwd: string, instanceCwd: string): string {
+  if (inspectCwdOrBin(instanceCwd).kind === 'file') {
+    return `This process is running from ${processCwd}, but the Storybook instance was started with the \`storybook\` binary at ${instanceCwd}. Pass \`--cwd ${quoteShellArg(instanceCwd)}\` and retry.`;
+  }
   return `This process is running from ${processCwd}, but the Storybook instance is running from ${instanceCwd}. \`cd ${quoteShellArg(instanceCwd)}\` and retry, or pass \`--cwd ${quoteShellArg(instanceCwd)}\`.`;
 }
 

--- a/code/core/src/cli/tools/sdk/attached-runtime.test.ts
+++ b/code/core/src/cli/tools/sdk/attached-runtime.test.ts
@@ -330,6 +330,22 @@ describe('bootstrapAttachedRuntime', () => {
     expect(deps.createNodeChannel).not.toHaveBeenCalled();
   });
 
+  it('returns spawn when record.cwd is a storybook binary that resolves the instance version', async () => {
+    const binRecord = {
+      ...RECORD,
+      cwd: '/repo/node_modules/.bin/storybook',
+    };
+    const { deps } = makeRuntimeDeps([binRecord], {
+      cwd: () => '/elsewhere',
+      resolveProjectVersion: (path: string) => (path === binRecord.cwd ? '10.2.0' : undefined),
+    });
+
+    const result = await bootstrapAttachedRuntime({ cwd: '/repo', autoSpawn: true }, deps);
+
+    expect(result).toEqual({ kind: 'spawn', record: binRecord, siblings: [] });
+    expect(deps.createNodeChannel).not.toHaveBeenCalled();
+  });
+
   it('throws SpawnFailedError when autoSpawn is on but storybook cannot be resolved under the instance', async () => {
     const { deps } = makeRuntimeDeps([RECORD], {
       cwd: () => '/elsewhere',

--- a/code/core/src/cli/tools/sdk/child-client.test.ts
+++ b/code/core/src/cli/tools/sdk/child-client.test.ts
@@ -127,6 +127,39 @@ describe('spawnChildHost', () => {
       }
     );
 
+  it('resolves a nested relative configDir before forking a binary child host', async () => {
+    const bin = fileURLToPath(import.meta.url);
+    await spawnChildHost(
+      {
+        cwd: bin,
+        options: { ...OPTIONS, configDir: 'config/storybook' },
+        clientInfo: CLIENT,
+        requestedMode: 'attached',
+      },
+      {
+        fork: fork as never,
+        resolveScript: () => '/repo/node_modules/storybook/dist/cli/tools/sdk/child-host.js',
+        logger: { log, warn },
+      }
+    );
+
+    expect(fork).toHaveBeenCalledWith(
+      '/repo/node_modules/storybook/dist/cli/tools/sdk/child-host.js',
+      [],
+      expect.objectContaining({
+        cwd: resolve(process.cwd(), 'config'),
+      })
+    );
+    expect(child.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'init',
+        options: expect.objectContaining({
+          configDir: resolve(process.cwd(), 'config/storybook'),
+        }),
+      })
+    );
+  });
+
   it('forks from a storybook binary using dirname(configDir) as the child cwd', async () => {
     const bin = fileURLToPath(import.meta.url);
     await spawnChildHost(

--- a/code/core/src/cli/tools/sdk/child-client.test.ts
+++ b/code/core/src/cli/tools/sdk/child-client.test.ts
@@ -1,4 +1,6 @@
 import { EventEmitter } from 'node:events';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { telemetry } from 'storybook/internal/telemetry';
@@ -124,6 +126,31 @@ describe('spawnChildHost', () => {
         logger: { log, warn },
       }
     );
+
+  it('forks from a storybook binary using dirname(configDir) as the child cwd', async () => {
+    const bin = fileURLToPath(import.meta.url);
+    await spawnChildHost(
+      {
+        cwd: bin,
+        options: { ...OPTIONS, configDir: '/repo/.storybook' },
+        clientInfo: CLIENT,
+        requestedMode: 'attached',
+      },
+      {
+        fork: fork as never,
+        resolveScript: () => '/repo/node_modules/storybook/dist/cli/tools/sdk/child-host.js',
+        logger: { log, warn },
+      }
+    );
+
+    expect(fork).toHaveBeenCalledWith(
+      '/repo/node_modules/storybook/dist/cli/tools/sdk/child-host.js',
+      [],
+      expect.objectContaining({
+        cwd: resolve('/repo'),
+      })
+    );
+  });
 
   it('forks the project-local child host with cwd, piped stdio, ipc, and loop-guard env', async () => {
     await spawn();

--- a/code/core/src/cli/tools/sdk/child-client.ts
+++ b/code/core/src/cli/tools/sdk/child-client.ts
@@ -28,6 +28,7 @@ import {
   ToolsRuntimeError,
 } from './errors.ts';
 import { workingDirectoryForCwdOrBin } from '../../../common/utils/cwd-or-bin.ts';
+import { resolveStorybookConfigDir } from '../config-dir.ts';
 import { resolveChildHostScript } from './resolve-project-storybook.ts';
 import type {
   AttachedTools,
@@ -87,8 +88,10 @@ export async function spawnChildHost(
   const log = deps.logger ?? logger;
   const forkChild = deps.fork ?? fork;
   const cwd = args.cwd;
-  const forkCwd = workingDirectoryForCwdOrBin(cwd, args.options.configDir);
-  const resolvedMode: 'local' | 'attached' = args.options.mode === 'local' ? 'local' : 'attached';
+  const configDir = resolveStorybookConfigDir({ cwd, configDir: args.options.configDir });
+  const options = { ...args.options, configDir };
+  const forkCwd = workingDirectoryForCwdOrBin(cwd, configDir);
+  const resolvedMode: 'local' | 'attached' = options.mode === 'local' ? 'local' : 'attached';
 
   let scriptPath: string;
   try {
@@ -229,7 +232,7 @@ export async function spawnChildHost(
   try {
     hello = await waitForHello(child, send, {
       cwd: cwd,
-      options: args.options,
+      options,
       clientInfo: args.clientInfo,
       resolvedMode,
     });

--- a/code/core/src/cli/tools/sdk/child-client.ts
+++ b/code/core/src/cli/tools/sdk/child-client.ts
@@ -27,6 +27,7 @@ import {
   SpawnFailedError,
   ToolsRuntimeError,
 } from './errors.ts';
+import { workingDirectoryForCwdOrBin } from '../../../common/utils/cwd-or-bin.ts';
 import { resolveChildHostScript } from './resolve-project-storybook.ts';
 import type {
   AttachedTools,
@@ -86,6 +87,7 @@ export async function spawnChildHost(
   const log = deps.logger ?? logger;
   const forkChild = deps.fork ?? fork;
   const cwd = args.cwd;
+  const forkCwd = workingDirectoryForCwdOrBin(cwd, args.options.configDir);
   const resolvedMode: 'local' | 'attached' = args.options.mode === 'local' ? 'local' : 'attached';
 
   let scriptPath: string;
@@ -111,7 +113,7 @@ export async function spawnChildHost(
   let child: ChildProcess;
   try {
     child = forkChild(scriptPath, [], {
-      cwd,
+      cwd: forkCwd,
       stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
       env,
     } satisfies ForkOptions);

--- a/code/core/src/cli/tools/sdk/create-tools.ts
+++ b/code/core/src/cli/tools/sdk/create-tools.ts
@@ -74,11 +74,13 @@ export type CreateToolsDeps = {
  *
  * `local` loads that configuration without a running Storybook. When this process is already in
  * the target directory, it loads in-process. Otherwise it spawns a child host from the `storybook`
- * package resolved under that directory. It never changes `process.cwd()`.
+ * package resolved under that directory or from a `storybook` binary passed as `cwd`. It never
+ * changes `process.cwd()`.
  *
  * `attached` joins a running Storybook over its channel and never changes `process.cwd()`. When
  * this process is not that instance's twin, attached mode defaults to spawning a child host from
- * the `storybook` package resolved under the instance directory.
+ * the `storybook` package resolved under the instance directory or from the instance `storybook`
+ * binary.
  *
  * `auto` tries `attached` first and, on a gate failure, loads `local` instead. The returned host
  * then carries `fallbackNotice` with the gate message and that it fell back.
@@ -185,6 +187,7 @@ async function createAttachedTools(
         autoSpawn: false,
         cwd: attached.record.cwd,
         port: attached.record.port,
+        configDir: attached.record.configDir ?? options.configDir,
       },
       clientInfo,
       requestedMode,

--- a/code/core/src/cli/tools/sdk/fidelity.test.ts
+++ b/code/core/src/cli/tools/sdk/fidelity.test.ts
@@ -1,7 +1,11 @@
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 
 import type { StorybookInstanceRecord } from '../instances/types.ts';
 import { checkFidelity } from './fidelity.ts';
+
+const storybookFile = fileURLToPath(import.meta.url);
 
 const record: StorybookInstanceRecord = {
   schemaVersion: 1,
@@ -27,6 +31,26 @@ describe('checkFidelity', () => {
       kind: 'cwd',
       processCwd: expect.stringMatching(/elsewhere$/),
       instanceCwd: expect.stringMatching(/repo$/),
+    });
+  });
+
+  it('accepts a storybook binary cwd when this process resolves the same package', () => {
+    expect(
+      checkFidelity({ ...record, cwd: storybookFile }, { cwd: process.cwd(), version: '10.2.0' })
+    ).toEqual({ ok: true });
+  });
+
+  it('rejects a storybook binary cwd that cannot resolve the same package', () => {
+    expect(
+      checkFidelity(
+        { ...record, cwd: '/no-such-storybook-bin' },
+        { cwd: process.cwd(), version: '10.2.0' }
+      )
+    ).toEqual({
+      ok: false,
+      kind: 'cwd',
+      processCwd: expect.any(String),
+      instanceCwd: expect.stringMatching(/no-such-storybook-bin$/),
     });
   });
 

--- a/code/core/src/cli/tools/sdk/fidelity.ts
+++ b/code/core/src/cli/tools/sdk/fidelity.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path';
 
+import { inspectCwdOrBin, resolveStorybookPackageJson } from '../../../common/utils/cwd-or-bin.ts';
 import type { StorybookInstanceRecord } from '../instances/types.ts';
 
 export type FidelityMatch = { ok: true };
@@ -15,13 +16,25 @@ export type FidelityMismatch =
 
 export type FidelityResult = FidelityMatch | FidelityMismatch;
 
+function cwdMatchesInstance(processCwd: string, instanceCwd: string): boolean {
+  if (processCwd === instanceCwd) {
+    return true;
+  }
+  if (inspectCwdOrBin(instanceCwd).kind !== 'file') {
+    return false;
+  }
+  const processPackage = resolveStorybookPackageJson(processCwd);
+  const instancePackage = resolveStorybookPackageJson(instanceCwd);
+  return processPackage !== undefined && processPackage === instancePackage;
+}
+
 export function checkFidelity(
   record: Pick<StorybookInstanceRecord, 'cwd' | 'storybookVersion'>,
   { cwd, version }: { cwd: string; version: string }
 ): FidelityResult {
   const processCwd = resolve(cwd);
   const instanceCwd = resolve(record.cwd);
-  if (processCwd !== instanceCwd) {
+  if (!cwdMatchesInstance(processCwd, instanceCwd)) {
     return { ok: false, kind: 'cwd', processCwd, instanceCwd };
   }
 

--- a/code/core/src/cli/tools/sdk/resolve-project-storybook.test.ts
+++ b/code/core/src/cli/tools/sdk/resolve-project-storybook.test.ts
@@ -1,0 +1,36 @@
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  resolveChildHostScript,
+  resolveProjectStorybookVersion,
+} from './resolve-project-storybook.ts';
+
+const thisFile = fileURLToPath(import.meta.url);
+
+describe('resolveProjectStorybookVersion', () => {
+  it('resolves the storybook version from a project directory', () => {
+    expect(resolveProjectStorybookVersion(process.cwd())).toEqual(expect.any(String));
+  });
+
+  it('resolves the storybook version from a file inside the storybook package', () => {
+    expect(resolveProjectStorybookVersion(thisFile)).toBe(
+      resolveProjectStorybookVersion(process.cwd())
+    );
+  });
+
+  it('returns undefined when neither a directory nor a file can resolve storybook', () => {
+    expect(resolveProjectStorybookVersion('/no-such-storybook-project-or-bin')).toBeUndefined();
+  });
+});
+
+describe('resolveChildHostScript', () => {
+  it('resolves the child-host entry from a project directory', () => {
+    expect(resolveChildHostScript(process.cwd())).toEqual(expect.stringContaining('child-host'));
+  });
+
+  it('resolves the child-host entry from a file inside the storybook package', () => {
+    expect(resolveChildHostScript(thisFile)).toBe(resolveChildHostScript(process.cwd()));
+  });
+});

--- a/code/core/src/cli/tools/sdk/resolve-project-storybook.ts
+++ b/code/core/src/cli/tools/sdk/resolve-project-storybook.ts
@@ -1,14 +1,16 @@
 import { readFileSync } from 'node:fs';
-import { createRequire } from 'node:module';
-import { join } from 'node:path';
+
+import { createRequireFromCwdOrBin, requireSearchPath } from '../../../common/utils/cwd-or-bin.ts';
 
 const STORYBOOK_MANIFEST = 'storybook/package.json';
 const CHILD_HOST_ENTRY = 'storybook/internal/tools/child-host';
 
-export function resolveProjectStorybookVersion(projectDir: string): string | undefined {
+export function resolveProjectStorybookVersion(cwdOrBin: string): string | undefined {
   try {
-    const projectRequire = createRequire(join(projectDir, 'package.json'));
-    const manifestPath = projectRequire.resolve(STORYBOOK_MANIFEST, { paths: [projectDir] });
+    const projectRequire = createRequireFromCwdOrBin(cwdOrBin);
+    const manifestPath = projectRequire.resolve(STORYBOOK_MANIFEST, {
+      paths: [requireSearchPath(cwdOrBin)],
+    });
     const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { version?: unknown };
     return typeof manifest.version === 'string' ? manifest.version : undefined;
   } catch {
@@ -16,7 +18,7 @@ export function resolveProjectStorybookVersion(projectDir: string): string | und
   }
 }
 
-export function resolveChildHostScript(projectDir: string): string {
-  const projectRequire = createRequire(join(projectDir, 'package.json'));
-  return projectRequire.resolve(CHILD_HOST_ENTRY, { paths: [projectDir] });
+export function resolveChildHostScript(cwdOrBin: string): string {
+  const projectRequire = createRequireFromCwdOrBin(cwdOrBin);
+  return projectRequire.resolve(CHILD_HOST_ENTRY, { paths: [requireSearchPath(cwdOrBin)] });
 }

--- a/code/core/src/cli/tools/sdk/types.ts
+++ b/code/core/src/cli/tools/sdk/types.ts
@@ -27,7 +27,7 @@ export type ToolsClientInfo = {
 };
 
 export type CreateToolsOptions = {
-  /** Project directory of the target Storybook; defaults to `process.cwd()`. */
+  /** Project directory of the target Storybook, or a path to its `storybook` binary; defaults to `process.cwd()`. */
   cwd?: string;
   /** Directory to load the Storybook configuration from; relative paths resolve from `cwd`. */
   configDir?: string;
@@ -59,7 +59,7 @@ export type ToolsStorybookInfo = {
   pid?: number;
   /** Port of the running Storybook, as recorded by `storybook dev`. */
   port?: number;
-  /** Directory the running Storybook was started from. */
+  /** Directory the running Storybook was started from, or the `storybook` binary that started it. */
   cwd?: string;
   /**
    * Set when attach chose among several matching instances: the competing instances, best first,

--- a/code/core/src/cli/tools/tool-tokens.ts
+++ b/code/core/src/cli/tools/tool-tokens.ts
@@ -204,7 +204,10 @@ export function parsePort(
  * these flags itself and would otherwise drift from the registration.
  */
 export const TOOLS_OPTION_SPECS: ReadonlyArray<{ flags: string; description: string }> = [
-  { flags: '--cwd <path>', description: 'Project directory of the target Storybook' },
+  {
+    flags: '--cwd <path>',
+    description: 'Project directory of the target Storybook, or a path to its storybook binary',
+  },
   {
     flags: '-c, --config-dir <dir-name>',
     description: 'Storybook config directory of the target Storybook',

--- a/code/core/src/common/utils/cwd-or-bin.test.ts
+++ b/code/core/src/common/utils/cwd-or-bin.test.ts
@@ -1,0 +1,76 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  inspectCwdOrBin,
+  resolveRecordedCwd,
+  resolveStorybookPackageJson,
+  workingDirectoryForCwdOrBin,
+} from './cwd-or-bin.ts';
+
+const thisFile = fileURLToPath(import.meta.url);
+const thisDir = dirname(thisFile);
+
+describe('inspectCwdOrBin', () => {
+  it('classifies an existing directory as a directory', () => {
+    expect(inspectCwdOrBin(thisDir)).toEqual({ kind: 'directory', path: resolve(thisDir) });
+  });
+
+  it('classifies an existing file as a file', () => {
+    expect(inspectCwdOrBin(thisFile)).toEqual({ kind: 'file', path: resolve(thisFile) });
+  });
+
+  it('classifies a missing path as a directory', () => {
+    expect(inspectCwdOrBin('/no-such-storybook-cwd-or-bin')).toEqual({
+      kind: 'directory',
+      path: resolve('/no-such-storybook-cwd-or-bin'),
+    });
+  });
+});
+
+describe('workingDirectoryForCwdOrBin', () => {
+  it('returns the path when it is a directory', () => {
+    expect(workingDirectoryForCwdOrBin(thisDir)).toBe(resolve(thisDir));
+  });
+
+  it('uses dirname(configDir) when the path is a file', () => {
+    expect(workingDirectoryForCwdOrBin(thisFile, '/repo/.storybook')).toBe(resolve('/repo'));
+  });
+
+  it('falls back to process.cwd() when the path is a file and no configDir is given', () => {
+    expect(workingDirectoryForCwdOrBin(thisFile)).toBe(process.cwd());
+  });
+});
+
+describe('resolveRecordedCwd', () => {
+  it('keeps a process cwd that can resolve the storybook package', () => {
+    expect(
+      resolveRecordedCwd({
+        processCwd: process.cwd(),
+        invokedPath: thisFile,
+      })
+    ).toBe(resolve(process.cwd()));
+  });
+
+  it('records the invoked storybook file when the process cwd cannot resolve storybook', () => {
+    expect(
+      resolveRecordedCwd({
+        processCwd: '/no-such-storybook-project-cwd-or-bin',
+        invokedPath: thisFile,
+      })
+    ).toBe(resolve(thisFile));
+    expect(resolveStorybookPackageJson(thisFile)).toEqual(expect.stringContaining('package.json'));
+  });
+
+  it('falls back to the process cwd when neither the cwd nor the invoked path resolve storybook', () => {
+    expect(
+      resolveRecordedCwd({
+        processCwd: '/no-such-storybook-project-cwd-or-bin',
+        invokedPath: '/no-such-storybook-bin',
+        fallbackFile: '/no-such-storybook-fallback',
+      })
+    ).toBe(resolve('/no-such-storybook-project-cwd-or-bin'));
+  });
+});

--- a/code/core/src/common/utils/cwd-or-bin.ts
+++ b/code/core/src/common/utils/cwd-or-bin.ts
@@ -1,0 +1,77 @@
+import { statSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const STORYBOOK_MANIFEST = 'storybook/package.json';
+
+export type CwdOrBin = { kind: 'directory'; path: string } | { kind: 'file'; path: string };
+
+export function inspectCwdOrBin(path: string): CwdOrBin {
+  const resolved = resolve(path);
+  try {
+    if (statSync(resolved).isFile()) {
+      return { kind: 'file', path: resolved };
+    }
+  } catch {
+    // A path that does not exist is treated as a project directory so config dirs still resolve.
+  }
+  return { kind: 'directory', path: resolved };
+}
+
+export function createRequireFromCwdOrBin(path: string): NodeJS.Require {
+  const inspected = inspectCwdOrBin(path);
+  return inspected.kind === 'file'
+    ? createRequire(inspected.path)
+    : createRequire(join(inspected.path, 'package.json'));
+}
+
+export function requireSearchPath(path: string): string {
+  const inspected = inspectCwdOrBin(path);
+  return inspected.kind === 'file' ? dirname(inspected.path) : inspected.path;
+}
+
+export function resolveStorybookPackageJson(path: string): string | undefined {
+  try {
+    return createRequireFromCwdOrBin(path).resolve(STORYBOOK_MANIFEST, {
+      paths: [requireSearchPath(path)],
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+export function workingDirectoryForCwdOrBin(path: string, configDir?: string): string {
+  const inspected = inspectCwdOrBin(path);
+  if (inspected.kind === 'directory') {
+    return inspected.path;
+  }
+  if (configDir) {
+    return dirname(resolve(configDir));
+  }
+  return process.cwd();
+}
+
+export function resolveRecordedCwd({
+  processCwd = process.cwd(),
+  invokedPath = process.argv[1],
+  fallbackFile = fileURLToPath(import.meta.url),
+}: {
+  processCwd?: string;
+  invokedPath?: string;
+  fallbackFile?: string;
+} = {}): string {
+  if (resolveStorybookPackageJson(processCwd)) {
+    return resolve(processCwd);
+  }
+  for (const candidate of [invokedPath, fallbackFile]) {
+    if (!candidate) {
+      continue;
+    }
+    const inspected = inspectCwdOrBin(candidate);
+    if (inspected.kind === 'file' && resolveStorybookPackageJson(inspected.path)) {
+      return inspected.path;
+    }
+  }
+  return resolve(processCwd);
+}

--- a/code/core/src/core-server/utils/runtime-instance-registry.test.ts
+++ b/code/core/src/core-server/utils/runtime-instance-registry.test.ts
@@ -11,6 +11,8 @@ import { tmpdir, userInfo } from 'node:os';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
+import { fileURLToPath } from 'node:url';
+
 import { join, resolve } from 'pathe';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -227,6 +229,18 @@ describe('createRuntimeInstanceRecord', () => {
     });
 
     expect(record.configDir).toBe(resolve('/repo/packages/ui/.storybook'));
+  });
+
+  it('resolves a relative configDir from process.cwd() when cwd is a storybook binary', () => {
+    const bin = fileURLToPath(import.meta.url);
+    const record = createRuntimeInstanceRecord({
+      ...baseOptions,
+      cwd: bin,
+      configDir: '.storybook',
+    });
+
+    expect(record.cwd).toBe(resolve(bin));
+    expect(record.configDir).toBe(resolve(process.cwd(), '.storybook'));
   });
 
   it('keeps an absolute configDir as-is', () => {

--- a/code/core/src/core-server/utils/runtime-instance-registry.ts
+++ b/code/core/src/core-server/utils/runtime-instance-registry.ts
@@ -9,6 +9,8 @@ import type { StorybookConfig } from 'storybook/internal/types';
 
 import { join, resolve } from 'pathe';
 
+import { inspectCwdOrBin, resolveRecordedCwd } from '../../common/utils/cwd-or-bin.ts';
+
 import { CLAUDE_PREVIEW_AGENT_NAME } from '../../shared/constants/agent-provenance.ts';
 import { isClaudePreviewLaunch } from '../../shared/utils/agent-environment.ts';
 import { detectAgent } from '../../telemetry/detect-agent.ts';
@@ -55,6 +57,7 @@ export type RuntimeInstanceRecord = {
   schemaVersion: 1;
   instanceId: string;
   pid: number;
+  /** Project directory of the running Storybook, or the `storybook` binary that started it. */
   cwd: string;
   /**
    * Resolved config directory of the running Storybook. Lets `storybook ai` find this instance
@@ -131,7 +134,7 @@ export function createRuntimeInstanceRecord({
   address,
   agent,
   configDir,
-  cwd = process.cwd(),
+  cwd = resolveRecordedCwd(),
   instanceId = randomUUID(),
   mcp = { status: 'not-installed' },
   now = new Date(),
@@ -160,7 +163,11 @@ export function createRuntimeInstanceRecord({
     instanceId,
     pid,
     cwd: resolve(cwd),
-    ...(configDir ? { configDir: resolve(cwd, configDir) } : {}),
+    ...(configDir
+      ? {
+          configDir: resolve(inspectCwdOrBin(cwd).kind === 'file' ? process.cwd() : cwd, configDir),
+        }
+      : {}),
     url: storybookBaseUrl,
     port,
     ...(token ? { token } : {}),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The Tools attach path resolved the `storybook` package from the instance record's `cwd`, which was always the process working directory of `storybook dev`. Starting the project's own binary from another directory (`"$PROJECT/node_modules/.bin/storybook" dev -c "$PROJECT/.storybook"`) stored that other directory. Discovery still found the instance via `configDir`, then attach failed because that directory has no `storybook` install.

`cwd` on the instance record and `--cwd` now accept either a project directory or a Storybook binary. `stat` decides:

- directory: same package resolution and spawn behavior as today
- file: treat it as the `storybook` bin (`createRequire(bin)`), and give the child host `dirname(configDir)` as its working directory

When `storybook dev` starts from a directory that cannot resolve `storybook`, the registry records `process.argv[1]` (the invoked bin) instead of that empty directory. Attach from the project can stay in-process when both sides resolve the same `storybook` package.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

This reproduces the empty-cwd + project-bin case from #sb-release-10-6. Use a sandbox or any local Storybook project that has `example-button--primary`.

1. Build this branch (`yarn nx compile core` from the repo root).
2. Pick a Storybook project that already runs (`PROJECT`). Create an empty directory (`EMPTY`).
3. From `$EMPTY`, start the project's binary against its config:

```bash
export STORYBOOK_DISABLE_TELEMETRY=1
"$PROJECT/node_modules/.bin/storybook" dev -p 6006 --ci -c "$PROJECT/.storybook"
```

4. Confirm the registry record under `~/.storybook/instances` has `cwd` set to the **binary path** (a file), not `$EMPTY`, and `configDir` set to `$PROJECT/.storybook`.
5. From `$PROJECT`, run:

```bash
npx storybook tools stories preview --stories '[{"storyId":"example-button--primary"}]'
```

6. Expected: exit 0, markdown includes `http://localhost:6006`, and stderr does **not** say it could not resolve `storybook` from `$EMPTY`.
7. Regression: start Storybook the usual way (`cd "$PROJECT" && npm run storybook`) and repeat step 5. Attach should still succeed. `--cwd` pointing at a project directory should behave as before.

Worth extra scrutiny: Windows path/stat behavior, `--cwd <bin>` with a relative `--config-dir`, and attach help text when a matching instance's `cwd` is a file (it should suggest `--cwd <bin>`, not `cd <bin>`).

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

Suggested labels: `bug`, `ci:normal`, `qa:needed` (path/`stat` behavior can differ on Windows).

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://chromaticqa.slack.com/archives/C0BRV9P4K9S/p1787859237554969?thread_ts=1787859237.554969&cid=C0BRV9P4K9S)

<div><a href="https://cursor.com/agents/bc-534f4469-9ba3-51ff-9c52-1614ca632dfd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-534f4469-9ba3-51ff-9c52-1614ca632dfd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

