### PR TITLE
Addon Vitest: Resolve story test globs against the project root

### DIFF
--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -299,8 +299,16 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
       // )
 
       const testConfig = nonMutableInputConfig.test;
+      // Vitest resolves the story globs below against the root this plugin returns (via
+      // `viteFinal`), not the root it was invoked with. When those differ — a Vitest config
+      // above `configDir/..`, as in a monorepo — relativizing against the invoking root points
+      // every glob outside the project and silently matches no files.
       finalOptions.vitestRoot =
-        testConfig?.dir || testConfig?.root || nonMutableInputConfig.root || process.cwd();
+        testConfig?.dir ||
+        testConfig?.root ||
+        viteConfigFromStorybook.root ||
+        nonMutableInputConfig.root ||
+        process.cwd();
 
       const includeStories = stories
         .map((story) => {
@@ -319,6 +327,7 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
         });
 
       finalOptions.includeStories = includeStories;
+
       const projectId = oneWayHash(finalOptions.configDir);
 
       const areProjectAnnotationRequired = await requiresProjectAnnotations(

--- a/code/addons/vitest/src/vitest-plugin/vitest-root.test.ts
+++ b/code/addons/vitest/src/vitest-plugin/vitest-root.test.ts
@@ -1,79 +1,83 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { Plugin } from 'vitest/config';
+import { validateConfigurationFiles } from 'storybook/internal/common';
+import { StoryIndexGenerator, experimental_loadStorybook } from 'storybook/internal/core-server';
+import { isTelemetryModuleEnabled } from 'storybook/internal/telemetry';
+
+import { storybookTest } from './index.ts';
 
 const REPO_ROOT = '/repo';
 const PACKAGE_ROOT = '/repo/apps/storybook';
 const CONFIG_DIR = '/repo/apps/storybook/.storybook';
 
-const presetApply = vi.fn(async (key: string, fallback?: unknown) => {
-  switch (key) {
-    case 'stories':
-      return ['../stories/**/*.stories.tsx'];
-    case 'framework':
-      return { name: '@storybook/react-vite' };
-    // Mirrors a project without its own `viteFinal`: the common config is returned untouched,
-    // so the root the plugin proposes is the root it ends up returning.
-    case 'viteFinal':
-      return fallback;
-    case 'core':
-      return { disableTelemetry: true };
-    default:
-      return fallback;
-  }
+vi.mock('storybook/internal/common', { spy: true });
+vi.mock('storybook/internal/core-server', { spy: true });
+vi.mock('storybook/internal/telemetry', { spy: true });
+
+const presetApply = vi.fn();
+
+beforeEach(() => {
+  vi.stubEnv('VITEST', 'true');
+
+  presetApply.mockImplementation(async (key: string, fallback?: unknown) => {
+    switch (key) {
+      case 'stories':
+        return ['../stories/**/*.stories.tsx'];
+      case 'framework':
+        return { name: '@storybook/react-vite' };
+      // Mirrors a project without its own `viteFinal`: the common config is returned untouched,
+      // so the root the plugin proposes is the root it ends up returning.
+      case 'viteFinal':
+        return fallback;
+      case 'core':
+        return { disableTelemetry: true };
+      default:
+        return fallback;
+    }
+  });
+
+  vi.mocked(experimental_loadStorybook).mockResolvedValue({
+    presets: { apply: presetApply },
+  } as unknown as Awaited<ReturnType<typeof experimental_loadStorybook>>);
+  vi.mocked(StoryIndexGenerator.findMatchingFilesForSpecifiers).mockResolvedValue([]);
+  vi.mocked(validateConfigurationFiles).mockResolvedValue(undefined as never);
+  vi.mocked(isTelemetryModuleEnabled).mockReturnValue(false);
 });
 
-vi.mock('storybook/internal/core-server', () => ({
-  experimental_loadStorybook: vi.fn(async () => ({ presets: { apply: presetApply } })),
-  StoryIndexGenerator: {
-    findMatchingFilesForSpecifiers: vi.fn(async () => []),
-    storyFileNames: vi.fn(() => []),
-  },
-  Tag: { TEST: 'test' },
-  mapStaticDir: vi.fn(),
-}));
-
-vi.mock('storybook/internal/common', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('storybook/internal/common')>()),
-  validateConfigurationFiles: vi.fn(async () => {}),
-  getInterpretedFile: vi.fn(() => undefined),
-}));
-
-vi.mock('storybook/internal/telemetry', () => ({
-  detectAgent: vi.fn(() => undefined),
-  isTelemetryModuleEnabled: vi.fn(() => false),
-  isWithinInitialSession: vi.fn(async () => false),
-  oneWayHash: vi.fn(() => 'project-hash'),
-  telemetry: vi.fn(),
-  setTelemetryEnabled: vi.fn(),
-}));
-
-vi.mock('storybook/internal/csf-tools', () => ({
-  componentTransform: vi.fn(),
-  readConfig: vi.fn(),
-  vitestTransform: vi.fn(),
-}));
-
-const { storybookTest } = await import('./index.ts');
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 /** Runs the plugin's `config` hook the way Vitest does, and returns the config it contributes. */
 async function getPluginConfig(invokingRoot: string) {
   const plugins = await storybookTest({ configDir: CONFIG_DIR });
-  const plugin = plugins.find(
-    (p) => (p as Plugin)?.name === 'vite-plugin-storybook-test'
-  ) as Plugin;
+  const plugin = plugins.find((p) => p.name === 'vite-plugin-storybook-test')!;
 
   const configHook = plugin.config!;
   const handler = typeof configHook === 'function' ? configHook : configHook.handler;
 
-  return handler.call({}, { root: invokingRoot }, { command: 'serve', mode: 'development' });
+  const config = await handler.call(
+    {
+      meta: { rollupVersion: '4.0.0', viteVersion: '7.0.0' },
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: (message: unknown): never => {
+        throw new Error(String(message));
+      },
+    },
+    { root: invokingRoot },
+    { command: 'serve', mode: 'development' }
+  );
+
+  if (!config || !config.test) {
+    throw new Error('The plugin config hook returned no test config');
+  }
+
+  return { root: config.root, test: config.test };
 }
 
 describe('story test patterns', () => {
-  beforeEach(() => {
-    vi.stubEnv('VITEST', 'true');
-  });
-
   // The plugin sets the project root itself, so story globs have to be written relative to that
   // root rather than to whichever root Vitest happened to be invoked with. When a Vitest config
   // lives above the package — a monorepo root — the two differ, and globs built against the

--- a/code/addons/vitest/src/vitest-plugin/vitest-root.test.ts
+++ b/code/addons/vitest/src/vitest-plugin/vitest-root.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Plugin } from 'vitest/config';
+
+const REPO_ROOT = '/repo';
+const PACKAGE_ROOT = '/repo/apps/storybook';
+const CONFIG_DIR = '/repo/apps/storybook/.storybook';
+
+const presetApply = vi.fn(async (key: string, fallback?: unknown) => {
+  switch (key) {
+    case 'stories':
+      return ['../stories/**/*.stories.tsx'];
+    case 'framework':
+      return { name: '@storybook/react-vite' };
+    // Mirrors a project without its own `viteFinal`: the common config is returned untouched,
+    // so the root the plugin proposes is the root it ends up returning.
+    case 'viteFinal':
+      return fallback;
+    case 'core':
+      return { disableTelemetry: true };
+    default:
+      return fallback;
+  }
+});
+
+vi.mock('storybook/internal/core-server', () => ({
+  experimental_loadStorybook: vi.fn(async () => ({ presets: { apply: presetApply } })),
+  StoryIndexGenerator: {
+    findMatchingFilesForSpecifiers: vi.fn(async () => []),
+    storyFileNames: vi.fn(() => []),
+  },
+  Tag: { TEST: 'test' },
+  mapStaticDir: vi.fn(),
+}));
+
+vi.mock('storybook/internal/common', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('storybook/internal/common')>()),
+  validateConfigurationFiles: vi.fn(async () => {}),
+  getInterpretedFile: vi.fn(() => undefined),
+}));
+
+vi.mock('storybook/internal/telemetry', () => ({
+  detectAgent: vi.fn(() => undefined),
+  isTelemetryModuleEnabled: vi.fn(() => false),
+  isWithinInitialSession: vi.fn(async () => false),
+  oneWayHash: vi.fn(() => 'project-hash'),
+  telemetry: vi.fn(),
+  setTelemetryEnabled: vi.fn(),
+}));
+
+vi.mock('storybook/internal/csf-tools', () => ({
+  componentTransform: vi.fn(),
+  readConfig: vi.fn(),
+  vitestTransform: vi.fn(),
+}));
+
+const { storybookTest } = await import('./index.ts');
+
+/** Runs the plugin's `config` hook the way Vitest does, and returns the config it contributes. */
+async function getPluginConfig(invokingRoot: string) {
+  const plugins = await storybookTest({ configDir: CONFIG_DIR });
+  const plugin = plugins.find(
+    (p) => (p as Plugin)?.name === 'vite-plugin-storybook-test'
+  ) as Plugin;
+
+  const configHook = plugin.config!;
+  const handler = typeof configHook === 'function' ? configHook : configHook.handler;
+
+  return handler.call({}, { root: invokingRoot }, { command: 'serve', mode: 'development' });
+}
+
+describe('story test patterns', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITEST', 'true');
+  });
+
+  // The plugin sets the project root itself, so story globs have to be written relative to that
+  // root rather than to whichever root Vitest happened to be invoked with. When a Vitest config
+  // lives above the package — a monorepo root — the two differ, and globs built against the
+  // invoking root resolve outside the project and match no story files at all, silently.
+  it('resolves story globs against the root it returns, not the invoking root', async () => {
+    const config = await getPluginConfig(REPO_ROOT);
+
+    expect(config.root).toBe(PACKAGE_ROOT);
+    expect(config.test.include).toEqual(['stories/**/*.stories.tsx']);
+  });
+
+  it('resolves story globs the same way when the invoking root already matches', async () => {
+    const config = await getPluginConfig(PACKAGE_ROOT);
+
+    expect(config.root).toBe(PACKAGE_ROOT);
+    expect(config.test.include).toEqual(['stories/**/*.stories.tsx']);
+  });
+});


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

