### PR TITLE
Angular: Declare style preprocessors as optional peers and name the missing one

### DIFF
--- a/code/core/src/server-errors.ts
+++ b/code/core/src/server-errors.ts
@@ -592,6 +592,30 @@ export class AngularUnresolvedStyleError extends StorybookError {
   }
 }
 
+export class AngularMissingStylePreprocessorError extends StorybookError {
+  constructor(public data: { stylePath: string; install: string; alternative?: string }) {
+    super({
+      name: 'AngularMissingStylePreprocessorError',
+      category: Category.FRAMEWORK_ANGULAR,
+      code: 3,
+      documentation: 'https://storybook.js.org/docs/get-started/frameworks/angular-vite',
+      message: [
+        dedent`
+          Cannot compile '${data.stylePath}': the '${data.install}' package is not installed where Vite can load it.
+
+          Add it to your project:
+
+            npm install --save-dev ${data.install}
+
+          Angular's builders get '${data.install}' as a dependency of '@angular/build', so a package manager is free to leave it under 'node_modules/@angular/build/node_modules', where Vite never looks. Vite resolves a CSS preprocessor from your project directory upwards, which is why a project that compiles with 'ng build' can still fail here.`,
+        data.alternative && `'${data.alternative}' works as well, if you would rather use that.`,
+      ]
+        .filter(Boolean)
+        .join('\n\n'),
+    });
+  }
+}
+
 export class CriticalPresetLoadError extends StorybookError {
   constructor(
     public data: {

--- a/code/core/src/server-errors.ts
+++ b/code/core/src/server-errors.ts
@@ -607,7 +607,7 @@ export class AngularMissingStylePreprocessorError extends StorybookError {
 
             npm install --save-dev ${data.install}
 
-          Angular's builders get '${data.install}' as a dependency of '@angular/build', so a package manager is free to leave it under 'node_modules/@angular/build/node_modules', where Vite never looks. Vite resolves a CSS preprocessor from your project directory upwards, which is why a project that compiles with 'ng build' can still fail here.`,
+          Vite resolves a CSS preprocessor from your project directory upwards, so a copy installed deeper in the tree - such as the one Angular's builders bring in for themselves - is invisible to it. That is why a project which compiles with 'ng build' can still fail here.`,
         data.alternative && `'${data.alternative}' works as well, if you would rather use that.`,
       ]
         .filter(Boolean)

--- a/code/frameworks/angular-vite/package.json
+++ b/code/frameworks/angular-vite/package.json
@@ -107,6 +107,7 @@
     "less": "^4.0.0",
     "rxjs": "^7.4.0",
     "sass": "^1.0.0",
+    "sass-embedded": "^1.0.0",
     "storybook": "workspace:^",
     "typescript": ">= 5.9.x",
     "vite": ">=8.0.0",
@@ -120,6 +121,9 @@
       "optional": true
     },
     "sass": {
+      "optional": true
+    },
+    "sass-embedded": {
       "optional": true
     },
     "zone.js": {

--- a/code/frameworks/angular-vite/package.json
+++ b/code/frameworks/angular-vite/package.json
@@ -104,7 +104,9 @@
     "@angular/compiler-cli": ">=21.0.0 < 23.0.0",
     "@angular/core": ">=21.0.0 < 23.0.0",
     "@angular/platform-browser": ">=21.0.0 < 23.0.0",
+    "less": "^4.0.0",
     "rxjs": "^7.4.0",
+    "sass": "^1.0.0",
     "storybook": "workspace:^",
     "typescript": ">= 5.9.x",
     "vite": ">=8.0.0",
@@ -112,6 +114,12 @@
   },
   "peerDependenciesMeta": {
     "@angular/cli": {
+      "optional": true
+    },
+    "less": {
+      "optional": true
+    },
+    "sass": {
       "optional": true
     },
     "zone.js": {

--- a/code/frameworks/angular-vite/src/preset.test.ts
+++ b/code/frameworks/angular-vite/src/preset.test.ts
@@ -161,21 +161,9 @@ describe('stylePreprocessorCheckPlugin', () => {
     handler: (code: string, id: string) => unknown;
   };
 
-  // Vite runs the handler only for the ids the declared `filter` matches, so the tests go through
-  // that gate too rather than calling the handler directly. Reading the filter unconditionally is
-  // deliberate: dropping it would put this hook back in front of every module in the graph, and
-  // every assertion below would still pass if these tests skipped past it.
   const runTransform = (hook: StyleCheckHook, id: string) =>
     hook.filter.id.test(id) ? hook.handler('', id) : undefined;
 
-  // Stands in for a `node_modules` tree without installing anything: `packages` are the directories
-  // present under `installedIn`, and `entryPointResolves` are the ones whose entry point Node's CJS
-  // resolver will also hand back. They differ for a package whose `exports` map has no `require`
-  // condition, which Vite loads and `createRequire` refuses.
-  //
-  // `notExported` is that third outcome, which the resolver reports as its own error code: the
-  // package is installed and only its entry point was refused. Collapsing it into "not found" is
-  // what makes a PnP project with such a preprocessor look uninstalled.
   function transformStyle(
     id: string,
     {

--- a/code/frameworks/angular-vite/src/preset.test.ts
+++ b/code/frameworks/angular-vite/src/preset.test.ts
@@ -157,12 +157,14 @@ describe('stylePreprocessorCheckPlugin', () => {
   const VITE_DIR = dirname(fileURLToPath(import.meta.resolve('vite')));
 
   type StyleCheckHook = {
-    filter: { id: RegExp };
+    filter: { id: { include: RegExp; exclude: RegExp } };
     handler: (code: string, id: string) => unknown;
   };
 
   const runTransform = (hook: StyleCheckHook, id: string) =>
-    hook.filter.id.test(id) ? hook.handler('', id) : undefined;
+    hook.filter.id.include.test(id) && !hook.filter.id.exclude.test(id)
+      ? hook.handler('', id)
+      : undefined;
 
   function transformStyle(
     id: string,
@@ -171,11 +173,13 @@ describe('stylePreprocessorCheckPlugin', () => {
       installedIn = WORKSPACE_ROOT,
       entryPointResolves = packages,
       notExported = [],
+      bypassFilter = false,
     }: {
       packages?: string[];
       installedIn?: string;
       entryPointResolves?: string[];
       notExported?: string[];
+      bypassFilter?: boolean;
     } = {}
   ) {
     const present = new Set(
@@ -209,7 +213,8 @@ describe('stylePreprocessorCheckPlugin', () => {
 
     const plugin = stylePreprocessorCheckPlugin();
     (plugin.configResolved as (config: unknown) => void)({ root: WORKSPACE_ROOT });
-    return () => runTransform(plugin.transform as StyleCheckHook, id);
+    const hook = plugin.transform as StyleCheckHook;
+    return () => (bypassFilter ? hook.handler('', id) : runTransform(hook, id));
   }
 
   afterEach(() => {
@@ -257,6 +262,24 @@ describe('stylePreprocessorCheckPlugin', () => {
     expect(compile).toThrow(AngularMissingStylePreprocessorError);
     expect(compile).toThrow(/button\.scss'/);
     expect(compile).not.toThrow(/\?used/);
+  });
+
+  // Vite's css plugins exclude these queries from their transform, so the file is read as an asset
+  // and no preprocessor runs. Throwing here would refuse a project that compiles.
+  it.each(['raw', 'url', 'worker', 'sharedworker'])(
+    'leaves a stylesheet requested as `?%s` alone',
+    (query) => {
+      expect(
+        transformStyle(`${resolve(WORKSPACE_ROOT, 'src/button.scss')}?${query}`)
+      ).not.toThrow();
+    }
+  );
+
+  // A filter is an optimization Vite is free to skip, so the handler asks the same question itself.
+  it('leaves a `?raw` stylesheet alone even when the filter is skipped', () => {
+    expect(
+      transformStyle(`${resolve(WORKSPACE_ROOT, 'src/button.scss')}?raw`, { bypassFilter: true })
+    ).not.toThrow();
   });
 
   it('leaves files that need no preprocessor alone', () => {
@@ -330,7 +353,8 @@ describe('stylePreprocessorCheckPlugin', () => {
   // only if it covers every stylesheet and nothing else.
   it('is asked about stylesheets and nothing else', () => {
     const { filter } = stylePreprocessorCheckPlugin().transform as StyleCheckHook;
-    const matching = (ids: string[]) => ids.filter((id) => filter.id.test(id));
+    const matching = (ids: string[]) =>
+      ids.filter((id) => filter.id.include.test(id) && !filter.id.exclude.test(id));
 
     expect(
       matching([
@@ -342,7 +366,14 @@ describe('stylePreprocessorCheckPlugin', () => {
       ])
     ).toHaveLength(4);
     expect(
-      matching(['src/app.ts', 'src/app.html', 'src/button.css', 'src/scss-helpers.ts'])
+      matching([
+        'src/app.ts',
+        'src/app.html',
+        'src/button.css',
+        'src/scss-helpers.ts',
+        // Read as an asset, never handed to a preprocessor.
+        'src/button.scss?raw',
+      ])
     ).toEqual([]);
   });
 

--- a/code/frameworks/angular-vite/src/preset.test.ts
+++ b/code/frameworks/angular-vite/src/preset.test.ts
@@ -7,9 +7,10 @@ import {
   AngularUnresolvedStyleError,
 } from 'storybook/internal/server-errors';
 
-import { statSync } from 'node:fs';
+import { existsSync, statSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { resolve } from 'node:path';
+import { dirname, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { fs as memfs, vol } from 'memfs';
 import { mergeConfig, normalizePath } from 'vite';
@@ -151,17 +152,42 @@ describe('angularOptionsPlugin style preprocessor paths', () => {
 });
 
 describe('stylePreprocessorCheckPlugin', () => {
-  // `installedPackages` stands in for the user's `node_modules`: every other request throws the way
-  // `require.resolve` does for a package that is not there.
-  function transformStyle(id: string, installedPackages: string[]) {
-    vi.mocked(createRequire).mockReturnValue({
-      resolve: (request: string) => {
-        if (!installedPackages.includes(request)) {
-          throw new Error(`Cannot find module '${request}'`);
-        }
-        return request;
-      },
-    } as unknown as NodeJS.Require);
+  // Vite's fallback directory. Computed the same way the plugin computes it, because a package
+  // only Vite's own tree can reach is one Vite still loads.
+  const VITE_DIR = dirname(fileURLToPath(import.meta.resolve('vite')));
+
+  // Stands in for a `node_modules` tree without installing anything: `packages` are the directories
+  // present under `installedIn`, and `entryPointResolves` are the ones whose entry point Node's CJS
+  // resolver will also hand back. They differ for a package whose `exports` map has no `require`
+  // condition, which Vite loads and `createRequire` refuses.
+  function transformStyle(
+    id: string,
+    {
+      packages = [],
+      installedIn = WORKSPACE_ROOT,
+      entryPointResolves = packages,
+    }: { packages?: string[]; installedIn?: string; entryPointResolves?: string[] } = {}
+  ) {
+    const present = new Set(
+      packages.map((pkg) => resolve(installedIn, 'node_modules', pkg, 'package.json'))
+    );
+    vi.mocked(existsSync).mockImplementation((path) => present.has(String(path)));
+    // Node resolves upwards, so the mock answers per directory rather than globally: asking from
+    // somewhere that cannot see `installedIn` has to fail, or a test cannot tell the two search
+    // directories apart.
+    vi.mocked(createRequire).mockImplementation((from) => {
+      const askedFrom = dirname(String(from));
+      const prefix = installedIn.endsWith(sep) ? installedIn : installedIn + sep;
+      const canSee = askedFrom === installedIn || askedFrom.startsWith(prefix);
+      return {
+        resolve: (request: string) => {
+          if (!canSee || !entryPointResolves.includes(request)) {
+            throw new Error(`Cannot find module '${request}'`);
+          }
+          return request;
+        },
+      } as unknown as NodeJS.Require;
+    });
 
     const plugin = stylePreprocessorCheckPlugin();
     (plugin.configResolved as (config: unknown) => void)({ root: WORKSPACE_ROOT });
@@ -170,38 +196,45 @@ describe('stylePreprocessorCheckPlugin', () => {
 
   afterEach(() => {
     vi.mocked(createRequire).mockRestore();
+    vi.mocked(existsSync).mockRestore();
   });
 
   // Vite's own message names `sass-embedded`, because `loadSassPackage` tries that first and
   // rethrows *its* error, so the user installs a package that was never the missing one.
   it('names `sass` when a project with no sass at all compiles SCSS', () => {
-    const compile = transformStyle(resolve(WORKSPACE_ROOT, 'src/button.scss'), []);
+    const compile = transformStyle(resolve(WORKSPACE_ROOT, 'src/button.scss'));
 
     expect(compile).toThrow(AngularMissingStylePreprocessorError);
     expect(compile).toThrow(/npm install --save-dev sass/);
   });
 
   it('offers `sass-embedded` as the alternative rather than the fix', () => {
-    const compile = transformStyle(resolve(WORKSPACE_ROOT, 'src/button.scss'), []);
+    const compile = transformStyle(resolve(WORKSPACE_ROOT, 'src/button.scss'));
 
     expect(compile).toThrow(/'sass-embedded' works as well/);
   });
 
   it.each(['sass', 'sass-embedded'])('compiles SCSS when the project has %s', (pkg) => {
-    expect(transformStyle(resolve(WORKSPACE_ROOT, 'src/button.scss'), [pkg])).not.toThrow();
+    expect(
+      transformStyle(resolve(WORKSPACE_ROOT, 'src/button.scss'), { packages: [pkg] })
+    ).not.toThrow();
   });
 
   it('checks `.sass` and `.less` against their own packages', () => {
-    expect(transformStyle(resolve(WORKSPACE_ROOT, 'src/button.sass'), ['sass'])).not.toThrow();
-    expect(transformStyle(resolve(WORKSPACE_ROOT, 'src/button.less'), ['sass'])).toThrow(
-      /npm install --save-dev less/
-    );
-    expect(transformStyle(resolve(WORKSPACE_ROOT, 'src/button.less'), ['less'])).not.toThrow();
+    expect(
+      transformStyle(resolve(WORKSPACE_ROOT, 'src/button.sass'), { packages: ['sass'] })
+    ).not.toThrow();
+    expect(
+      transformStyle(resolve(WORKSPACE_ROOT, 'src/button.less'), { packages: ['sass'] })
+    ).toThrow(/npm install --save-dev less/);
+    expect(
+      transformStyle(resolve(WORKSPACE_ROOT, 'src/button.less'), { packages: ['less'] })
+    ).not.toThrow();
   });
 
   // Vite appends `?used`, `?inline` and friends before a stylesheet reaches `transform`.
   it('checks a stylesheet that arrives with a Vite query suffix', () => {
-    const compile = transformStyle(`${resolve(WORKSPACE_ROOT, 'src/button.scss')}?used`, []);
+    const compile = transformStyle(`${resolve(WORKSPACE_ROOT, 'src/button.scss')}?used`);
 
     expect(compile).toThrow(AngularMissingStylePreprocessorError);
     expect(compile).toThrow(/button\.scss'/);
@@ -209,16 +242,55 @@ describe('stylePreprocessorCheckPlugin', () => {
   });
 
   it('leaves files that need no preprocessor alone', () => {
-    expect(transformStyle(resolve(WORKSPACE_ROOT, 'src/button.css'), [])).not.toThrow();
-    expect(transformStyle(resolve(WORKSPACE_ROOT, 'src/button.ts'), [])).not.toThrow();
+    expect(transformStyle(resolve(WORKSPACE_ROOT, 'src/button.css'))).not.toThrow();
+    expect(transformStyle(resolve(WORKSPACE_ROOT, 'src/button.ts'))).not.toThrow();
   });
 
   // A hoisted `sass` sits above the Vite root, which is exactly where Vite finds it and where this
   // check has to look too - anything narrower reports a working project as broken.
-  it('searches from the Vite root, not from the stylesheet', () => {
-    transformStyle(resolve(WORKSPACE_ROOT, 'src/button.scss'), ['sass'])();
+  it('searches upwards from the Vite root, not only inside it', () => {
+    expect(
+      transformStyle(resolve(WORKSPACE_ROOT, 'src/button.scss'), {
+        packages: ['sass'],
+        installedIn: dirname(WORKSPACE_ROOT),
+      })
+    ).not.toThrow();
+  });
 
-    expect(createRequire).toHaveBeenCalledWith(resolve(WORKSPACE_ROOT, 'noop.js'));
+  // Every case below is a project Vite compiles. The check aborts the build, so reporting any of
+  // them as missing turns a working setup into a hard failure.
+  //
+  // Vite resolves preprocessors with its own conditions, so a package whose `exports` map offers
+  // only `import` loads for Vite while `createRequire().resolve` throws ERR_PACKAGE_PATH_NOT_EXPORTED.
+  it('accepts a preprocessor whose `exports` map has no `require` condition', () => {
+    expect(
+      transformStyle(resolve(WORKSPACE_ROOT, 'src/button.scss'), {
+        packages: ['sass'],
+        entryPointResolves: [],
+      })
+    ).not.toThrow();
+  });
+
+  // `loadPreprocessorPath` falls back to Vite's own directory when the root cannot see the package,
+  // which is how a linked or monorepo checkout compiles SCSS with nothing installed near the root.
+  it('accepts a copy that only Vite`s own directory can reach', () => {
+    expect(
+      transformStyle(resolve(WORKSPACE_ROOT, 'src/button.scss'), {
+        packages: ['sass'],
+        installedIn: VITE_DIR,
+      })
+    ).not.toThrow();
+  });
+
+  // Yarn PnP has no `node_modules` directories to walk, so the resolver is the only thing that can
+  // answer there.
+  it('accepts a Yarn PnP install, where there is no `node_modules` to walk', () => {
+    expect(
+      transformStyle(resolve(WORKSPACE_ROOT, 'src/button.scss'), {
+        packages: [],
+        entryPointResolves: ['sass'],
+      })
+    ).not.toThrow();
   });
 
   // Without `pre`, `vite:css` transforms first and fails with its own `sass-embedded` message, so

--- a/code/frameworks/angular-vite/src/preset.test.ts
+++ b/code/frameworks/angular-vite/src/preset.test.ts
@@ -156,6 +156,18 @@ describe('stylePreprocessorCheckPlugin', () => {
   // only Vite's own tree can reach is one Vite still loads.
   const VITE_DIR = dirname(fileURLToPath(import.meta.resolve('vite')));
 
+  type StyleCheckHook = {
+    filter: { id: RegExp };
+    handler: (code: string, id: string) => unknown;
+  };
+
+  // Vite runs the handler only for the ids the declared `filter` matches, so the tests go through
+  // that gate too rather than calling the handler directly. Reading the filter unconditionally is
+  // deliberate: dropping it would put this hook back in front of every module in the graph, and
+  // every assertion below would still pass if these tests skipped past it.
+  const runTransform = (hook: StyleCheckHook, id: string) =>
+    hook.filter.id.test(id) ? hook.handler('', id) : undefined;
+
   // Stands in for a `node_modules` tree without installing anything: `packages` are the directories
   // present under `installedIn`, and `entryPointResolves` are the ones whose entry point Node's CJS
   // resolver will also hand back. They differ for a package whose `exports` map has no `require`
@@ -209,7 +221,7 @@ describe('stylePreprocessorCheckPlugin', () => {
 
     const plugin = stylePreprocessorCheckPlugin();
     (plugin.configResolved as (config: unknown) => void)({ root: WORKSPACE_ROOT });
-    return () => (plugin.transform as (code: string, id: string) => unknown)('', id);
+    return () => runTransform(plugin.transform as StyleCheckHook, id);
   }
 
   afterEach(() => {
@@ -322,6 +334,28 @@ describe('stylePreprocessorCheckPlugin', () => {
         notExported: ['sass'],
       })
     ).not.toThrow();
+  });
+
+  // `pre` puts this hook ahead of the whole module graph, so an unfiltered handler would be called
+  // once per module - overwhelmingly for files that can never need a preprocessor - to answer a
+  // question about stylesheets. The filter is what keeps it off that path, and it earns its place
+  // only if it covers every stylesheet and nothing else.
+  it('is asked about stylesheets and nothing else', () => {
+    const { filter } = stylePreprocessorCheckPlugin().transform as StyleCheckHook;
+    const matching = (ids: string[]) => ids.filter((id) => filter.id.test(id));
+
+    expect(
+      matching([
+        'src/button.scss',
+        'src/button.sass',
+        'src/button.less',
+        // Vite appends `?used`, `?inline` and friends before a stylesheet reaches `transform`.
+        'src/button.scss?used',
+      ])
+    ).toHaveLength(4);
+    expect(
+      matching(['src/app.ts', 'src/app.html', 'src/button.css', 'src/scss-helpers.ts'])
+    ).toEqual([]);
   });
 
   // Without `pre`, `vite:css` transforms first and fails with its own `sass-embedded` message, so

--- a/code/frameworks/angular-vite/src/preset.test.ts
+++ b/code/frameworks/angular-vite/src/preset.test.ts
@@ -220,6 +220,20 @@ describe('stylePreprocessorCheckPlugin', () => {
 
     expect(createRequire).toHaveBeenCalledWith(resolve(WORKSPACE_ROOT, 'noop.js'));
   });
+
+  // Without `pre`, `vite:css` transforms first and fails with its own `sass-embedded` message, so
+  // every assertion above still passes while the user sees none of it.
+  it('runs ahead of `vite:css`, whose message it exists to replace', () => {
+    expect(stylePreprocessorCheckPlugin().enforce).toBe('pre');
+  });
+
+  it('is registered by viteFinal, which is the only thing that runs it', async () => {
+    const result = await viteFinal({ root: WORKSPACE_ROOT }, optionsWith({}));
+
+    expect(result.plugins).toContainEqual(
+      expect.objectContaining({ name: 'storybook-angular-vite-style-preprocessor-check' })
+    );
+  });
 });
 
 describe('angularOptionsPlugin global styles', () => {

--- a/code/frameworks/angular-vite/src/preset.test.ts
+++ b/code/frameworks/angular-vite/src/preset.test.ts
@@ -2,9 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { findConfigFile } from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
-import { AngularUnresolvedStyleError } from 'storybook/internal/server-errors';
+import {
+  AngularMissingStylePreprocessorError,
+  AngularUnresolvedStyleError,
+} from 'storybook/internal/server-errors';
 
 import { statSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
 
 import { fs as memfs, vol } from 'memfs';
@@ -18,6 +22,7 @@ import {
   experimental_manifests,
   experimental_storyDocsProvider,
   features,
+  stylePreprocessorCheckPlugin,
   viteFinal,
 } from './preset.ts';
 import type { StandaloneOptions } from './builders/utils/standalone-options.ts';
@@ -34,6 +39,9 @@ vi.mock('vite', { spy: true });
 // Spy-only mock: `styles` resolution stats candidate files, and only that call is redirected to a
 // memfs volume, so everything else in the preset keeps reading the real filesystem.
 vi.mock('node:fs', { spy: true });
+// Spy-only as well: the preprocessor check is the one place that asks node for a package, and the
+// tests below need to say which packages a user's project has without installing any of them.
+vi.mock('node:module', { spy: true });
 // The only mock that has to replace the module rather than spy on it: loading the real Angular
 // plugin drags a full Angular toolchain into the run, and none of these tests are about it.
 vi.mock('@analogjs/vite-plugin-angular', () => ({ default: (): unknown[] => [] }));
@@ -139,6 +147,78 @@ describe('angularOptionsPlugin style preprocessor paths', () => {
   it('returns nothing when no style preprocessor paths are configured', () => {
     expect(runConfig(undefined)).toBeUndefined();
     expect(runConfig({})).toBeUndefined();
+  });
+});
+
+describe('stylePreprocessorCheckPlugin', () => {
+  // `installedPackages` stands in for the user's `node_modules`: every other request throws the way
+  // `require.resolve` does for a package that is not there.
+  function transformStyle(id: string, installedPackages: string[]) {
+    vi.mocked(createRequire).mockReturnValue({
+      resolve: (request: string) => {
+        if (!installedPackages.includes(request)) {
+          throw new Error(`Cannot find module '${request}'`);
+        }
+        return request;
+      },
+    } as unknown as NodeJS.Require);
+
+    const plugin = stylePreprocessorCheckPlugin();
+    (plugin.configResolved as (config: unknown) => void)({ root: WORKSPACE_ROOT });
+    return () => (plugin.transform as (code: string, id: string) => unknown)('', id);
+  }
+
+  afterEach(() => {
+    vi.mocked(createRequire).mockRestore();
+  });
+
+  // Vite's own message names `sass-embedded`, because `loadSassPackage` tries that first and
+  // rethrows *its* error, so the user installs a package that was never the missing one.
+  it('names `sass` when a project with no sass at all compiles SCSS', () => {
+    const compile = transformStyle(resolve(WORKSPACE_ROOT, 'src/button.scss'), []);
+
+    expect(compile).toThrow(AngularMissingStylePreprocessorError);
+    expect(compile).toThrow(/npm install --save-dev sass/);
+  });
+
+  it('offers `sass-embedded` as the alternative rather than the fix', () => {
+    const compile = transformStyle(resolve(WORKSPACE_ROOT, 'src/button.scss'), []);
+
+    expect(compile).toThrow(/'sass-embedded' works as well/);
+  });
+
+  it.each(['sass', 'sass-embedded'])('compiles SCSS when the project has %s', (pkg) => {
+    expect(transformStyle(resolve(WORKSPACE_ROOT, 'src/button.scss'), [pkg])).not.toThrow();
+  });
+
+  it('checks `.sass` and `.less` against their own packages', () => {
+    expect(transformStyle(resolve(WORKSPACE_ROOT, 'src/button.sass'), ['sass'])).not.toThrow();
+    expect(transformStyle(resolve(WORKSPACE_ROOT, 'src/button.less'), ['sass'])).toThrow(
+      /npm install --save-dev less/
+    );
+    expect(transformStyle(resolve(WORKSPACE_ROOT, 'src/button.less'), ['less'])).not.toThrow();
+  });
+
+  // Vite appends `?used`, `?inline` and friends before a stylesheet reaches `transform`.
+  it('checks a stylesheet that arrives with a Vite query suffix', () => {
+    const compile = transformStyle(`${resolve(WORKSPACE_ROOT, 'src/button.scss')}?used`, []);
+
+    expect(compile).toThrow(AngularMissingStylePreprocessorError);
+    expect(compile).toThrow(/button\.scss'/);
+    expect(compile).not.toThrow(/\?used/);
+  });
+
+  it('leaves files that need no preprocessor alone', () => {
+    expect(transformStyle(resolve(WORKSPACE_ROOT, 'src/button.css'), [])).not.toThrow();
+    expect(transformStyle(resolve(WORKSPACE_ROOT, 'src/button.ts'), [])).not.toThrow();
+  });
+
+  // A hoisted `sass` sits above the Vite root, which is exactly where Vite finds it and where this
+  // check has to look too - anything narrower reports a working project as broken.
+  it('searches from the Vite root, not from the stylesheet', () => {
+    transformStyle(resolve(WORKSPACE_ROOT, 'src/button.scss'), ['sass'])();
+
+    expect(createRequire).toHaveBeenCalledWith(resolve(WORKSPACE_ROOT, 'noop.js'));
   });
 });
 

--- a/code/frameworks/angular-vite/src/preset.test.ts
+++ b/code/frameworks/angular-vite/src/preset.test.ts
@@ -160,13 +160,23 @@ describe('stylePreprocessorCheckPlugin', () => {
   // present under `installedIn`, and `entryPointResolves` are the ones whose entry point Node's CJS
   // resolver will also hand back. They differ for a package whose `exports` map has no `require`
   // condition, which Vite loads and `createRequire` refuses.
+  //
+  // `notExported` is that third outcome, which the resolver reports as its own error code: the
+  // package is installed and only its entry point was refused. Collapsing it into "not found" is
+  // what makes a PnP project with such a preprocessor look uninstalled.
   function transformStyle(
     id: string,
     {
       packages = [],
       installedIn = WORKSPACE_ROOT,
       entryPointResolves = packages,
-    }: { packages?: string[]; installedIn?: string; entryPointResolves?: string[] } = {}
+      notExported = [],
+    }: {
+      packages?: string[];
+      installedIn?: string;
+      entryPointResolves?: string[];
+      notExported?: string[];
+    } = {}
   ) {
     const present = new Set(
       packages.map((pkg) => resolve(installedIn, 'node_modules', pkg, 'package.json'))
@@ -181,10 +191,18 @@ describe('stylePreprocessorCheckPlugin', () => {
       const canSee = askedFrom === installedIn || askedFrom.startsWith(prefix);
       return {
         resolve: (request: string) => {
-          if (!canSee || !entryPointResolves.includes(request)) {
-            throw new Error(`Cannot find module '${request}'`);
+          if (canSee && entryPointResolves.includes(request)) {
+            return request;
           }
-          return request;
+          const refusedEntryPoint = canSee && notExported.includes(request);
+          throw Object.assign(
+            new Error(
+              refusedEntryPoint
+                ? `No "exports" main defined in '${request}'`
+                : `Cannot find module '${request}'`
+            ),
+            { code: refusedEntryPoint ? 'ERR_PACKAGE_PATH_NOT_EXPORTED' : 'MODULE_NOT_FOUND' }
+          );
         },
       } as unknown as NodeJS.Require;
     });
@@ -289,6 +307,19 @@ describe('stylePreprocessorCheckPlugin', () => {
       transformStyle(resolve(WORKSPACE_ROOT, 'src/button.scss'), {
         packages: [],
         entryPointResolves: ['sass'],
+      })
+    ).not.toThrow();
+  });
+
+  // The two cases above combined, and the one layout no `node_modules` walk can rescue: under PnP
+  // the resolver is the only witness, so it has to tell "no such package" apart from "the package is
+  // here and its entry point is not exported to `require`". Only the first is a missing install.
+  it('accepts a Yarn PnP install whose `exports` map has no `require` condition', () => {
+    expect(
+      transformStyle(resolve(WORKSPACE_ROOT, 'src/button.scss'), {
+        packages: [],
+        entryPointResolves: [],
+        notExported: ['sass'],
       })
     ).not.toThrow();
   });

--- a/code/frameworks/angular-vite/src/preset.ts
+++ b/code/frameworks/angular-vite/src/preset.ts
@@ -13,9 +13,9 @@ import {
 } from 'storybook/internal/server-errors';
 import type { PresetProperty, StorybookConfigRaw } from 'storybook/internal/types';
 
-import { readFileSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { basename, isAbsolute, join, relative, resolve } from 'node:path';
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { DOCUMENTATION_JSON, resolveCompodocConfig } from './compodoc-config.ts';
@@ -343,18 +343,48 @@ const STYLE_PREPROCESSORS: Record<string, { install: string; alternative?: strin
 
 const STYLE_PREPROCESSOR_ID = /\.(scss|sass|less)(?:$|\?)/;
 
-const isInstalledNear = (pkg: string, dir: string) => {
+// This check aborts the build, so it has to be at least as permissive as Vite. It deliberately
+// asks whether the package is *present* rather than whether its entry point resolves: Vite loads
+// preprocessors with its own resolver and conditions, so an `exports` map without a `require`
+// condition resolves for Vite and throws for `createRequire`. Walking `node_modules` covers that;
+// the `createRequire` arm covers Yarn PnP, where there are no `node_modules` directories to walk.
+const isPackagePresentFrom = (pkg: string, fromDir: string) => {
+  let dir = resolve(fromDir);
+  while (true) {
+    if (existsSync(join(dir, 'node_modules', pkg, 'package.json'))) {
+      return true;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+
   try {
-    createRequire(join(dir, 'noop.js')).resolve(pkg);
+    createRequire(join(fromDir, 'noop.js')).resolve(pkg);
     return true;
   } catch {
     return false;
   }
 };
 
+const viteInstallDir = () => {
+  try {
+    return dirname(fileURLToPath(import.meta.resolve('vite')));
+  } catch {
+    return undefined;
+  }
+};
+
+const isInstalledNear = (pkg: string, root: string) =>
+  [root, viteInstallDir()]
+    .filter((dir): dir is string => !!dir)
+    .some((dir) => isPackagePresentFrom(pkg, dir));
+
 export function stylePreprocessorCheckPlugin(): Plugin {
-  // `loadPreprocessorPath` resolves from the Vite root first, so this asks the same question from
-  // the same place: a preprocessor reported missing here is one Vite is about to fail on too.
+  // Same two directories and same order as `loadPreprocessorPath`, so a preprocessor reported
+  // missing here is one Vite is about to fail on too.
   let root = process.cwd();
   const installed = new Map<string, boolean>();
 

--- a/code/frameworks/angular-vite/src/preset.ts
+++ b/code/frameworks/angular-vite/src/preset.ts
@@ -399,30 +399,38 @@ export function stylePreprocessorCheckPlugin(): Plugin {
       root = config.root;
       installed.clear();
     },
-    transform(_code, id) {
-      const lang = STYLE_PREPROCESSOR_ID.exec(id)?.[1];
-      const preprocessor = lang ? STYLE_PREPROCESSORS[lang] : undefined;
-      if (!lang || !preprocessor) {
-        return;
-      }
+    transform: {
+      // Only a stylesheet can be missing a preprocessor, and this hook sits in `pre`, ahead of
+      // every module in the graph. Declaring the filter keeps the handler out of that path: Vite
+      // evaluates it before it calls into JS, and under Rolldown it never crosses the boundary at
+      // all. The handler still asks the same question, because a filter is an optimization Vite is
+      // free to skip, never the guard the error depends on.
+      filter: { id: STYLE_PREPROCESSOR_ID },
+      handler(_code, id) {
+        const lang = STYLE_PREPROCESSOR_ID.exec(id)?.[1];
+        const preprocessor = lang ? STYLE_PREPROCESSORS[lang] : undefined;
+        if (!lang || !preprocessor) {
+          return;
+        }
 
-      if (!installed.has(lang)) {
-        const candidates = [preprocessor.install, preprocessor.alternative].filter(
-          (pkg): pkg is string => !!pkg
-        );
-        installed.set(
-          lang,
-          candidates.some((pkg) => isInstalledNear(pkg, root))
-        );
-      }
+        if (!installed.has(lang)) {
+          const candidates = [preprocessor.install, preprocessor.alternative].filter(
+            (pkg): pkg is string => !!pkg
+          );
+          installed.set(
+            lang,
+            candidates.some((pkg) => isInstalledNear(pkg, root))
+          );
+        }
 
-      if (!installed.get(lang)) {
-        throw new AngularMissingStylePreprocessorError({
-          stylePath: id.split('?')[0],
-          install: preprocessor.install,
-          alternative: preprocessor.alternative,
-        });
-      }
+        if (!installed.get(lang)) {
+          throw new AngularMissingStylePreprocessorError({
+            stylePath: id.split('?')[0],
+            install: preprocessor.install,
+            alternative: preprocessor.alternative,
+          });
+        }
+      },
     },
   };
 }

--- a/code/frameworks/angular-vite/src/preset.ts
+++ b/code/frameworks/angular-vite/src/preset.ts
@@ -7,11 +7,15 @@ import {
   getRealPath,
 } from 'storybook/internal/mocking-utils';
 import { logger } from 'storybook/internal/node-logger';
-import { AngularUnresolvedStyleError } from 'storybook/internal/server-errors';
+import {
+  AngularMissingStylePreprocessorError,
+  AngularUnresolvedStyleError,
+} from 'storybook/internal/server-errors';
 import type { PresetProperty, StorybookConfigRaw } from 'storybook/internal/types';
 
 import { readFileSync, statSync } from 'node:fs';
-import { basename, isAbsolute, relative, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import { basename, isAbsolute, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { DOCUMENTATION_JSON, resolveCompodocConfig } from './compodoc-config.ts';
@@ -227,6 +231,7 @@ export const viteFinal = async (config: UserConfig, options?: StandaloneOptions)
       ...pluginsToInject,
       angularViteRedirectReapplyPlugin(options),
       angularOptionsPlugin(options, { normalizePath, zoneless }),
+      stylePreprocessorCheckPlugin(),
       storybookOxcPlugin(),
       ...(docgenServer && options?.configDir ? [compodocJsonStubPlugin(options.configDir)] : []),
     ],
@@ -328,6 +333,74 @@ function resolveBuilderStyle(stylePath: string, workspaceRoot: string) {
   }
 
   return stylePath;
+}
+
+// Vite loads a CSS preprocessor through `loadPreprocessorPath`, which resolves the package from the
+// Vite root upwards and then from Vite's own directory upwards, and nowhere else. Angular gets
+// `sass` as a *dependency* of `@angular/build`, so whether Storybook can compile `.scss` at all
+// comes down to whether the package manager hoisted that copy to the top level. When it did not,
+// Vite's own diagnostic names `sass-embedded`, because `loadSassPackage` tries that one first and
+// rethrows *its* failure, and the user installs the package they do not need.
+const STYLE_PREPROCESSORS: Record<string, { install: string; alternative?: string }> = {
+  scss: { install: 'sass', alternative: 'sass-embedded' },
+  sass: { install: 'sass', alternative: 'sass-embedded' },
+  less: { install: 'less' },
+};
+
+const STYLE_PREPROCESSOR_ID = /\.(scss|sass|less)(?:$|\?)/;
+
+const isInstalledNear = (pkg: string, dir: string) => {
+  try {
+    createRequire(join(dir, 'noop.js')).resolve(pkg);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export function stylePreprocessorCheckPlugin(): Plugin {
+  // `loadPreprocessorPath` resolves from the Vite root first, so this asks the same question from
+  // the same place: a preprocessor reported missing here is one Vite is about to fail on too.
+  let root = process.cwd();
+  const installed = new Map<string, boolean>();
+
+  return {
+    name: 'storybook-angular-vite-style-preprocessor-check',
+    // Ahead of the core `vite:css` transform, so the actionable error replaces Vite's instead of
+    // arriving after it.
+    enforce: 'pre',
+    configResolved(config) {
+      root = config.root;
+      installed.clear();
+    },
+    transform(_code, id) {
+      const lang = STYLE_PREPROCESSOR_ID.exec(id)?.[1];
+      const preprocessor = lang ? STYLE_PREPROCESSORS[lang] : undefined;
+      if (!lang || !preprocessor) {
+        return;
+      }
+
+      if (!installed.has(lang)) {
+        const candidates = [preprocessor.install, preprocessor.alternative].filter(
+          (pkg): pkg is string => !!pkg
+        );
+        installed.set(
+          lang,
+          candidates.some((pkg) => isInstalledNear(pkg, root))
+        );
+      }
+
+      if (!installed.get(lang)) {
+        throw new AngularMissingStylePreprocessorError({
+          stylePath: id.split('?')[0],
+          install: preprocessor.install,
+          alternative: preprocessor.alternative,
+        });
+      }
+
+      return;
+    },
+  };
 }
 
 export function angularOptionsPlugin(

--- a/code/frameworks/angular-vite/src/preset.ts
+++ b/code/frameworks/angular-vite/src/preset.ts
@@ -400,11 +400,6 @@ export function stylePreprocessorCheckPlugin(): Plugin {
       installed.clear();
     },
     transform: {
-      // Only a stylesheet can be missing a preprocessor, and this hook sits in `pre`, ahead of
-      // every module in the graph. Declaring the filter keeps the handler out of that path: Vite
-      // evaluates it before it calls into JS, and under Rolldown it never crosses the boundary at
-      // all. The handler still asks the same question, because a filter is an optimization Vite is
-      // free to skip, never the guard the error depends on.
       filter: { id: STYLE_PREPROCESSOR_ID },
       handler(_code, id) {
         const lang = STYLE_PREPROCESSOR_ID.exec(id)?.[1];

--- a/code/frameworks/angular-vite/src/preset.ts
+++ b/code/frameworks/angular-vite/src/preset.ts
@@ -335,12 +335,6 @@ function resolveBuilderStyle(stylePath: string, workspaceRoot: string) {
   return stylePath;
 }
 
-// Vite loads a CSS preprocessor through `loadPreprocessorPath`, which resolves the package from the
-// Vite root upwards and then from Vite's own directory upwards, and nowhere else. Angular gets
-// `sass` as a *dependency* of `@angular/build`, so whether Storybook can compile `.scss` at all
-// comes down to whether the package manager hoisted that copy to the top level. When it did not,
-// Vite's own diagnostic names `sass-embedded`, because `loadSassPackage` tries that one first and
-// rethrows *its* failure, and the user installs the package they do not need.
 const STYLE_PREPROCESSORS: Record<string, { install: string; alternative?: string }> = {
   scss: { install: 'sass', alternative: 'sass-embedded' },
   sass: { install: 'sass', alternative: 'sass-embedded' },

--- a/code/frameworks/angular-vite/src/preset.ts
+++ b/code/frameworks/angular-vite/src/preset.ts
@@ -397,8 +397,6 @@ export function stylePreprocessorCheckPlugin(): Plugin {
           alternative: preprocessor.alternative,
         });
       }
-
-      return;
     },
   };
 }

--- a/code/frameworks/angular-vite/src/preset.ts
+++ b/code/frameworks/angular-vite/src/preset.ts
@@ -343,6 +343,11 @@ const STYLE_PREPROCESSORS: Record<string, { install: string; alternative?: strin
 
 const STYLE_PREPROCESSOR_ID = /\.(scss|sass|less)(?:$|\?)/;
 
+// Vite's own css plugins exclude these queries from their transform, so a `.scss?raw` import is
+// read as an asset and never reaches a preprocessor. Aborting the build for one would refuse a
+// project that compiles.
+const SPECIAL_QUERY_ID = /[?&](?:worker|sharedworker|raw|url)\b/;
+
 // Asks whether the package is present, not whether its entry point resolves: this check aborts the
 // build, and Vite loads preprocessors with its own conditions, so an `exports` map without a
 // `require` condition resolves for Vite and throws here. The `createRequire` arm is only for Yarn
@@ -400,9 +405,9 @@ export function stylePreprocessorCheckPlugin(): Plugin {
       installed.clear();
     },
     transform: {
-      filter: { id: STYLE_PREPROCESSOR_ID },
+      filter: { id: { include: STYLE_PREPROCESSOR_ID, exclude: SPECIAL_QUERY_ID } },
       handler(_code, id) {
-        const lang = STYLE_PREPROCESSOR_ID.exec(id)?.[1];
+        const lang = SPECIAL_QUERY_ID.test(id) ? undefined : STYLE_PREPROCESSOR_ID.exec(id)?.[1];
         const preprocessor = lang ? STYLE_PREPROCESSORS[lang] : undefined;
         if (!lang || !preprocessor) {
           return;

--- a/code/frameworks/angular-vite/src/preset.ts
+++ b/code/frameworks/angular-vite/src/preset.ts
@@ -343,11 +343,11 @@ const STYLE_PREPROCESSORS: Record<string, { install: string; alternative?: strin
 
 const STYLE_PREPROCESSOR_ID = /\.(scss|sass|less)(?:$|\?)/;
 
-// This check aborts the build, so it has to be at least as permissive as Vite. It deliberately
-// asks whether the package is *present* rather than whether its entry point resolves: Vite loads
-// preprocessors with its own resolver and conditions, so an `exports` map without a `require`
-// condition resolves for Vite and throws for `createRequire`. Walking `node_modules` covers that;
-// the `createRequire` arm covers Yarn PnP, where there are no `node_modules` directories to walk.
+// Asks whether the package is present, not whether its entry point resolves: this check aborts the
+// build, and Vite loads preprocessors with its own conditions, so an `exports` map without a
+// `require` condition resolves for Vite and throws here. The `createRequire` arm is only for Yarn
+// PnP, which has no `node_modules` to walk; `import.meta.resolve` cannot replace it, because its
+// `parent` argument is silently ignored without `--experimental-import-meta-resolve`.
 const isPackagePresentFrom = (pkg: string, fromDir: string) => {
   let dir = resolve(fromDir);
   while (true) {
@@ -364,8 +364,10 @@ const isPackagePresentFrom = (pkg: string, fromDir: string) => {
   try {
     createRequire(join(fromDir, 'noop.js')).resolve(pkg);
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    // Node found the package and refused only its entry point, because the `exports` map has no
+    // `require` condition. Vite resolves with its own conditions, so that is present, not missing.
+    return (error as NodeJS.ErrnoException)?.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED';
   }
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11985,13 +11985,22 @@ __metadata:
     "@angular/compiler-cli": ">=21.0.0 < 23.0.0"
     "@angular/core": ">=21.0.0 < 23.0.0"
     "@angular/platform-browser": ">=21.0.0 < 23.0.0"
+    less: ^4.0.0
     rxjs: ^7.4.0
+    sass: ^1.0.0
+    sass-embedded: ^1.0.0
     storybook: "workspace:^"
     typescript: ">= 5.9.x"
     vite: ">=8.0.0"
     zone.js: ">=0.14.0"
   peerDependenciesMeta:
     "@angular/cli":
+      optional: true
+    less:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
       optional: true
     zone.js:
       optional: true


### PR DESCRIPTION
Refs #36012

<!-- Not `Closes`: this covers gaps 1 and 3 of that issue, the resolution importer is left open on purpose. See "What this does not fix". -->

## What I did

An Angular project that compiles `.scss` gets its sass implementation from the Angular builder, and `@storybook/angular-vite` declared nothing at all.
Vite does not bundle a preprocessor either - it resolves one from the Vite root upwards - so whether Storybook could compile SCSS came down to whether the package manager happened to hoist the copy `@angular/build` installs for itself.
When it did not, the user got Vite's own diagnostic pointing at `sass-embedded`, which is not the package they are missing.

This declares `sass`, `sass-embedded` and `less` as optional peers, and adds a pre-flight check that names the package the user actually has to install.

### Why a peer and not a dependency

This is the one part that is easy to get backwards, so it is worth spelling out:

```
dependency of @storybook/angular-vite  ->  lands in @storybook/angular-vite/node_modules  ->  Vite never looks there
optional peer                          ->  lands at the consumer root                     ->  exactly where loadPreprocessorPath resolves from
```

Hence the weaker-looking mechanism is the one that works.
Optional, so nobody writing plain CSS is asked to install a compiler.

### Where the check sits

```
   .scss import
        |
        v
   storybook-angular-vite-style-preprocessor-check     enforce: 'pre'
        |   looks for `sass` in `node_modules` from config.root upwards,
        |   then from Vite's own directory - the same two places, same order
        |
        +-- present ---------> pass through, vite:css compiles as before
        |
        +-- absent ----------> throw AngularMissingStylePreprocessorError
        v
   vite:css        (its own `sass-embedded` message is now unreachable)
```

It asks whether the package is *present*, not whether `require.resolve` succeeds on it.
Vite loads preprocessors with its own conditions, so a package whose `exports` map declares no `require` condition resolves for Vite and throws for `createRequire`.
Reading that as missing would abort a build that in fact works, and this check aborts the build, so it has to be at least as permissive as Vite is.

The `createRequire` arm survives only for Yarn PnP, which has no `node_modules` directories to walk. There the same distinction has to be made from the error code, because a refused entry point means the package is installed:

```ts
} catch (error) {
  // Node found the package and refused only its entry point, because the `exports` map has no
  // `require` condition. Vite resolves with its own conditions, so that is present, not missing.
  return (error as NodeJS.ErrnoException)?.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED';
}
```

`enforce: 'pre'` is load-bearing rather than decorative.
Without it `vite:css` transforms first and the user reads the old message again, while every unit test on the plugin still passes.
Hence one test asserts the ordering and another asserts that `viteFinal` registers the plugin at all:

```ts
it('runs ahead of `vite:css`, whose message it exists to replace', () => {
  expect(stylePreprocessorCheckPlugin().enforce).toBe('pre');
});
```

### Before

Vite's diagnostic on a project whose root cannot reach sass, from the reproduction repository in #36012:

```
[vite:css] Preprocessor dependency "sass-embedded" not found. Did you install it? Try `npm install -D sass-embedded`.
file: .../nosass/src/style.scss
```

`sass-embedded` is a misdirection: `loadSassPackage` tries it first and rethrows *its* error when both are missing, so the user installs a package that was never the problem.

### After

Captured from the error class at this head:

```
Cannot compile '/app/src/styles.scss': the 'sass' package is not installed where Vite can load it.

Add it to your project:

  npm install --save-dev sass

Vite resolves a CSS preprocessor from your project directory upwards, so a copy installed deeper in the tree - such as the one Angular's builders bring in for themselves - is invisible to it. That is why a project which compiles with 'ng build' can still fail here.

'sass-embedded' works as well, if you would rather use that.

More info: https://storybook.js.org/docs/get-started/frameworks/angular-vite?ref=error
```

`.less` gets the same shape with `less` and no alternative.

### What this does not fix

Gap 2 of #36012, the sass resolution importer that `@angular-devkit/build-angular` installs and this preset does not, is untouched.
A workspace-root-relative `@use` therefore still fails.
It is independent of everything here and I would rather keep it in its own PR, so this one is `Refs` and not `Closes`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

Reproducing this needs a `node_modules` layout where `sass` is *not* hoisted, which a generated sandbox will not give you, so this uses the repository from the issue.

1. `git clone https://github.com/PhilippMDoerner/NimStoryFont && cd NimStoryFont/frontend`
2. `npm ci`, then `npm ls sass`. Its committed lockfile declares `@angular/build: ^22.1.3` and no top-level `sass`, so the only copy sits under `node_modules/@angular/build/node_modules`.
3. Migrate the project onto `angular-vite` with `npx storybook automigrate angular-to-angular-vite`, against a canary of this PR.
4. Start Storybook and open any SCSS-styled component.
   Expected: the build fails naming `sass`, with the `npm install --save-dev sass` line from the message above. On `next` today it names `sass-embedded` instead.
5. `npm install --save-dev sass`, restart Storybook, open the same component.
   Expected: it renders.
6. Shorter variant if cloning is inconvenient: in any Angular app already on `angular-vite`, `rm -rf node_modules/sass node_modules/sass-embedded` and repeat steps 4 and 5.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No docs change here.
The three peers are optional and the error links to the `angular-vite` docs page, so nothing in the docs is currently wrong.
Happy to add a short "styling" note to that page if you would rather have it in this PR - WDYT?

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-36098-sha-e4b924c1`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-36098-sha-e4b924c1 sandbox` or in an existing project with `npx storybook@0.0.0-pr-36098-sha-e4b924c1 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-36098-sha-e4b924c1`](https://npmjs.com/package/storybook/v/0.0.0-pr-36098-sha-e4b924c1) |
| **Triggered by** | @huang-julien |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`agent/sto-78-angular-vite-sass`](https://github.com/storybookjs/storybook/tree/agent/sto-78-angular-vite-sass) |
| **Commit** | [`e4b924c1`](https://github.com/storybookjs/storybook/commit/e4b924c115d44d452454acb84eb341a06d7f2c6a) |
| **Datetime** | Tue Sep  1 12:23:35 UTC 2026 (`1788265415`) |
| **Workflow run** | [33507407142](https://github.com/storybookjs/storybook/actions/runs/33507407142) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=36098`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

