### PR TITLE
Tools: Flush remote-command ack before the handler's fan-out starts

### DIFF
--- a/code/core/src/__tests/server-errors.test.ts
+++ b/code/core/src/__tests/server-errors.test.ts
@@ -1,9 +1,23 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  OpenServiceRemoteCommandConfigDriftError,
   OpenServiceRemoteCommandUnhandledError,
   WebpackCompilationError,
 } from '../server-errors.ts';
+
+describe('OpenServiceRemoteCommandConfigDriftError', () => {
+  it('reports the missing handler and scopes the restart guidance to the attached instance', () => {
+    const error = new OpenServiceRemoteCommandConfigDriftError({
+      serviceId: 'core/docgen',
+      commandName: 'extractAllDocgen',
+    });
+
+    expect(error.message).toBe(
+      'The Storybook this runtime is attached to reported it has no handler for remote command "core/docgen.extractAllDocgen". The two processes are running different configurations (for example a feature flag enabled in one but not the other). Restart the attached Storybook with a configuration matching this process.'
+    );
+  });
+});
 
 describe('OpenServiceRemoteCommandUnhandledError', () => {
   it('describes an unacknowledged delegated command without blaming configuration', () => {

--- a/code/core/src/__tests/server-errors.test.ts
+++ b/code/core/src/__tests/server-errors.test.ts
@@ -1,6 +1,35 @@
 import { describe, expect, it } from 'vitest';
 
-import { WebpackCompilationError } from '../server-errors.ts';
+import {
+  OpenServiceRemoteCommandUnhandledError,
+  WebpackCompilationError,
+} from '../server-errors.ts';
+
+describe('OpenServiceRemoteCommandUnhandledError', () => {
+  it('describes an unacknowledged delegated command without blaming configuration', () => {
+    const error = new OpenServiceRemoteCommandUnhandledError({
+      serviceId: 'core/docgen',
+      commandName: 'extractAllDocgen',
+      delegated: true,
+    });
+
+    expect(error.message).toBe(
+      'The Storybook this runtime is attached to did not acknowledge remote command "core/docgen.extractAllDocgen" in time — it may be busy or unreachable. Retry; note the command may still have executed on that instance.'
+    );
+    expect(error.message).not.toMatch(/configuration|restart/i);
+  });
+
+  it('describes an unimplemented command when not delegated', () => {
+    const error = new OpenServiceRemoteCommandUnhandledError({
+      serviceId: 'core/docgen',
+      commandName: 'extractAllDocgen',
+    });
+
+    expect(error.message).toBe(
+      'No runtime acknowledged remote command "core/docgen.extractAllDocgen"; its handler is not implemented in any connected runtime.'
+    );
+  });
+});
 
 describe('WebpackCompilationError', () => {
   it('should correctly handle error with stats.compilation.errors', () => {

--- a/code/core/src/cli/tools/architecture.md
+++ b/code/core/src/cli/tools/architecture.md
@@ -137,11 +137,12 @@ Messages name the exact corrective command.
 | Stale record / connection refused | WS connect fails                      | Registry cleanup; fallback note                                                                  |
 | Server started before upgrade     | Instance-cwd package ≠ record version | Both version strings; restart Storybook                                                          |
 | Spawn resolution failure          | No `storybook` under `record.cwd`     | `SpawnFailedError` remediation; local fallback                                                   |
-| Config drift                      | Remote command ack timeout            | Running Storybook was started with a different configuration — restart it                        |
+| Unacknowledged command            | Remote command ack timeout            | Attached Storybook did not acknowledge in time; the command may still have executed — retry      |
 
-Rows other than config drift are factory-time attach gates. In `auto`, those return a local host
-and a fallback notice (omitted from `--json` output). Under `--attach`, they are hard errors with
-the same text. Config drift is a post-attach `tools.call` failure: `auto` does not fall back then.
+Rows other than the unacknowledged command are factory-time attach gates. In `auto`, those return a
+local host and a fallback notice (omitted from `--json` output). Under `--attach`, they are hard
+errors with the same text. An unacknowledged command is a post-attach `tools.call` failure: `auto`
+does not fall back then.
 
 ## Limits
 

--- a/code/core/src/cli/tools/architecture.md
+++ b/code/core/src/cli/tools/architecture.md
@@ -35,8 +35,11 @@ The caller registers services through the same `services` preset the server runs
 stay registered. `setDelegatedMode(true)` runs once at the attached entry, before the first
 `registerService`. Command dispatch then skips local handlers and routes every command over the
 channel (`services:command-invoke` → `command-ack` → `command-result` / `command-error`). Errors
-rebuild through `service-error-serialization.ts`. If no implementer acknowledges within the ack
-timeout, the caller throws `OpenServiceRemoteCommandUnhandledError` with attach-specific guidance.
+rebuild through `service-error-serialization.ts`. If the instance reports the command unhandled
+(`services:command-unhandled` — it does not register the service or the command's handler), the
+caller throws `OpenServiceRemoteCommandConfigDriftError` immediately with restart guidance. If no
+implementer acknowledges within the ack timeout, the caller throws
+`OpenServiceRemoteCommandUnhandledError` with attach-specific guidance.
 
 See [Delegated mode](../../shared/open-service/README.md#delegated-mode).
 
@@ -137,12 +140,13 @@ Messages name the exact corrective command.
 | Stale record / connection refused | WS connect fails                      | Registry cleanup; fallback note                                                                  |
 | Server started before upgrade     | Instance-cwd package ≠ record version | Both version strings; restart Storybook                                                          |
 | Spawn resolution failure          | No `storybook` under `record.cwd`     | `SpawnFailedError` remediation; local fallback                                                   |
+| Config drift                      | Instance reports command unhandled    | Attached Storybook has no handler for the command — restart it with a matching configuration     |
 | Unacknowledged command            | Remote command ack timeout            | Attached Storybook did not acknowledge in time; the command may still have executed — retry      |
 
-Rows other than the unacknowledged command are factory-time attach gates. In `auto`, those return a
-local host and a fallback notice (omitted from `--json` output). Under `--attach`, they are hard
-errors with the same text. An unacknowledged command is a post-attach `tools.call` failure: `auto`
-does not fall back then.
+Rows other than the last two are factory-time attach gates. In `auto`, those return a local host
+and a fallback notice (omitted from `--json` output). Under `--attach`, they are hard errors with
+the same text. Config drift and an unacknowledged command are post-attach `tools.call` failures:
+`auto` does not fall back then.
 
 ## Limits
 

--- a/code/core/src/server-errors.ts
+++ b/code/core/src/server-errors.ts
@@ -299,6 +299,17 @@ export class OpenServiceRemoteCommandUnhandledError extends StorybookError {
   }
 }
 
+export class OpenServiceRemoteCommandConfigDriftError extends StorybookError {
+  constructor(public data: { serviceId: ServiceId; commandName: string }) {
+    super({
+      name: 'OpenServiceRemoteCommandConfigDriftError',
+      category: Category.CORE_COMMON,
+      code: 30,
+      message: `The Storybook this runtime is attached to reported it has no handler for remote command "${data.serviceId}.${data.commandName}". The two processes are running different configurations (for example a feature flag enabled in one but not the other). Restart the attached Storybook with a configuration matching this process.`,
+    });
+  }
+}
+
 export class OpenServiceOperationNameCollisionError extends StorybookError {
   constructor(public data: { serviceId: ServiceId; operationName: string }) {
     super({

--- a/code/core/src/server-errors.ts
+++ b/code/core/src/server-errors.ts
@@ -293,7 +293,7 @@ export class OpenServiceRemoteCommandUnhandledError extends StorybookError {
       category: Category.CORE_COMMON,
       code: 15,
       message: data.delegated
-        ? `No runtime acknowledged remote command "${data.serviceId}.${data.commandName}"; this runtime delegates every command to the Storybook it is attached to, and that Storybook was started with a different configuration. Restart it so the command's handler is available.`
+        ? `The Storybook this runtime is attached to did not acknowledge remote command "${data.serviceId}.${data.commandName}" in time — it may be busy or unreachable. Retry; note the command may still have executed on that instance.`
         : `No runtime acknowledged remote command "${data.serviceId}.${data.commandName}"; its handler is not implemented in any connected runtime.`,
     });
   }

--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -730,11 +730,12 @@ All four events are namespaced under `services:` and carry the `serviceId` so a 
 several services routes them correctly.
 
 | Event | Direction | Payload |
-| ------------------------- | ------------------------ | ----------------------------------------------------- |
-| `services:command-invoke` | requester → implementers | `{ serviceId, commandName, input, callId, clientId }` |
-| `services:command-ack`    | implementer → requester  | `{ serviceId, callId, clientId }`                     |
-| `services:command-result` | implementer → requester  | `{ serviceId, callId, result, clientId }`             |
-| `services:command-error`  | implementer → requester  | `{ serviceId, callId, error, clientId }`              |
+| ---------------------------- | -------------------------- | ----------------------------------------------------- |
+| `services:command-invoke`    | requester → implementers   | `{ serviceId, commandName, input, callId, clientId }` |
+| `services:command-ack`       | implementer → requester    | `{ serviceId, callId, clientId }`                     |
+| `services:command-result`    | implementer → requester    | `{ serviceId, callId, result, clientId }`             |
+| `services:command-error`     | implementer → requester    | `{ serviceId, callId, error, clientId }`              |
+| `services:command-unhandled` | non-implementer → requester | `{ serviceId, callId, clientId }`                     |
 
 - `callId` is the per-invocation correlation id (see [Correlation and parallel calls](#correlation-and-parallel-calls)).
 - `clientId` is the id of the runtime that emitted the envelope — the requester on an invoke, the
@@ -813,6 +814,14 @@ query's `load` calls a server-only command. Once a peer acknowledges, the reques
 `services:command-result` or `services:command-error` as before. Unregistering the service still
 rejects outstanding calls with `OpenServiceRemoteCommandDisconnectedError`.
 
+A peer that receives an invoke it cannot dispatch does not stay silent: a non-delegated runtime
+replies `services:command-unhandled` — per-service when it hosts the service but lacks that
+command's handler, and realm-globally (one reporter installed by the registry) when the service id
+is not registered at all. Non-delegated requesters ignore the reply: with no peer registry, one
+peer's report cannot speak for the others (a preview legitimately cannot dispatch a server-only
+command that the server will answer), so absence-of-ack stays their only signal. Only a
+[delegated](#delegated-mode) requester acts on it — see below.
+
 ### Delegated mode
 
 A runtime that attaches to an already-running Storybook (rather than starting its own) must not
@@ -838,11 +847,21 @@ What changes is **dispatch**, not registration:
 The flag is runtime-wide and read at registration time, like the installed channel, so set it once at
 the entry boundary before the first `registerService` call. `clearRegistry()` resets it.
 
-When nothing acknowledges within `REMOTE_COMMAND_ACK_TIMEOUT_MS`, the resulting
-`OpenServiceRemoteCommandUnhandledError` carries delegation-specific guidance instead of "not
-implemented in any connected runtime": the attached Storybook did not acknowledge the command in
-time (it may be busy or unreachable), and — delivery being at-least-once — the command may still
-have executed there, which a retry should take into account.
+Genuine configuration drift — the attached Storybook does not register the service or the command
+this runtime's configuration does — is reported positively rather than inferred: command events are
+not relayed across a hub's transports, so the attached instance is the only runtime that ever sees
+a delegated caller's invoke, and its `services:command-unhandled` reply is authoritative. The
+delegated requester rejects immediately with `OpenServiceRemoteCommandConfigDriftError`, whose
+message names the command and gives the restart guidance that is now known to be correct. An older
+instance never sends the reply — as does one that registered no services at all (the reporter
+installs with the first registration) or one asked about an id it registered earlier (mid-HMR
+re-registration) — and each of those degrades to the timeout below.
+
+When nothing acknowledges within `REMOTE_COMMAND_ACK_TIMEOUT_MS` (and no unhandled reply arrived),
+the resulting `OpenServiceRemoteCommandUnhandledError` carries delegation-specific guidance instead
+of "not implemented in any connected runtime": the attached Storybook did not acknowledge the
+command in time (it may be busy or unreachable), and — delivery being at-least-once — the command
+may still have executed there, which a retry should take into account.
 
 The `storybook tools` SDK is the attached caller: it sets this flag, then loads the instance
 config. See [cli/tools/architecture.md](../../cli/tools/architecture.md).

--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -726,7 +726,7 @@ how dispatch reaches the Storybook it attached to.
 
 ### Events
 
-All four events are namespaced under `services:` and carry the `serviceId` so a runtime that hosts
+All command events are namespaced under `services:` and carry the `serviceId` so a runtime that hosts
 several services routes them correctly.
 
 | Event | Direction | Payload |

--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -712,9 +712,12 @@ Every registered runtime plays **both** roles at once, decided per command:
   first `services:command-result` for that `callId`, or rejects with the reconstructed error from the
   first `services:command-error`.
 - **Responder** (has a local handler): on a matching `services:command-invoke` it emits
-  `services:command-ack` **immediately** (before running), executes the command locally — which
+  `services:command-ack` **immediately** (before running), then executes the command locally on a
+  deferred macrotask — so an async channel flushes the ack before any handler work starts, keeping
+  acks within the window regardless of how long a handler's synchronous fan-out runs. Execution
   validates input, mutates state, and broadcasts the post-mutation snapshot through the normal command
-  wrappers so every peer converges — then emits `services:command-result` or `services:command-error`.
+  wrappers so every peer converges — then it emits `services:command-result` or
+  `services:command-error`.
 
 Outside [delegated mode](#delegated-mode), a runtime never requests a command it implements (it runs
 that locally), so a responder never answers its own invoke echo: `onInvoke` only acts on commands in
@@ -837,8 +840,9 @@ the entry boundary before the first `registerService` call. `clearRegistry()` re
 
 When nothing acknowledges within `REMOTE_COMMAND_ACK_TIMEOUT_MS`, the resulting
 `OpenServiceRemoteCommandUnhandledError` carries delegation-specific guidance instead of "not
-implemented in any connected runtime": the attached Storybook was started with a different
-configuration, so it must be restarted for that command's handler to exist.
+implemented in any connected runtime": the attached Storybook did not acknowledge the command in
+time (it may be busy or unreachable), and — delivery being at-least-once — the command may still
+have executed there, which a retry should take into account.
 
 The `storybook tools` SDK is the attached caller: it sets this flag, then loads the instance
 config. See [cli/tools/architecture.md](../../cli/tools/architecture.md).

--- a/code/core/src/shared/open-service/service-channel.ts
+++ b/code/core/src/shared/open-service/service-channel.ts
@@ -29,6 +29,7 @@ export const SERVICE_COMMAND_INVOKE = 'services:command-invoke' as const;
 export const SERVICE_COMMAND_ACK = 'services:command-ack' as const;
 export const SERVICE_COMMAND_RESULT = 'services:command-result' as const;
 export const SERVICE_COMMAND_ERROR = 'services:command-error' as const;
+export const SERVICE_COMMAND_UNHANDLED = 'services:command-unhandled' as const;
 
 /**
  * Channel payloads are untrusted input, so each event has a Valibot schema. Listeners narrow with
@@ -99,6 +100,18 @@ export const commandAckSchema = v.object({
   clientId: v.string(),
 });
 export type CommandAckPayload = v.InferOutput<typeof commandAckSchema>;
+
+/**
+ * Emitted by a non-delegated peer that received a `services:command-invoke` it cannot dispatch —
+ * a positive config-drift report that only a delegated requester acts on (see
+ * `connectCommandTransport`).
+ */
+export const commandUnhandledSchema = v.object({
+  serviceId: v.string(),
+  callId: v.string(),
+  clientId: v.string(),
+});
+export type CommandUnhandledPayload = v.InferOutput<typeof commandUnhandledSchema>;
 
 /** Sent by an implementing peer after a remote command resolves successfully. */
 export const commandResultSchema = v.object({

--- a/code/core/src/shared/open-service/service-command-transport.test.ts
+++ b/code/core/src/shared/open-service/service-command-transport.test.ts
@@ -24,10 +24,11 @@ import {
   SERVICE_PATCHES,
   type CommandErrorPayload,
   type CommandInvokePayload,
+  type ServiceChannel,
 } from './service-channel.ts';
 import { deserializeError } from './service-error-serialization.ts';
 import { clearRegistry, registerService, unregisterService } from './service-registry.ts';
-import { REMOTE_COMMAND_ACK_TIMEOUT_MS } from './service-transport.ts';
+import { REMOTE_COMMAND_ACK_TIMEOUT_MS, connectCommandTransport } from './service-transport.ts';
 import { createTestChannel, installTestChannel } from '../../channels/test-channel.ts';
 
 const remoteOnlyServiceDef = defineService({
@@ -354,6 +355,73 @@ describe('remote command responder (has local handler)', () => {
     expect(emittedCalls(channel, SERVICE_COMMAND_ACK)).toHaveLength(0);
     expect(emittedCalls(channel, SERVICE_COMMAND_RESULT)).toHaveLength(0);
   });
+});
+
+describe('ack delivery with a busy responder', () => {
+  // Models the dev server's channel (`async: true`): every emitted event needs an event-loop turn
+  // before it reaches the wire, like a websocket write behind `setImmediate`.
+  function createMacrotaskDeliveryChannel(): ServiceChannel {
+    const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+    return {
+      on: (eventName, listener) => {
+        const existing = listeners.get(eventName) ?? new Set();
+        existing.add(listener);
+        listeners.set(eventName, existing);
+      },
+      off: (eventName, listener) => {
+        listeners.get(eventName)?.delete(listener);
+      },
+      emit: (eventName, ...args) => {
+        setImmediate(() => {
+          listeners.get(eventName)?.forEach((listener) => listener(...args));
+        });
+      },
+    };
+  }
+
+  // retry: real timers are required here (the starvation is wall-clock), so an extreme scheduler
+  // stall could fire the ack window early; the regression itself fails deterministically.
+  it(
+    'resolves the requester when the responder handler occupies the microtask queue past the ack window',
+    { retry: 3 },
+    async () => {
+      const channel = createMacrotaskDeliveryChannel();
+      const serviceId = 'internal-fixture/busy-responder';
+
+      const requester = connectCommandTransport({
+        serviceId,
+        ownClientId: 'requester',
+        channel,
+        localCommands: {},
+        implementedCommandNames: new Set(),
+        commandNames: ['fanOut'],
+        delegated: false,
+      });
+      const responder = connectCommandTransport({
+        serviceId,
+        ownClientId: 'responder',
+        channel,
+        localCommands: {
+          fanOut: async (input) => {
+            const end = Date.now() + REMOTE_COMMAND_ACK_TIMEOUT_MS + 100;
+            while (Date.now() < end) {
+              await Promise.resolve();
+            }
+            return `fanned-out:${(input as { value: string }).value}`;
+          },
+        },
+        implementedCommandNames: new Set(['fanOut']),
+        commandNames: ['fanOut'],
+        delegated: false,
+      });
+      onTestFinished(() => {
+        requester.disconnect();
+        responder.disconnect();
+      });
+
+      await expect(requester.commands.fanOut({ value: 'all' })).resolves.toBe('fanned-out:all');
+    }
+  );
 });
 
 describe('load bodies and command routing', () => {

--- a/code/core/src/shared/open-service/service-command-transport.test.ts
+++ b/code/core/src/shared/open-service/service-command-transport.test.ts
@@ -21,6 +21,7 @@ import {
   SERVICE_COMMAND_ERROR,
   SERVICE_COMMAND_INVOKE,
   SERVICE_COMMAND_RESULT,
+  SERVICE_COMMAND_UNHANDLED,
   SERVICE_PATCHES,
   type CommandErrorPayload,
   type CommandInvokePayload,
@@ -335,11 +336,11 @@ describe('remote command responder (has local handler)', () => {
     expect((restored.cause as Error).message).toBe('root cause');
   });
 
-  it('ignores invokes for commands it does not implement', async () => {
+  it('reports an invoke for a hosted command it does not implement instead of acking', async () => {
     const channel = createTestChannel();
     installTestChannel(channel);
 
-    // This runtime has no local handler for `doThing`, so it must not answer the invoke.
+    // This runtime has no local handler for `doThing`, so it must report rather than answer.
     registerService(remoteOnlyServiceDef);
 
     channel.emitExternal(SERVICE_COMMAND_INVOKE, {
@@ -354,31 +355,41 @@ describe('remote command responder (has local handler)', () => {
 
     expect(emittedCalls(channel, SERVICE_COMMAND_ACK)).toHaveLength(0);
     expect(emittedCalls(channel, SERVICE_COMMAND_RESULT)).toHaveLength(0);
+    expect(emittedCalls(channel, SERVICE_COMMAND_UNHANDLED)).toEqual([
+      [
+        SERVICE_COMMAND_UNHANDLED,
+        expect.objectContaining({
+          serviceId: remoteOnlyServiceDef.id,
+          callId: 'call-unhandled',
+          clientId: expect.any(String),
+        }),
+      ],
+    ]);
   });
 });
 
-describe('ack delivery with a busy responder', () => {
-  // Models the dev server's channel (`async: true`): every emitted event needs an event-loop turn
-  // before it reaches the wire, like a websocket write behind `setImmediate`.
-  function createMacrotaskDeliveryChannel(): ServiceChannel {
-    const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
-    return {
-      on: (eventName, listener) => {
-        const existing = listeners.get(eventName) ?? new Set();
-        existing.add(listener);
-        listeners.set(eventName, existing);
-      },
-      off: (eventName, listener) => {
-        listeners.get(eventName)?.delete(listener);
-      },
-      emit: (eventName, ...args) => {
-        setImmediate(() => {
-          listeners.get(eventName)?.forEach((listener) => listener(...args));
-        });
-      },
-    };
-  }
+// Models the dev server's channel (`async: true`): every emitted event needs an event-loop turn
+// before it reaches the wire, like a websocket write behind `setImmediate`.
+function createMacrotaskDeliveryChannel(): ServiceChannel {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  return {
+    on: (eventName, listener) => {
+      const existing = listeners.get(eventName) ?? new Set();
+      existing.add(listener);
+      listeners.set(eventName, existing);
+    },
+    off: (eventName, listener) => {
+      listeners.get(eventName)?.delete(listener);
+    },
+    emit: (eventName, ...args) => {
+      setImmediate(() => {
+        listeners.get(eventName)?.forEach((listener) => listener(...args));
+      });
+    },
+  };
+}
 
+describe('ack delivery with a busy responder', () => {
   // retry: real timers are required here (the starvation is wall-clock), so an extreme scheduler
   // stall could fire the ack window early; the regression itself fails deterministically.
   it(
@@ -422,6 +433,106 @@ describe('ack delivery with a busy responder', () => {
       await expect(requester.commands.fanOut({ value: 'all' })).resolves.toBe('fanned-out:all');
     }
   );
+});
+
+describe('command-unhandled reporting', () => {
+  it('rejects a delegated requester promptly when the peer reports the command unhandled', async () => {
+    const channel = createMacrotaskDeliveryChannel();
+    const serviceId = 'internal-fixture/drifted-instance';
+
+    const requester = connectCommandTransport({
+      serviceId,
+      ownClientId: 'requester',
+      channel,
+      localCommands: {},
+      implementedCommandNames: new Set(),
+      commandNames: ['fanOut'],
+      delegated: true,
+    });
+    const responder = connectCommandTransport({
+      serviceId,
+      ownClientId: 'responder',
+      channel,
+      localCommands: {},
+      implementedCommandNames: new Set(),
+      commandNames: ['fanOut'],
+      delegated: false,
+    });
+    onTestFinished(() => {
+      requester.disconnect();
+      responder.disconnect();
+    });
+
+    await expect(requester.commands.fanOut({ value: 'all' })).rejects.toThrow(
+      'reported it has no handler for remote command "internal-fixture/drifted-instance.fanOut"'
+    );
+  });
+
+  it('does not report a service id this realm registered earlier', async () => {
+    const channel = createTestChannel();
+    installTestChannel(channel);
+
+    registerService(remoteOnlyServiceDef);
+    unregisterService(remoteOnlyServiceDef.id);
+
+    channel.emitExternal(SERVICE_COMMAND_INVOKE, {
+      serviceId: remoteOnlyServiceDef.id,
+      commandName: 'doThing',
+      input: { value: 'hi' },
+      callId: 'call-mid-hmr',
+      clientId: 'requester',
+    });
+
+    expect(emittedCalls(channel, SERVICE_COMMAND_UNHANDLED)).toHaveLength(0);
+  });
+
+  it('still resolves a non-delegated requester when another peer answers after an unhandled report', async () => {
+    const channel = createTestChannel();
+    installTestChannel(channel);
+
+    const service = registerService(remoteOnlyServiceDef);
+    const promise = service.commands.doThing({ value: 'hi' });
+
+    const { callId } = emittedCalls(channel, SERVICE_COMMAND_INVOKE)[0][1] as CommandInvokePayload;
+    channel.emitExternal(SERVICE_COMMAND_UNHANDLED, {
+      serviceId: remoteOnlyServiceDef.id,
+      callId,
+      clientId: 'peer-without-handler',
+    });
+    channel.emitExternal(SERVICE_COMMAND_RESULT, {
+      serviceId: remoteOnlyServiceDef.id,
+      callId,
+      result: 'done',
+      clientId: 'peer-with-handler',
+    });
+
+    await expect(promise).resolves.toBe('done');
+  });
+
+  it('reports an invoke for a service this realm does not register at all', async () => {
+    const channel = createTestChannel();
+    installTestChannel(channel);
+
+    registerService(remoteOnlyServiceDef);
+
+    channel.emitExternal(SERVICE_COMMAND_INVOKE, {
+      serviceId: 'other/never-registered',
+      commandName: 'doThing',
+      input: {},
+      callId: 'call-unknown-service',
+      clientId: 'requester',
+    });
+
+    expect(emittedCalls(channel, SERVICE_COMMAND_UNHANDLED)).toEqual([
+      [
+        SERVICE_COMMAND_UNHANDLED,
+        expect.objectContaining({
+          serviceId: 'other/never-registered',
+          callId: 'call-unknown-service',
+        }),
+      ],
+    ]);
+  });
 });
 
 describe('load bodies and command routing', () => {

--- a/code/core/src/shared/open-service/service-delegated-mode.test.ts
+++ b/code/core/src/shared/open-service/service-delegated-mode.test.ts
@@ -3,12 +3,16 @@ import * as v from 'valibot';
 import { afterEach, describe, expect, it, onTestFinished, vi } from 'vitest';
 
 import { createTestChannel, installTestChannel } from '../../channels/test-channel.ts';
-import { OpenServiceRemoteCommandUnhandledError } from '../../server-errors.ts';
+import {
+  OpenServiceRemoteCommandConfigDriftError,
+  OpenServiceRemoteCommandUnhandledError,
+} from '../../server-errors.ts';
 import { mutableRecordLookupServiceDef } from './fixtures.ts';
 import {
   SERVICE_COMMAND_ACK,
   SERVICE_COMMAND_INVOKE,
   SERVICE_COMMAND_RESULT,
+  SERVICE_COMMAND_UNHANDLED,
   SERVICE_PATCHES,
   type CommandInvokePayload,
 } from './service-channel.ts';
@@ -185,7 +189,31 @@ describe('delegated command dispatch', () => {
 
     expect(emittedCalls(channel, SERVICE_COMMAND_ACK)).toHaveLength(0);
     expect(emittedCalls(channel, SERVICE_COMMAND_RESULT)).toHaveLength(0);
+    expect(emittedCalls(channel, SERVICE_COMMAND_UNHANDLED)).toHaveLength(0);
     expect(handlerSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects with config-drift guidance when the peer reports the command unhandled', async () => {
+    const channel = createTestChannel();
+    installTestChannel(channel);
+
+    setDelegatedMode(true);
+    const service = registerService(locallyImplementedServiceDef);
+
+    const promise = service.commands.doThing({ value: 'hi' });
+
+    const { callId } = emittedCalls(channel, SERVICE_COMMAND_INVOKE)[0][1] as CommandInvokePayload;
+    channel.emitExternal(SERVICE_COMMAND_UNHANDLED, {
+      serviceId: locallyImplementedServiceDef.id,
+      callId,
+      clientId: 'instance',
+    });
+
+    const error = await promise.catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(OpenServiceRemoteCommandConfigDriftError);
+    expect((error as Error).message).toBe(
+      'The Storybook this runtime is attached to reported it has no handler for remote command "internal-fixture/delegated-local-implementation.doThing". The two processes are running different configurations (for example a feature flag enabled in one but not the other). Restart the attached Storybook with a configuration matching this process.'
+    );
   });
 
   it('rejects with an unacknowledged-command error when no peer acknowledges the invoke', async () => {

--- a/code/core/src/shared/open-service/service-delegated-mode.test.ts
+++ b/code/core/src/shared/open-service/service-delegated-mode.test.ts
@@ -188,7 +188,7 @@ describe('delegated command dispatch', () => {
     expect(handlerSpy).not.toHaveBeenCalled();
   });
 
-  it('rejects with restart guidance when no peer acknowledges the invoke', async () => {
+  it('rejects with an unacknowledged-command error when no peer acknowledges the invoke', async () => {
     vi.useFakeTimers();
 
     const channel = createTestChannel();
@@ -203,7 +203,7 @@ describe('delegated command dispatch', () => {
     const error = await failure;
     expect(error).toBeInstanceOf(OpenServiceRemoteCommandUnhandledError);
     expect((error as Error).message).toBe(
-      'No runtime acknowledged remote command "internal-fixture/delegated-local-implementation.doThing"; this runtime delegates every command to the Storybook it is attached to, and that Storybook was started with a different configuration. Restart it so the command\'s handler is available.'
+      'The Storybook this runtime is attached to did not acknowledge remote command "internal-fixture/delegated-local-implementation.doThing" in time — it may be busy or unreachable. Retry; note the command may still have executed on that instance.'
     );
   });
 

--- a/code/core/src/shared/open-service/service-registry.ts
+++ b/code/core/src/shared/open-service/service-registry.ts
@@ -22,10 +22,10 @@ import {
   OpenServiceMissingServiceError,
   OpenServiceOperationNameCollisionError,
 } from '../../server-errors.ts';
-import { generateClientId } from './service-channel.ts';
+import { type ServiceChannel, generateClientId } from './service-channel.ts';
 import { createServiceRuntime } from './service-runtime.ts';
 import { createSnapshotReconciler } from './service-sync.ts';
-import { connectServiceToChannel } from './service-transport.ts';
+import { connectServiceToChannel, connectUnknownServiceReporter } from './service-transport.ts';
 import type { StaticLoader } from './static-fetch.ts';
 import type {
   AnyServiceDefinition,
@@ -57,6 +57,15 @@ const REGISTRY_SYMBOL = Symbol.for('storybook.open-service.registry');
 type RegistryInventory = {
   entries: Map<string, RegistryEntry>;
   delegatedMode: boolean;
+  /**
+   * Every id this realm has ever registered. The unknown-service reporter must not report an id
+   * that is merely mid-HMR (unregistered and about to re-register): a false report converts a
+   * transient into config-drift restart guidance, while staying silent only degrades to the
+   * retryable timeout error.
+   */
+  everRegisteredIds: Set<string>;
+  /** The realm's unknown-service reporter, keyed to the channel it listens on. */
+  unknownServiceReporter?: { channel: ServiceChannel; disconnect: () => void };
 };
 
 /**
@@ -74,6 +83,7 @@ function getInventory(): RegistryInventory {
   registryGlobal[REGISTRY_SYMBOL] ??= {
     entries: new Map<string, RegistryEntry>(),
     delegatedMode: false,
+    everRegisteredIds: new Set<string>(),
   };
 
   return registryGlobal[REGISTRY_SYMBOL];
@@ -99,6 +109,26 @@ export function setDelegatedMode(enabled: boolean): void {
 /** Whether this runtime delegates command dispatch to the Storybook it is attached to. */
 export function isDelegatedMode(): boolean {
   return getInventory().delegatedMode;
+}
+
+// One reporter per realm answers invokes for service ids nothing here registers (the whole-service
+// config-drift shape, which no per-service transport can see). Keyed to the channel so swapping
+// channels (tests, teardown/re-install) re-attaches it instead of leaking listeners.
+function ensureUnknownServiceReporter(channel: ServiceChannel): void {
+  const inventory = getInventory();
+  if (inventory.unknownServiceReporter?.channel === channel) {
+    return;
+  }
+
+  inventory.unknownServiceReporter?.disconnect();
+  inventory.unknownServiceReporter = {
+    channel,
+    disconnect: connectUnknownServiceReporter({
+      channel,
+      isServiceRegistered: (serviceId) => inventory.everRegisteredIds.has(serviceId),
+      isDelegated: () => inventory.delegatedMode,
+    }),
+  };
 }
 
 function assertUniqueOperationNames(definition: AnyServiceDefinition): void {
@@ -304,6 +334,9 @@ export function registerService<
     throw new OpenServiceMissingChannelError({ serviceId: definition.id });
   }
 
+  getInventory().everRegisteredIds.add(definition.id);
+  ensureUnknownServiceReporter(channel);
+
   // A command may only have a handler in some runtimes (e.g. supplied at server registration). Where
   // a local handler exists, callers run it locally and broadcast; where it does not, the resulting
   // command routes calls to a peer that implements it and awaits the reply. A delegated runtime
@@ -423,12 +456,15 @@ export function unregisterService(serviceId: ServiceId): void {
  * — from one scenario do not leak into the next.
  */
 export function clearRegistry(): void {
-  const registry = getRegistry();
+  const inventory = getInventory();
 
-  for (const entry of registry.values()) {
+  for (const entry of inventory.entries.values()) {
     entry.disconnect();
   }
 
-  registry.clear();
-  getInventory().delegatedMode = false;
+  inventory.entries.clear();
+  inventory.delegatedMode = false;
+  inventory.everRegisteredIds.clear();
+  inventory.unknownServiceReporter?.disconnect();
+  inventory.unknownServiceReporter = undefined;
 }

--- a/code/core/src/shared/open-service/service-transport.ts
+++ b/code/core/src/shared/open-service/service-transport.ts
@@ -76,6 +76,11 @@ type RuntimeCommand = (input: unknown) => Promise<unknown>;
  * case the requester rejects with `OpenServiceRemoteCommandUnhandledError` even though the command
  * still ran and broadcast its mutation. Remote command execution is therefore best-effort /
  * at-least-once, not exactly-once: callers must not assume a rejection means nothing happened.
+ *
+ * The window assumes an ack reaches the wire promptly, which ack-then-execute alone does not
+ * guarantee: on an async channel the emitted ack needs an event-loop turn, which the responder's
+ * own handler can starve for the length of its synchronous prefix. Deferring handler execution to
+ * a macrotask (see `onInvoke`) is what keeps acks inside the window regardless of the handler.
  */
 export const REMOTE_COMMAND_ACK_TIMEOUT_MS = 300;
 
@@ -267,8 +272,9 @@ export function connectRuntimeToChannel(
  *   `services:command-result` for that `callId`, or rejects with the (deserialized) error from the
  *   first `services:command-error`.
  * - **Responder** (has a local handler): on a matching `services:command-invoke` it emits
- *   `services:command-ack` immediately, runs the command locally (which also broadcasts the
- *   post-mutation state via the broadcast wrappers, so peers converge as usual), then emits
+ *   `services:command-ack` immediately, runs the command locally on a deferred macrotask — so an
+ *   async channel flushes the ack before any handler work starts (which also broadcasts the
+ *   post-mutation state via the broadcast wrappers, so peers converge as usual) — then emits
  *   `services:command-result` or `services:command-error`.
  *
  * Both roles coexist on one runtime: it responds for the commands it implements and requests the
@@ -361,26 +367,31 @@ export function connectCommandTransport(context: {
       clientId: ownClientId,
     } satisfies CommandAckPayload);
 
-    void Promise.resolve()
-      .then(() => localCommands[invoke.commandName](invoke.input))
-      .then(
-        (result) => {
-          channel.emit(SERVICE_COMMAND_RESULT, {
-            serviceId,
-            callId: invoke.callId,
-            result,
-            clientId: ownClientId,
-          } satisfies CommandResultPayload);
-        },
-        (error: unknown) => {
-          channel.emit(SERVICE_COMMAND_ERROR, {
-            serviceId,
-            callId: invoke.callId,
-            error: serializeError(error),
-            clientId: ownClientId,
-          } satisfies CommandErrorPayload);
-        }
-      );
+    // On an async channel the emitted ack still needs an event-loop turn to reach the wire, so the
+    // handler starts on a macrotask: a microtask start would starve that turn for as long as the
+    // handler's synchronous prefix runs (a fan-out over hundreds of components outlives the window).
+    setTimeout(() => {
+      void Promise.resolve()
+        .then(() => localCommands[invoke.commandName](invoke.input))
+        .then(
+          (result) => {
+            channel.emit(SERVICE_COMMAND_RESULT, {
+              serviceId,
+              callId: invoke.callId,
+              result,
+              clientId: ownClientId,
+            } satisfies CommandResultPayload);
+          },
+          (error: unknown) => {
+            channel.emit(SERVICE_COMMAND_ERROR, {
+              serviceId,
+              callId: invoke.callId,
+              error: serializeError(error),
+              clientId: ownClientId,
+            } satisfies CommandErrorPayload);
+          }
+        );
+    }, 0);
   };
 
   // Requester: resolve/reject the pending promise for a reply addressed to one of our calls.

--- a/code/core/src/shared/open-service/service-transport.ts
+++ b/code/core/src/shared/open-service/service-transport.ts
@@ -29,6 +29,7 @@
 import * as v from 'valibot';
 
 import {
+  OpenServiceRemoteCommandConfigDriftError,
   OpenServiceRemoteCommandDisconnectedError,
   OpenServiceRemoteCommandUnhandledError,
 } from '../../server-errors.ts';
@@ -37,6 +38,7 @@ import {
   SERVICE_COMMAND_ERROR,
   SERVICE_COMMAND_INVOKE,
   SERVICE_COMMAND_RESULT,
+  SERVICE_COMMAND_UNHANDLED,
   SERVICE_PATCHES,
   SERVICE_SYNC_START,
   SERVICE_SYNC_START_REPLY,
@@ -44,6 +46,7 @@ import {
   type CommandErrorPayload,
   type CommandInvokePayload,
   type CommandResultPayload,
+  type CommandUnhandledPayload,
   type PatchesPayload,
   type ServiceChannel,
   type SyncStartPayload,
@@ -52,6 +55,7 @@ import {
   commandErrorSchema,
   commandInvokeSchema,
   commandResultSchema,
+  commandUnhandledSchema,
   generateClientId,
   stampedSnapshotSchema,
   syncStartSchema,
@@ -276,6 +280,11 @@ export function connectRuntimeToChannel(
  *   async channel flushes the ack before any handler work starts (which also broadcasts the
  *   post-mutation state via the broadcast wrappers, so peers converge as usual) — then emits
  *   `services:command-result` or `services:command-error`.
+ * - **Non-implementer**: a non-delegated runtime that hosts the service but not the invoked
+ *   command's handler replies `services:command-unhandled` instead of staying silent. Only a
+ *   delegated requester acts on that reply (rejecting with config-drift guidance, since the
+ *   Storybook it attached to is the only runtime that sees its invokes); other requesters ignore
+ *   it, because one peer's report cannot speak for the others.
  *
  * Both roles coexist on one runtime: it responds for the commands it implements and requests the
  * ones it does not. A runtime never requests a command it implements (it runs that locally), so it
@@ -352,14 +361,24 @@ export function connectCommandTransport(context: {
   // Responder: run a locally-implemented command on a peer's request and reply with the outcome.
   const onInvoke = (payload: unknown): void => {
     const parsed = v.safeParse(commandInvokeSchema, payload);
-    if (
-      !parsed.success ||
-      parsed.output.serviceId !== serviceId ||
-      !dispatchesLocally(parsed.output.commandName)
-    ) {
+    if (!parsed.success || parsed.output.serviceId !== serviceId) {
       return;
     }
     const invoke = parsed.output;
+
+    if (!dispatchesLocally(invoke.commandName)) {
+      // A hosted service without this command's handler is a positive config-drift signal for a
+      // delegated caller. A delegated runtime answers no invokes, and a runtime that requested a
+      // command remotely must not report its own echo.
+      if (!delegated && invoke.clientId !== ownClientId) {
+        channel.emit(SERVICE_COMMAND_UNHANDLED, {
+          serviceId,
+          callId: invoke.callId,
+          clientId: ownClientId,
+        } satisfies CommandUnhandledPayload);
+      }
+      return;
+    }
 
     channel.emit(SERVICE_COMMAND_ACK, {
       serviceId,
@@ -425,10 +444,29 @@ export function connectCommandTransport(context: {
     clearTimeout(entry.noAckTimer);
   };
 
+  // Only for a delegated requester is one peer's report authoritative (the attached Storybook is
+  // the only runtime that sees its invokes); elsewhere absence-of-ack stays the only signal.
+  const onUnhandled = (payload: unknown): void => {
+    const report = v.safeParse(commandUnhandledSchema, payload);
+    if (!report.success || report.output.serviceId !== serviceId || !delegated) {
+      return;
+    }
+
+    settle(report.output.callId, (entry) =>
+      entry.reject(
+        new OpenServiceRemoteCommandConfigDriftError({
+          serviceId,
+          commandName: entry.commandName,
+        })
+      )
+    );
+  };
+
   channel.on(SERVICE_COMMAND_INVOKE, onInvoke);
   channel.on(SERVICE_COMMAND_RESULT, onResult);
   channel.on(SERVICE_COMMAND_ERROR, onError);
   channel.on(SERVICE_COMMAND_ACK, onAck);
+  channel.on(SERVICE_COMMAND_UNHANDLED, onUnhandled);
 
   const requestRemote = (commandName: string, input: unknown): Promise<unknown> => {
     const callId = generateClientId();
@@ -473,6 +511,7 @@ export function connectCommandTransport(context: {
       channel.off(SERVICE_COMMAND_RESULT, onResult);
       channel.off(SERVICE_COMMAND_ERROR, onError);
       channel.off(SERVICE_COMMAND_ACK, onAck);
+      channel.off(SERVICE_COMMAND_UNHANDLED, onUnhandled);
 
       // Fail any still-pending remote calls so awaiters don't hang forever past teardown.
       for (const [, entry] of pending) {
@@ -481,6 +520,45 @@ export function connectCommandTransport(context: {
       }
       pending.clear();
     },
+  };
+}
+
+/**
+ * Reports invokes for service ids this realm does not register at all.
+ *
+ * The per-service transport can only speak for services it hosts, but the common config-drift
+ * shape — a feature flag gating a whole service — leaves the invoke with no listener at all. One
+ * realm-global listener closes that gap: a non-delegated realm replies `services:command-unhandled`
+ * for any invoke whose service id it has never registered, so a delegated caller learns the drift
+ * positively instead of waiting out the ack window. Delegated realms answer nothing, a realm never
+ * reports its own invokes (they are only ever for services it registers), and an id that was
+ * registered before (mid-HMR re-registration) is not reported — staying silent degrades to the
+ * retryable timeout error, while a false report would hand out restart guidance for a transient.
+ */
+export function connectUnknownServiceReporter(context: {
+  channel: ServiceChannel;
+  isServiceRegistered: (serviceId: ServiceId) => boolean;
+  isDelegated: () => boolean;
+}): () => void {
+  const { channel, isServiceRegistered, isDelegated } = context;
+  const ownClientId = generateClientId();
+
+  const onInvoke = (payload: unknown): void => {
+    const parsed = v.safeParse(commandInvokeSchema, payload);
+    if (!parsed.success || isDelegated() || isServiceRegistered(parsed.output.serviceId)) {
+      return;
+    }
+
+    channel.emit(SERVICE_COMMAND_UNHANDLED, {
+      serviceId: parsed.output.serviceId,
+      callId: parsed.output.callId,
+      clientId: ownClientId,
+    } satisfies CommandUnhandledPayload);
+  };
+
+  channel.on(SERVICE_COMMAND_INVOKE, onInvoke);
+  return (): void => {
+    channel.off(SERVICE_COMMAND_INVOKE, onInvoke);
   };
 }
 

--- a/code/core/src/shared/open-service/service-transport.ts
+++ b/code/core/src/shared/open-service/service-transport.ts
@@ -389,6 +389,9 @@ export function connectCommandTransport(context: {
     // On an async channel the emitted ack still needs an event-loop turn to reach the wire, so the
     // handler starts on a macrotask: a microtask start would starve that turn for as long as the
     // handler's synchronous prefix runs (a fan-out over hundreds of components outlives the window).
+    // A timer, not `setImmediate`: an immediate would glue the handler to the same check phase as
+    // the deferred ack sends, starving the acks of sibling invokes read in the same poll batch (a
+    // docs listing issues the docgen and mdx fan-outs together); the timer waits one full turn.
     setTimeout(() => {
       void Promise.resolve()
         .then(() => localCommands[invoke.commandName](invoke.input))

--- a/code/e2e-internal/tools-attach.spec.ts
+++ b/code/e2e-internal/tools-attach.spec.ts
@@ -59,6 +59,10 @@ const REVIEW_INPUT = JSON.stringify({
 });
 
 test.describe('storybook tools attach', () => {
+  // Declaration order matters (the full-extraction test must stay last — see its comment), which
+  // the config's fullyParallel would not preserve outside CI's single worker. Not 'serial': these
+  // tests are independent, so one failure must not skip the rest.
+  test.describe.configure({ mode: 'default' });
   test.setTimeout(90_000);
 
   test('fails with start-Storybook guidance when --attach finds no instance', async () => {

--- a/code/e2e-internal/tools-attach.spec.ts
+++ b/code/e2e-internal/tools-attach.spec.ts
@@ -97,35 +97,6 @@ test.describe('storybook tools attach', () => {
     expect(review.exitCode, review.output).toBe(0);
   });
 
-  test('attached docs list succeeds through the instance docgen services', async ({ page }) => {
-    test.skip(
-      !runsAgainstDevServer,
-      'Live attach requires the running Storybook channel, which the static E2E job does not serve.'
-    );
-    await page.goto(process.env.STORYBOOK_URL || 'http://localhost:6006');
-    const docgenServerEnabled = await page.evaluate(() =>
-      Boolean(
-        (globalThis as { FEATURES?: { experimentalDocgenServer?: boolean } }).FEATURES
-          ?.experimentalDocgenServer
-      )
-    );
-    test.skip(
-      !docgenServerEnabled,
-      'Requires the internal Storybook started with STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER=true, as CI does.'
-    );
-    // Every per-component extraction broadcasts the full accumulated docgen state to each channel
-    // client, so leave the manager page before fanning out to spare the CI dev server that load.
-    await page.goto('about:blank');
-
-    // The env var makes the CLI's own config evaluation register the docgen services, so listing
-    // delegates the all-components extraction to the instance instead of reading local manifests.
-    const list = await runTools(['--attach', 'docs', 'list'], process.cwd(), {
-      STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER: 'true',
-    });
-    expect(list.exitCode, list.output).toBe(0);
-    expect(list.output).toContain('example-button');
-  });
-
   test('--attach still joins the running internal UI', async () => {
     test.skip(
       !runsAgainstDevServer,
@@ -181,6 +152,38 @@ test.describe('storybook tools attach', () => {
       ['--cwd', process.cwd(), 'docs', 'list'],
       join(process.cwd(), '..')
     );
+    expect(list.exitCode, list.output).toBe(0);
+    expect(list.output).toContain('example-button');
+  });
+
+  // Deliberately last: the first-ever full extraction leaves the instance holding (and syncing to
+  // later clients) an all-components state large enough to grind a small CI box, which failed the
+  // unrelated attach test that used to follow it. Tracked in #36105.
+  test('attached docs list succeeds through the instance docgen services', async ({ page }) => {
+    test.skip(
+      !runsAgainstDevServer,
+      'Live attach requires the running Storybook channel, which the static E2E job does not serve.'
+    );
+    await page.goto(process.env.STORYBOOK_URL || 'http://localhost:6006');
+    const docgenServerEnabled = await page.evaluate(() =>
+      Boolean(
+        (globalThis as { FEATURES?: { experimentalDocgenServer?: boolean } }).FEATURES
+          ?.experimentalDocgenServer
+      )
+    );
+    test.skip(
+      !docgenServerEnabled,
+      'Requires the internal Storybook started with STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER=true, as CI does.'
+    );
+    // Every per-component extraction broadcasts the full accumulated docgen state to each channel
+    // client, so leave the manager page before fanning out to spare the CI dev server that load.
+    await page.goto('about:blank');
+
+    // The env var makes the CLI's own config evaluation register the docgen services, so listing
+    // delegates the all-components extraction to the instance instead of reading local manifests.
+    const list = await runTools(['--attach', 'docs', 'list'], process.cwd(), {
+      STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER: 'true',
+    });
     expect(list.exitCode, list.output).toBe(0);
     expect(list.output).toContain('example-button');
   });

--- a/code/e2e-internal/tools-attach.spec.ts
+++ b/code/e2e-internal/tools-attach.spec.ts
@@ -97,6 +97,32 @@ test.describe('storybook tools attach', () => {
     expect(review.exitCode, review.output).toBe(0);
   });
 
+  test('attached docs list succeeds through the instance docgen services', async ({ page }) => {
+    test.skip(
+      !runsAgainstDevServer,
+      'Live attach requires the running Storybook channel, which the static E2E job does not serve.'
+    );
+    await page.goto(process.env.STORYBOOK_URL || 'http://localhost:6006');
+    const docgenServerEnabled = await page.evaluate(() =>
+      Boolean(
+        (globalThis as { FEATURES?: { experimentalDocgenServer?: boolean } }).FEATURES
+          ?.experimentalDocgenServer
+      )
+    );
+    test.skip(
+      !docgenServerEnabled,
+      'Requires the internal Storybook started with STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER=true, as CI does.'
+    );
+
+    // The env var makes the CLI's own config evaluation register the docgen services, so listing
+    // delegates the all-components extraction to the instance instead of reading local manifests.
+    const list = await runTools(['--attach', 'docs', 'list'], process.cwd(), {
+      STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER: 'true',
+    });
+    expect(list.exitCode, list.output).toBe(0);
+    expect(list.output).toContain('example-button');
+  });
+
   test('--attach still joins the running internal UI', async () => {
     test.skip(
       !runsAgainstDevServer,

--- a/code/e2e-internal/tools-attach.spec.ts
+++ b/code/e2e-internal/tools-attach.spec.ts
@@ -113,6 +113,9 @@ test.describe('storybook tools attach', () => {
       !docgenServerEnabled,
       'Requires the internal Storybook started with STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER=true, as CI does.'
     );
+    // Every per-component extraction broadcasts the full accumulated docgen state to each channel
+    // client, so leave the manager page before fanning out to spare the CI dev server that load.
+    await page.goto('about:blank');
 
     // The env var makes the CLI's own config evaluation register the docgen services, so listing
     // delegates the all-components extraction to the instance instead of reading local manifests.


### PR DESCRIPTION
Closes #36099

## What I did

Running `storybook tools docs list` against a dev server with `experimentalDocgenServer` enabled failed deterministically on any reasonably sized project. After ~5 seconds it claimed the server was "started with a different configuration" and told you to restart it. Neither was true — and restarting changed nothing.

### The bug

A remote command rejects when no ack arrives within 300ms. The responder did emit its ack before running the command — but it started the handler on a **microtask**, and on the dev server's async channel an emitted ack still needs an event-loop turn to reach the wire. `extractAllDocgen`'s synchronous fan-out ran as one long microtask drain before that turn, so the ack sat in the buffer for the whole fan-out. The drain grows with component count, which is why small projects passed and large ones failed every time. (Measurements in #36099.)

### The fix

The responder now starts the handler on a deferred **macrotask**, so the ack is flushed before any handler work begins. The 300ms window and the documented at-least-once semantics are unchanged.

### The error messages

The old message asserted one cause ("different configuration — restart") that the transport couldn't actually observe. Both cases now say what really happened:

**Instance busy or unreachable** (ack timeout, cause unknown):

> The Storybook this runtime is attached to did not acknowledge remote command "core/docgen.extractAllDocgen" in time — it may be busy or unreachable. Retry; note the command may still have executed on that instance.

**Genuine config drift** (new — detected, not guessed): a runtime that receives an invoke it cannot dispatch now reports that over the channel (`services:command-unhandled`) instead of staying silent. The attached CLI fails immediately — no 300ms wait — and the restart guidance returns, now only when it is true:

> The Storybook this runtime is attached to reported it has no handler for remote command "core/docgen.extractAllDocgen". The two processes are running different configurations (for example a feature flag enabled in one but not the other). Restart the attached Storybook with a configuration matching this process.

Only a delegated (attached) caller acts on the report — it is authoritative there because command events are never relayed, so the attached instance is the only runtime that sees the caller's invokes. Manager and preview ignore it, keeping browser semantics unchanged. Older instances never send it and degrade to the timeout message.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [x] end-to-end tests

**Unit** (transport level): a responder whose handler hogs the microtask queue past the ack window no longer fails the requester; a delegated requester rejects promptly on an unhandled report; hosted-but-unimplemented commands and never-registered service ids are both reported; a mid-HMR re-registered id is not (silence degrades to the retryable timeout, a false report would not); delegated runtimes stay silent; non-delegated requesters ignore reports. Both error messages are pinned in `server-errors.test.ts`.

**E2E**: `tools-attach.spec.ts` runs `--attach docs list` through the instance docgen services — the exact repro from the issue, against the internal Storybook's hundreds of components.

#### Manual testing

1. From `code/`: `STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER=true yarn storybook:ui`
2. From `code/`: `STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER=true node core/dist/bin/dispatcher.js tools --attach docs list`
3. Before this PR: exits 1 after ~5s with the false restart guidance. With it: prints the full component listing, exit 0.
4. Drift case: restart the server **without** the env var, rerun step 2 — it fails immediately with the config-drift message above.

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