### The bug

In a monorepo where the Vitest config lives above the Storybook package, addon-vitest finds **zero** story files — and nothing reports that as a problem. The Testing module shows a grey "Ran 0 tests", and `storybook tools test run` exits 0 with empty output. A broken setup looks identical to a green one.

Reported by @shilman on [storybook-tmp/astryx](https://github.com/storybook-tmp/astryx/tree/shilman/codex-10-6-beta-0).

### The cause

The plugin uses two different roots without realizing it:

- It **builds the story globs** relative to the root Vitest was invoked with (the directory of the Vitest config file).
- It **sets the project root** to `configDir/..` via `viteFinal`.

In the documented layout — `vitest.config.ts` next to `.storybook` — those are the same directory, so the bug is invisible. In a monorepo they differ, and the globs double up the package path:

```
astryx/
├── vitest.storybook.config.ts     ← storybookTest({ configDir: 'apps/storybook/.storybook' })
└── apps/storybook/.storybook/
```

| step | value |
| --- | --- |
| glob from `main.ts` | `../stories/**/*.stories.tsx` |
| made absolute | `astryx/apps/storybook/stories/**` |
| relativized against `astryx` (invoking root) | `apps/storybook/stories/**` |
| resolved by Vitest against `astryx/apps/storybook` (actual root) | `astryx/apps/storybook/apps/storybook/stories/**` ✗ |

`apps/storybook` appears twice; nothing matches; Vitest logs `No test files found`.

### The fix

Relativize the globs against the root the plugin actually returns, so the two agree by construction. One line, plus a regression test that fails without it. `test.dir` / `test.root` keep their existing precedence.

### Results on the reporting repo

|  | before | after |
| --- | --- | --- |
| test files discovered | 0 | 155 |
| stories tested | 0 | 1451 |
| exit code on `tools test run` | 0 (empty output) | honest results, incl. 1 real failure that was hidden |

### Out of scope

A run that matches no story files still reports success — this PR removes the known cause, not the class. I prototyped a config-time assertion ("Storybook found N story files, none match the test patterns") and pulled it out: Vitest wraps `config`-hook errors in an `AggregateError` that drops the message entirely, so it failed loudly without saying why. That check needs to live where the addon controls the error surface. Follow-up PR.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

Needs a monorepo whose Vitest config sits above the Storybook package:

1. Clone https://github.com/storybook-tmp/astryx at branch `shilman/codex-10-6-beta-0`, then `pnpm install`
2. `pnpm -F @astryxdesign/build build && pnpm exec playwright install chromium`
3. `pnpm -F @astryxdesign/storybook dev`
4. Open the Testing module in the sidebar and press **Run tests**

On `next`: "Ran 0 tests just now", server log says `No test files found`.
With this PR: 155 test files, 1451 stories run.

Also worth a spot check that a standard single-package sandbox (`vitest.config.ts` next to `.storybook`) still discovers the same tests as before, since this changes the root the globs resolve against.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
