### PR TITLE
Tools: Accept a story ID in `docs show-story` as an alternative to componentId + storyName

### DIFF
--- a/code/core/src/cli/tools/run.test.ts
+++ b/code/core/src/cli/tools/run.test.ts
@@ -59,7 +59,17 @@ const DOCS_ACCESS: DocsAccess = {
       },
     },
   }),
-  resolve: async () => undefined,
+  resolve: async (id) =>
+    id === 'button'
+      ? {
+          kind: 'component',
+          component: {
+            id: 'button',
+            name: 'Button',
+            stories: [{ id: 'button--primary', name: 'Primary', snippet: '<Button />' }],
+          },
+        }
+      : undefined,
 };
 
 const RECORD: StorybookInstanceRecord = {
@@ -234,6 +244,17 @@ describe('local tools', () => {
         host: 'in-process',
       })
     );
+  });
+
+  it('round-trips the show-story --storyId flag through token parsing to the handler', async () => {
+    const { deps } = makeDeps();
+
+    const result = await run(['docs', 'show-story', '--storyId', 'button--primary'], deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.outcome).toEqual({ kind: 'success' });
+    expect(result.output).toContain('# Button - Primary');
+    expect(result.output).toContain('<Button />');
   });
 
   it('prints the structured result data with --json', async () => {

--- a/code/core/src/shared/open-service/toolsets/docs/access-parity.test.ts
+++ b/code/core/src/shared/open-service/toolsets/docs/access-parity.test.ts
@@ -199,16 +199,24 @@ describe('docs tools render the same text in both docgen modes', () => {
     }
   });
 
-  it('showStory', async () => {
-    const render = async (toolset: ReturnType<typeof createDocsToolset>) =>
-      (
-        await toolset.methods.showStory.handler(
-          { componentId: 'button', storyName: 'Primary' },
-          ctx
-        )
-      ).markdown;
+  it.each([{ componentId: 'button', storyName: 'Primary' }, { storyId: 'button--primary' }])(
+    'showStory %o',
+    async (input) => {
+      const render = async (toolset: ReturnType<typeof createDocsToolset>) =>
+        (await toolset.methods.showStory.handler(input, ctx)).markdown;
 
-    expect(await render(serviceToolset())).toBe(await render(manifestToolset()));
+      expect(await render(serviceToolset())).toBe(await render(manifestToolset()));
+    }
+  );
+
+  it('showStory answers a story id and the matching name pair identically', async () => {
+    const toolset = manifestToolset();
+    const render = async (input: Record<string, string>) =>
+      (await toolset.methods.showStory.handler(input, ctx)).markdown;
+
+    expect(await render({ storyId: 'button--primary' })).toBe(
+      await render({ componentId: 'button', storyName: 'Primary' })
+    );
   });
 });
 
@@ -334,16 +342,18 @@ describe('docs tools render the same text in dev and from a built Storybook', ()
     expect(await renderShow(staticToolset(), componentId)).toBe(dev);
   });
 
-  it('showStory answers for a story with no snippet in both', async () => {
-    const render = async (toolset: ReturnType<typeof createDocsToolset>) =>
-      (await toolset.methods.showStory.handler({ componentId, storyName: 'Default' }, ctx))
-        .markdown;
+  it.each([{ componentId, storyName: 'Default' }, { storyId: `${componentId}--default` }])(
+    'showStory answers for a story with no snippet in both (%o)',
+    async (input) => {
+      const render = async (toolset: ReturnType<typeof createDocsToolset>) =>
+        (await toolset.methods.showStory.handler(input, ctx)).markdown;
 
-    const dev = await render(devToolset());
+      const dev = await render(devToolset());
 
-    expect(dev).toContain(`Story ID: ${componentId}--default`);
-    expect(await render(staticToolset())).toBe(dev);
-  });
+      expect(dev).toContain(`Story ID: ${componentId}--default`);
+      expect(await render(staticToolset())).toBe(dev);
+    }
+  );
 
   it('lists the real stories when asked for one that does not exist', async () => {
     const render = async (toolset: ReturnType<typeof createDocsToolset>) =>
@@ -351,7 +361,9 @@ describe('docs tools render the same text in dev and from a built Storybook', ()
 
     const dev = await render(devToolset());
 
-    expect(dev).toContain('Available stories: Default, Text');
+    expect(dev).toContain(
+      `Available stories: Default (${componentId}--default), Text (${componentId}--text)`
+    );
     expect(await render(staticToolset())).toBe(dev);
   });
 });

--- a/code/core/src/shared/open-service/toolsets/docs/definition.test.ts
+++ b/code/core/src/shared/open-service/toolsets/docs/definition.test.ts
@@ -132,7 +132,7 @@ describe('docs.showStory', () => {
 
     expect(outcome.ok).toBe(false);
     expect(outcome.markdown).toBe(
-      'Story "Missing" not found for component "button". Available stories: Primary'
+      'Story "Missing" not found for component "button". Available stories: Primary (button--primary)'
     );
   });
 
@@ -157,6 +157,117 @@ describe('docs.showStory', () => {
     expect(cliOutcome.markdown).toContain(
       'Use the npx storybook tools docs list tool to see available components'
     );
+  });
+
+  it('renders the story documentation for a story id, identically to the name lookup', async () => {
+    const outcome = await toolset.methods.showStory.handler({ storyId: 'button--primary' }, mcpCtx);
+
+    expect(outcome.ok).toBe(true);
+    expect(outcome.data.entry?.kind).toBe('component');
+
+    const byName = await toolset.methods.showStory.handler(
+      { componentId: 'button', storyName: 'Primary' },
+      mcpCtx
+    );
+    expect(outcome.markdown).toBe(byName.markdown);
+  });
+
+  it('prefers the story id when both shapes are passed', async () => {
+    const outcome = await toolset.methods.showStory.handler(
+      { storyId: 'button--primary', componentId: 'bogus', storyName: 'Bogus' },
+      mcpCtx
+    );
+
+    expect(outcome.ok).toBe(true);
+    expect(outcome.markdown).toContain('<Button />');
+  });
+
+  it('lists available stories with their ids when the story id misses a known component', async () => {
+    const outcome = await toolset.methods.showStory.handler({ storyId: 'button--nope' }, mcpCtx);
+
+    expect(outcome.ok).toBe(false);
+    expect(outcome.markdown).toBe(
+      'Story not found: "button--nope" for component "button". Available stories: Primary (button--primary)'
+    );
+  });
+
+  it('answers a story id with an unknown component prefix per transport', async () => {
+    const outcome = await toolset.methods.showStory.handler({ storyId: 'nope--primary' }, mcpCtx);
+
+    expect(outcome.ok).toBe(false);
+    expect(outcome.markdown).toBe(
+      'Story not found: "nope--primary". Use the docs-list tool with `withStoryIds: true` to see available stories and their ids.'
+    );
+
+    const cliOutcome = await toolset.methods.showStory.handler(
+      { storyId: 'nope--primary' },
+      cliCtx
+    );
+    expect(cliOutcome.markdown).toContain(
+      'Use the npx storybook tools docs list tool with `withStoryIds: true`'
+    );
+  });
+
+  it('treats a story id without a separator as a story lookup, not a component lookup', async () => {
+    const outcome = await toolset.methods.showStory.handler({ storyId: 'button' }, mcpCtx);
+
+    expect(outcome.ok).toBe(false);
+    expect(outcome.markdown).toBe(
+      'Story not found: "button" for component "button". Available stories: Primary (button--primary)'
+    );
+  });
+
+  it('rejects an input that is neither shape with guidance', async () => {
+    for (const input of [{}, { componentId: 'button' }, { storyName: 'Primary' }]) {
+      const outcome = await toolset.methods.showStory.handler(input, mcpCtx);
+
+      expect(outcome.ok).toBe(false);
+      expect(outcome.markdown).toBe(
+        'Provide either `storyId`, or both `componentId` and `storyName`. Story ids are listed by the docs-list tool with `withStoryIds: true` and in docs-show output.'
+      );
+    }
+  });
+
+  it('accepts both shapes through the input schema', async () => {
+    const schema = toolset.methods.showStory.input;
+
+    for (const input of [
+      { storyId: 'button--primary' },
+      { componentId: 'button', storyName: 'Primary' },
+    ]) {
+      expect((await schema['~standard'].validate(input)).issues).toBeUndefined();
+    }
+  });
+});
+
+describe('docs.showStory in a composition', () => {
+  const sources = [
+    { source: { id: 'local', title: 'Local' }, access: docsAccess },
+    {
+      source: { id: 'remote', title: 'Remote' },
+      access: { list: docsAccess.list, resolve: async () => undefined },
+    },
+  ];
+  const composed = createDocsToolset({ sources });
+
+  it('resolves a story id within the named source', async () => {
+    const outcome = await composed.methods.showStory.handler(
+      { storyId: 'button--primary', storybookId: 'local' },
+      mcpCtx
+    );
+
+    expect(outcome.ok).toBe(true);
+    expect(outcome.markdown).toContain('<Button />');
+  });
+
+  it('reports the source error for a story id naming an unknown source', async () => {
+    const outcome = await composed.methods.showStory.handler(
+      { storyId: 'button--primary', storybookId: 'elsewhere' },
+      mcpCtx
+    );
+
+    expect(outcome.ok).toBe(false);
+    expect(outcome.markdown).toContain('Storybook source not found: "elsewhere"');
   });
 });
 

--- a/code/core/src/shared/open-service/toolsets/docs/definition.ts
+++ b/code/core/src/shared/open-service/toolsets/docs/definition.ts
@@ -128,7 +128,7 @@ function isShowStorySelector({ storyId, componentId, storyName }: DocsShowStoryO
 /**
  * The component id a story id starts with (`button--primary` → `button`). Only a routing hint for
  * which manifest entry to resolve — a match is reported solely when a story's `id` equals the
- * input, so the lookup stays correct even if this derivation misreads an unusual id.
+ * input.
  */
 function componentIdOfStoryId(storyId: string): string {
   const separator = storyId.indexOf('--');
@@ -423,16 +423,19 @@ export function createDocsToolset(options: CreateDocsToolsetOptions) {
           };
           const request: DocsShowStoryOutput = { storyId, componentId, storyName, storybookId };
 
-          const selected = isShowStorySelector(request) ? access(storybookId, ctx) : {};
-          const data: DocsShowStoryOutput = selected.access
-            ? {
-                ...request,
-                // The id shape wins when both are passed, mirroring its listed preference.
-                entry: await selected.access.resolve(
-                  storyId !== undefined ? componentIdOfStoryId(storyId) : componentId!
-                ),
-              }
-            : { ...request, sourceError: selected.sourceError };
+          // The id shape wins when both are passed, mirroring its listed preference.
+          const resolveId =
+            storyId !== undefined
+              ? componentIdOfStoryId(storyId)
+              : componentId !== undefined && storyName !== undefined
+                ? componentId
+                : undefined;
+
+          const selected = resolveId !== undefined ? access(storybookId, ctx) : {};
+          const data: DocsShowStoryOutput =
+            selected.access && resolveId !== undefined
+              ? { ...request, entry: await selected.access.resolve(resolveId) }
+              : { ...request, sourceError: selected.sourceError };
 
           const markdown = renderShowStory(data, ctx);
 

--- a/code/core/src/shared/open-service/toolsets/docs/definition.ts
+++ b/code/core/src/shared/open-service/toolsets/docs/definition.ts
@@ -69,8 +69,9 @@ export type DocsShowOutput = {
 };
 
 export type DocsShowStoryOutput = {
-  componentId: string;
-  storyName: string;
+  componentId?: string;
+  storyName?: string;
+  storyId?: string;
   entry?: ResolvedDocsEntry;
   storybookId?: string;
   sourceError?: string;
@@ -113,16 +114,32 @@ type ComponentEntry = Extract<ResolvedDocsEntry, { kind: 'component' }>;
 
 /** The `showStory` counterpart of {@link ShowResolution}. */
 type ShowStoryResolution =
+  | { kind: 'input-invalid' }
   | { kind: 'source-error'; message: string }
   | { kind: 'component-missing' }
   | { kind: 'story-missing'; component: ComponentEntry['component'] }
-  | { kind: 'found'; component: ComponentEntry['component'] };
+  | { kind: 'found'; component: ComponentEntry['component']; storyName: string };
 
-function resolveShowStory({
-  entry,
-  storyName,
-  sourceError,
-}: DocsShowStoryOutput): ShowStoryResolution {
+/** Whether a `showStory` input names a story at all: a story id, or a complete name pair. */
+function isShowStorySelector({ storyId, componentId, storyName }: DocsShowStoryOutput): boolean {
+  return storyId !== undefined || (componentId !== undefined && storyName !== undefined);
+}
+
+/**
+ * The component id a story id starts with (`button--primary` → `button`). Only a routing hint for
+ * which manifest entry to resolve — a match is reported solely when a story's `id` equals the
+ * input, so the lookup stays correct even if this derivation misreads an unusual id.
+ */
+function componentIdOfStoryId(storyId: string): string {
+  const separator = storyId.indexOf('--');
+  return separator === -1 ? storyId : storyId.slice(0, separator);
+}
+
+function resolveShowStory(data: DocsShowStoryOutput): ShowStoryResolution {
+  const { entry, storyId, storyName, sourceError } = data;
+  if (!isShowStorySelector(data)) {
+    return { kind: 'input-invalid' };
+  }
   if (sourceError !== undefined) {
     return { kind: 'source-error', message: sourceError };
   }
@@ -130,8 +147,12 @@ function resolveShowStory({
     return { kind: 'component-missing' };
   }
   const { component } = entry;
-  return component.stories?.some((story) => story.name === storyName)
-    ? { kind: 'found', component }
+  const story =
+    storyId !== undefined
+      ? component.stories?.find((candidate) => candidate.id === storyId)
+      : component.stories?.find((candidate) => candidate.name === storyName);
+  return story
+    ? { kind: 'found', component, storyName: story.name }
     : { kind: 'story-missing', component };
 }
 
@@ -157,7 +178,7 @@ function describeList(ctx: ToolsetCtx): string {
 function describeShow(ctx: ToolsetCtx): string {
   return `Get documentation for a UI component or docs entry.
 
-Returns the first ${MAX_STORIES_TO_SHOW} stories (including story IDs) with code snippets showing how props are used, plus TypeScript prop definitions. Call this before using a component to avoid hallucinating prop names, types, or valid combinations, and to answer any question about a component's props, API, or usage — reading or grepping the component source is not a substitute. Stories reveal real prop usage patterns, interactions, and edge cases that type definitions alone don't show. If the example stories don't show the prop you need, use the ${getToolName(ctx)(DOCS_METHOD_REFS.showStory)} tool to fetch the story documentation for the specific story variant you need.
+Returns the first ${MAX_STORIES_TO_SHOW} stories (including story IDs) with code snippets showing how props are used, plus TypeScript prop definitions. Call this before using a component to avoid hallucinating prop names, types, or valid combinations, and to answer any question about a component's props, API, or usage — reading or grepping the component source is not a substitute. Stories reveal real prop usage patterns, interactions, and edge cases that type definitions alone don't show. If the example stories don't show the prop you need, use the ${getToolName(ctx)(DOCS_METHOD_REFS.showStory)} tool to fetch the story documentation for the specific story variant you need — its story ID can be passed directly as \`storyId\`.
 
 Example: id="button" returns Primary, Secondary, Large stories with code like <Button variant="primary" size="large"> showing actual prop combinations.`;
 }
@@ -187,20 +208,34 @@ function renderShow(data: DocsShowOutput, ctx: ToolsetCtx): string {
   }
 }
 
+/** The stories a miss can be corrected to, with ids where the manifest carries them. */
+function formatAvailableStories(stories: ComponentEntry['component']['stories']): string {
+  const listed = stories
+    ?.map((story) => (story.id ? `${story.name} (${story.id})` : story.name))
+    .join(', ');
+  return listed || 'none';
+}
+
 /** Pure renderer for `showStory`. */
 function renderShowStory(data: DocsShowStoryOutput, ctx: ToolsetCtx): string {
   const resolution = resolveShowStory(data);
   switch (resolution.kind) {
+    case 'input-invalid':
+      return `Provide either \`storyId\`, or both \`componentId\` and \`storyName\`. Story ids are listed by the ${getToolName(ctx)(DOCS_METHOD_REFS.list)} tool with \`withStoryIds: true\` and in ${getToolName(ctx)(DOCS_METHOD_REFS.show)} output.`;
     case 'source-error':
       return resolution.message;
     case 'component-missing':
-      return `Component not found: "${data.componentId}". Use the ${getToolName(ctx)(DOCS_METHOD_REFS.list)} tool to see available components.`;
+      return data.storyId !== undefined
+        ? `Story not found: "${data.storyId}". Use the ${getToolName(ctx)(DOCS_METHOD_REFS.list)} tool with \`withStoryIds: true\` to see available stories and their ids.`
+        : `Component not found: "${data.componentId}". Use the ${getToolName(ctx)(DOCS_METHOD_REFS.list)} tool to see available components.`;
     case 'story-missing': {
-      const availableStories = resolution.component.stories?.map((story) => story.name).join(', ');
-      return `Story "${data.storyName}" not found for component "${data.componentId}". Available stories: ${availableStories || 'none'}`;
+      const availableStories = formatAvailableStories(resolution.component.stories);
+      return data.storyId !== undefined
+        ? `Story not found: "${data.storyId}" for component "${resolution.component.id}". Available stories: ${availableStories}`
+        : `Story "${data.storyName}" not found for component "${data.componentId}". Available stories: ${availableStories}`;
     }
     case 'found':
-      return formatStoryDocumentation(resolution.component, data.storyName);
+      return formatStoryDocumentation(resolution.component, resolution.storyName);
     default: {
       const exhaustive: never = resolution;
       return exhaustive;
@@ -274,9 +309,33 @@ export function createDocsToolset(options: CreateDocsToolsetOptions) {
         id: v.pipe(v.string(), v.description('The component or docs entry ID (e.g., "button")')),
       });
 
+  // Two selector shapes in one flat object: MCP requires an `inputSchema` whose root is
+  // `type: "object"`, so this cannot be a top-level union (it would convert to a bare `anyOf`),
+  // and valibot refinements don't survive JSON Schema conversion, so the either-shape rule is
+  // enforced by the handler, which renders actionable guidance instead of a validation error.
+  const showStoryFields = {
+    storyId: v.pipe(
+      v.optional(v.string()),
+      v.description(
+        'The story ID, as listed by the docs list tool with withStoryIds: true and shown next to each story in the component documentation (e.g., "button--primary"). Prefer this over componentId + storyName whenever you have a story ID.'
+      )
+    ),
+    componentId: v.pipe(
+      v.optional(v.string()),
+      v.description(
+        'The component ID (e.g., "button"). Use together with storyName, and only when you have no story ID.'
+      )
+    ),
+    storyName: v.pipe(
+      v.optional(v.string()),
+      v.description(
+        'The human-readable story name (e.g., "Primary"). Use together with componentId.'
+      )
+    ),
+  };
   const showStorySchema = multiSource
-    ? v.object({ componentId: v.string(), storyName: v.string(), ...storybookIdField })
-    : v.object({ componentId: v.string(), storyName: v.string() });
+    ? v.object({ ...showStoryFields, ...storybookIdField })
+    : v.object(showStoryFields);
 
   /** The access for a lookup, plus the id it was scoped to. */
   const access = (storybookId: string | undefined, ctx: ToolsetCtx) =>
@@ -354,22 +413,26 @@ export function createDocsToolset(options: CreateDocsToolsetOptions) {
         input: showStorySchema,
         title: 'Get Documentation for Story',
         description:
-          'Get detailed documentation for a specific story variant of a UI component. Use this when you need to see more usage examples of a component, via the stories written for it.',
+          'Get detailed documentation for a specific story variant of a UI component. Use this when you need to see more usage examples of a component, via the stories written for it. Identify the story by its story ID (preferred), or by componentId plus storyName.',
         handler: async (input, ctx): Promise<ToolsetOutcome<DocsShowStoryOutput>> => {
-          const { componentId, storyName, storybookId } = input as {
-            componentId: string;
-            storyName: string;
+          const { storyId, componentId, storyName, storybookId } = input as {
+            storyId?: string;
+            componentId?: string;
+            storyName?: string;
             storybookId?: string;
           };
-          const selected = access(storybookId, ctx);
-          const data: DocsShowStoryOutput = selected.sourceError
-            ? { componentId, storyName, storybookId, sourceError: selected.sourceError }
-            : {
-                componentId,
-                storyName,
-                storybookId,
-                entry: await selected.access!.resolve(componentId),
-              };
+          const request: DocsShowStoryOutput = { storyId, componentId, storyName, storybookId };
+
+          const selected = isShowStorySelector(request) ? access(storybookId, ctx) : {};
+          const data: DocsShowStoryOutput = selected.access
+            ? {
+                ...request,
+                // The id shape wins when both are passed, mirroring its listed preference.
+                entry: await selected.access.resolve(
+                  storyId !== undefined ? componentIdOfStoryId(storyId) : componentId!
+                ),
+              }
+            : { ...request, sourceError: selected.sourceError };
 
           const markdown = renderShowStory(data, ctx);
 

--- a/code/lib/mcp/src/dist-contract.test.ts
+++ b/code/lib/mcp/src/dist-contract.test.ts
@@ -60,7 +60,7 @@ function markdownLinkTargets(markdown: string): string[] {
  * The budget stepped up when this package moved from shipping its own docs tools to bundling
  * Storybook's shared docs toolset — the engine it used to duplicate now arrives from core.
  */
-const SIZE_BUDGET_BYTES = 80_000;
+const SIZE_BUDGET_BYTES = 85_000;
 
 /**
  * The declarations are bundled from per-file emit and tree-shaken (~39 KB today). When they were

--- a/code/lib/mcp/src/tools/get-documentation-for-story.test.ts
+++ b/code/lib/mcp/src/tools/get-documentation-for-story.test.ts
@@ -123,6 +123,59 @@ describe('getComponentStoryDocumentationTool', () => {
 		`);
   });
 
+  it('should return the same story documentation for a story id', async () => {
+    const call = async (args: Record<string, string>) => {
+      const response = await server.receive(
+        {
+          jsonrpc: '2.0' as const,
+          id: 1,
+          method: 'tools/call',
+          params: { name: GET_STORY_TOOL_NAME, arguments: args },
+        },
+        { custom: { request: new Request('https://example.com/mcp'), manifestProvider } }
+      );
+      return (response.result as any).content[0].text;
+    };
+
+    expect(await call({ storyId: 'button--primary' })).toBe(
+      await call({ componentId: 'button', storyName: 'Primary' })
+    );
+  });
+
+  it('should return an error listing available story ids when a story id is not found', async () => {
+    const response = await server.receive(
+      {
+        jsonrpc: '2.0' as const,
+        id: 1,
+        method: 'tools/call',
+        params: { name: GET_STORY_TOOL_NAME, arguments: { storyId: 'button--nope' } },
+      },
+      { custom: { request: new Request('https://example.com/mcp'), manifestProvider } }
+    );
+
+    expect((response.result as any).isError).toBe(true);
+    expect((response.result as any).content[0].text).toBe(
+      'Story not found: "button--nope" for component "button". Available stories: Primary (button--primary)'
+    );
+  });
+
+  it('should return guidance when neither a story id nor a name pair is given', async () => {
+    const response = await server.receive(
+      {
+        jsonrpc: '2.0' as const,
+        id: 1,
+        method: 'tools/call',
+        params: { name: GET_STORY_TOOL_NAME, arguments: { componentId: 'button' } },
+      },
+      { custom: { request: new Request('https://example.com/mcp'), manifestProvider } }
+    );
+
+    expect((response.result as any).isError).toBe(true);
+    expect((response.result as any).content[0].text).toBe(
+      'Provide either `storyId`, or both `componentId` and `storyName`. Story ids are listed by the docs-list tool with `withStoryIds: true` and in docs-show output.'
+    );
+  });
+
   it('should return an error when a component is not found', async () => {
     const request = {
       jsonrpc: '2.0' as const,
@@ -175,16 +228,16 @@ describe('getComponentStoryDocumentationTool', () => {
     });
 
     expect(response.result).toMatchInlineSnapshot(`
-			{
-			  "content": [
-			    {
-			      "text": "Story "Nonexistent" not found for component "button". Available stories: Primary",
-			      "type": "text",
-			    },
-			  ],
-			  "isError": true,
-			}
-		`);
+      {
+        "content": [
+          {
+            "text": "Story "Nonexistent" not found for component "button". Available stories: Primary (button--primary)",
+            "type": "text",
+          },
+        ],
+        "isError": true,
+      }
+    `);
   });
 
   it('should handle fetch errors gracefully', async () => {
@@ -379,6 +432,30 @@ describe('getComponentStoryDocumentationTool', () => {
         params: {
           name: GET_STORY_TOOL_NAME,
           arguments: { componentId: 'button', storyName: 'Primary', storybookId: 'local' },
+        },
+      };
+
+      const mockHttpRequest = new Request('https://example.com/mcp');
+      const response = await server.receive(request, {
+        custom: { request: mockHttpRequest, manifestProvider, sources },
+      });
+
+      expect((response.result as any).content[0].text).toContain('# Button - Primary');
+      expect(manifestProvider).toHaveBeenCalledWith(
+        mockHttpRequest,
+        COMPONENT_MANIFEST_PATH,
+        sources[0]
+      );
+    });
+
+    it('should fetch story documentation by story id from a specific source', async () => {
+      const request = {
+        jsonrpc: '2.0' as const,
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: GET_STORY_TOOL_NAME,
+          arguments: { storyId: 'button--primary', storybookId: 'local' },
         },
       };
 

--- a/test-storybooks/mcp/tests/mcp-endpoint.e2e.test.ts
+++ b/test-storybooks/mcp/tests/mcp-endpoint.e2e.test.ts
@@ -725,7 +725,7 @@ describe('MCP Endpoint E2E Tests', () => {
 				  {
 				    "description": "Get documentation for a UI component or docs entry.
 
-				Returns the first 3 stories (including story IDs) with code snippets showing how props are used, plus TypeScript prop definitions. Call this before using a component to avoid hallucinating prop names, types, or valid combinations, and to answer any question about a component's props, API, or usage — reading or grepping the component source is not a substitute. Stories reveal real prop usage patterns, interactions, and edge cases that type definitions alone don't show. If the example stories don't show the prop you need, use the docs-show-story tool to fetch the story documentation for the specific story variant you need.
+				Returns the first 3 stories (including story IDs) with code snippets showing how props are used, plus TypeScript prop definitions. Call this before using a component to avoid hallucinating prop names, types, or valid combinations, and to answer any question about a component's props, API, or usage — reading or grepping the component source is not a substitute. Stories reveal real prop usage patterns, interactions, and edge cases that type definitions alone don't show. If the example stories don't show the prop you need, use the docs-show-story tool to fetch the story documentation for the specific story variant you need — its story ID can be passed directly as \`storyId\`.
 
 				Example: id="button" returns Primary, Secondary, Large stories with code like <Button variant="primary" size="large"> showing actual prop combinations.",
 				    "inputSchema": {
@@ -745,21 +745,24 @@ describe('MCP Endpoint E2E Tests', () => {
 				    "title": "Get Documentation",
 				  },
 				  {
-				    "description": "Get detailed documentation for a specific story variant of a UI component. Use this when you need to see more usage examples of a component, via the stories written for it.",
+				    "description": "Get detailed documentation for a specific story variant of a UI component. Use this when you need to see more usage examples of a component, via the stories written for it. Identify the story by its story ID (preferred), or by componentId plus storyName.",
 				    "inputSchema": {
 				      "$schema": "http://json-schema.org/draft-07/schema#",
 				      "properties": {
 				        "componentId": {
+				          "description": "The component ID (e.g., "button"). Use together with storyName, and only when you have no story ID.",
+				          "type": "string",
+				        },
+				        "storyId": {
+				          "description": "The story ID, as listed by the docs list tool with withStoryIds: true and shown next to each story in the component documentation (e.g., "button--primary"). Prefer this over componentId + storyName whenever you have a story ID.",
 				          "type": "string",
 				        },
 				        "storyName": {
+				          "description": "The human-readable story name (e.g., "Primary"). Use together with componentId.",
 				          "type": "string",
 				        },
 				      },
-				      "required": [
-				        "componentId",
-				        "storyName",
-				      ],
+				      "required": [],
 				      "type": "object",
 				    },
 				    "name": "docs-show-story",


### PR DESCRIPTION
Closes #36102

## What I did

`docs show-story` now accepts a story ID:

```bash
npx storybook tools docs show-story --storyId button--primary
```

Previously the tool only accepted a component ID plus a human-readable story name:

```bash
npx storybook tools docs show-story --componentId button --storyName "Primary"
```

That was an odd gap: `docs show` and `docs list --withStoryIds` already print story IDs, and the preview/test tools already accept them. An agent that just read `button--primary` out of `docs show` output had to decompose it back into a component ID and a story name — error-prone when story names contain spaces, colons, or emojis.

### Behavior

- **Both shapes work.** `{ storyId }` is new and preferred; `{ componentId, storyName }` keeps working unchanged. The schema descriptions steer agents toward `storyId`, and the `docs show` description now mentions the story ID can be passed directly.
- **Same everywhere.** Works in single-source and composed (multi-source) Storybooks — combined with `storybookId` exactly like the name shape — and identically through the MCP server and the tools CLI.
- **Same output.** A story-ID lookup renders byte-for-byte what the name lookup renders for the same story.
- **Careful resolution.** The component to resolve is derived from the ID's `--` prefix, but a match is only reported when a manifest story's `id` equals the input — no naive string parsing deciding the result.
- **Actionable errors.**
  - Unknown story ID, known component → lists the available stories *with their IDs* (the name-based miss message now includes IDs too).
  - Unknown component prefix → points at `docs list --withStoryIds`.
  - Neither shape provided → guidance naming both shapes.

### Why not the valibot union the issue asked for

The issue's implementation decision was a union of the two input shapes. That breaks at the MCP boundary:

- A top-level valibot union converts to a root `anyOf` with **no `type: "object"`**, which violates the MCP `inputSchema` contract. Verified empirically against `@tmcp/adapter-valibot`, the converter this repo ships.
- Valibot refinements (`check`/`rawCheck`) can't patch over it — they throw during JSON Schema conversion.

So the schema is one flat object with three optional fields, and the handler enforces "either `storyId`, or `componentId` + `storyName`". That also gives a nicer failure than a protocol-level validation error: the agent gets rendered guidance through the normal outcome channel. A comment at the schema records the constraint.

One consequence: if both shapes are passed at once, `storyId` wins — matching the preference the descriptions state.

### Side changes

- `@storybook/mcp` dist size budget: 80,000 → 85,000 bytes. The new schema descriptions pushed the bundle ~250 bytes over; the budget guards bundling regressions, not prose.
- The `test-storybooks/mcp` tools/list e2e snapshot was updated for the new schema, and validated by running that e2e suite locally.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [x] integration tests
- [x] end-to-end tests

Toolset definition tests (happy path, precedence, all three miss modes, composition), access-parity tests across all three access modes, `@storybook/mcp` tool tests, a CLI smoke test proving `--storyId` round-trips token parsing → schema → handler, and the MCP endpoint e2e snapshots.

#### Manual testing

1. In a project with the component manifest enabled (`cd code` in this repo works), run `npx storybook tools docs list --withStoryIds true` and copy a story ID.
2. `npx storybook tools docs show-story --storyId <that-id>` prints the same documentation as the `--componentId` + `--storyName` form.
3. `npx storybook tools docs show-story --storyId nope--nada`, and the bare command with no flags, both print actionable guidance.
4. `npx storybook tools docs show-story --help` documents all three flags.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

Docs-site updates are explicitly out of scope per the issue.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
