### PR TITLE
Angular: Filter the options plugin transform to the preview file

### DIFF
--- a/code/frameworks/angular-vite/src/preset.test.ts
+++ b/code/frameworks/angular-vite/src/preset.test.ts
@@ -142,6 +142,51 @@ describe('angularOptionsPlugin style preprocessor paths', () => {
   });
 });
 
+// The hook is declared in Vite's object form, so the callable half lives under `handler`.
+const transformHandler = (plugin: { transform?: unknown }) =>
+  (plugin.transform as { handler: (code: string, id: string) => unknown }).handler;
+
+const transformFilter = (plugin: { transform?: unknown }) =>
+  (plugin.transform as { filter: { id: RegExp } }).filter.id;
+
+describe('angularOptionsPlugin transform filter', () => {
+  const previewPath = resolve(WORKSPACE_ROOT, '.storybook', 'preview.ts');
+
+  const pluginFor = (previewFile: string | undefined) => {
+    vi.mocked(findConfigFile).mockReturnValue(previewFile);
+    return angularOptionsPlugin(
+      {
+        configDir: resolve(WORKSPACE_ROOT, '.storybook'),
+        angularBuilderContext: { workspaceRoot: WORKSPACE_ROOT },
+        angularBuilderOptions: {},
+      } as unknown as StandaloneOptions,
+      { normalizePath, zoneless: true }
+    );
+  };
+
+  // Without a filter Vite calls the hook once per module in the graph, and every one of those calls
+  // does a string comparison to conclude there is nothing to do.
+  it('keeps Vite from calling the hook for anything but the preview file', () => {
+    const filter = transformFilter(pluginFor(previewPath));
+
+    expect(filter.test(previewPath)).toBe(true);
+    expect(filter.test(resolve(WORKSPACE_ROOT, 'src/app.component.ts'))).toBe(false);
+    expect(filter.test(resolve(WORKSPACE_ROOT, '.storybook/preview-head.html'))).toBe(false);
+  });
+
+  // Vite matches the filter against the id as the resolver produced it, before the handler's own
+  // `normalizePath` gets a say, so a Windows id has to pass on its native separator.
+  it('matches a Windows id that still carries backslashes', () => {
+    const filter = transformFilter(pluginFor(previewPath));
+
+    expect(filter.test(previewPath.replace(/\//g, '\\'))).toBe(true);
+  });
+
+  it('registers no transform hook at all when the project has no preview file', () => {
+    expect(pluginFor(undefined).transform).toBeUndefined();
+  });
+});
+
 describe('angularOptionsPlugin global styles', () => {
   const previewPath = resolve(WORKSPACE_ROOT, '.storybook', 'preview.ts');
 
@@ -174,7 +219,7 @@ describe('angularOptionsPlugin global styles', () => {
 
     const plugin = angularOptionsPlugin(options, { normalizePath, zoneless: true });
     (plugin.config as (userConfig: unknown) => unknown)({ root: WORKSPACE_ROOT });
-    return (plugin.transform as any).call({}, '// preview', previewPath) as Promise<{
+    return transformHandler(plugin).call({}, '// preview', previewPath) as Promise<{
       code: string;
     }>;
   };
@@ -206,7 +251,7 @@ describe('angularOptionsPlugin global styles', () => {
     (plugin.config as (userConfig: unknown) => unknown)({
       root: resolve(WORKSPACE_ROOT, 'apps/ui-storybook'),
     });
-    const { code } = (await (plugin.transform as any).call({}, '// preview', projectPreview)) as {
+    const { code } = (await transformHandler(plugin).call({}, '// preview', projectPreview)) as {
       code: string;
     };
 
@@ -227,7 +272,7 @@ describe('angularOptionsPlugin global styles', () => {
 
     const plugin = angularOptionsPlugin(options, { normalizePath, zoneless: false });
     (plugin.config as (userConfig: unknown) => unknown)({ root: WORKSPACE_ROOT });
-    const { code } = (await (plugin.transform as any).call({}, '// preview', previewPath)) as {
+    const { code } = (await transformHandler(plugin).call({}, '// preview', previewPath)) as {
       code: string;
     };
 

--- a/code/frameworks/angular-vite/src/preset.ts
+++ b/code/frameworks/angular-vite/src/preset.ts
@@ -330,18 +330,29 @@ function resolveBuilderStyle(stylePath: string, workspaceRoot: string) {
   return stylePath;
 }
 
+// Vite matches `transform.filter` against the id the resolver produced, which on Windows can still
+// carry backslashes, so either separator is accepted here.
+const previewIdPattern = (previewPath: string) =>
+  new RegExp(
+    `${previewPath
+      .split(/[\\/]/)
+      .map((segment) => segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      .join('[\\\\/]')}$`
+  );
+
 export function angularOptionsPlugin(
   options: StandaloneOptions,
   { normalizePath, zoneless }: any
 ): Plugin {
-  let resolvedPreviewPath: string | undefined;
+  // Resolved when the plugin is built, not in `config`: Vite reads `transform.filter` once, when
+  // the plugin is registered, and never consults it again.
+  const resolvedPreviewPath = findConfigFile('preview', options.configDir) ?? undefined;
   // Angular resolves builder paths against the workspace root, which in a monorepo is a level (or
   // several) above the Vite root. Both `stylePreprocessorOptions` and `styles` need it.
   let workspaceRoot = process.cwd();
-  return {
+  const plugin: Plugin = {
     name: 'storybook-angular-vite-options-plugin',
     config(userConfig: UserConfig) {
-      resolvedPreviewPath = findConfigFile('preview', options.configDir) ?? undefined;
       workspaceRoot =
         options.angularBuilderContext?.workspaceRoot ?? userConfig?.root ?? process.cwd();
       const stylePreprocessorOptions =
@@ -371,43 +382,55 @@ export function angularOptionsPlugin(
         },
       };
     },
-    async transform(code, id) {
-      if (resolvedPreviewPath && normalizePath(id).endsWith(normalizePath(resolvedPreviewPath))) {
-        const imports: string[] = [];
-        const styles = options?.angularBuilderOptions?.styles;
+  };
 
-        if (Array.isArray(styles)) {
-          styles.forEach((style) => {
-            const stylePath =
-              typeof style === 'string'
-                ? style
-                : style !== null &&
-                    typeof style === 'object' &&
-                    'input' in style &&
-                    typeof style.input === 'string'
-                  ? style.input
-                  : undefined;
-            if (stylePath !== undefined) {
-              imports.push(normalizePath(resolveBuilderStyle(stylePath, workspaceRoot)));
-            }
-          });
-        }
+  // The transform below decorates the preview file and nothing else, so without one there is no
+  // work to do - and no path to build a filter from either.
+  if (!resolvedPreviewPath) {
+    return plugin;
+  }
 
-        if (!zoneless) {
-          imports.push('zone.js');
-        }
+  plugin.transform = {
+    filter: { id: previewIdPattern(resolvedPreviewPath) },
+    async handler(code, id) {
+      if (!normalizePath(id).endsWith(normalizePath(resolvedPreviewPath))) {
+        return;
+      }
 
-        return {
-          code: `
+      const imports: string[] = [];
+      const styles = options?.angularBuilderOptions?.styles;
+
+      if (Array.isArray(styles)) {
+        styles.forEach((style) => {
+          const stylePath =
+            typeof style === 'string'
+              ? style
+              : style !== null &&
+                  typeof style === 'object' &&
+                  'input' in style &&
+                  typeof style.input === 'string'
+                ? style.input
+                : undefined;
+          if (stylePath !== undefined) {
+            imports.push(normalizePath(resolveBuilderStyle(stylePath, workspaceRoot)));
+          }
+        });
+      }
+
+      if (!zoneless) {
+        imports.push('zone.js');
+      }
+
+      return {
+        code: `
             ${imports.map((extraImport) => `import '${extraImport}';`).join('\n')}
             ${code}
           `,
-        };
-      }
-
-      return;
+      };
     },
   };
+
+  return plugin;
 }
 
 // Re-apply Storybook's mock contracts AFTER analogjs has compiled the file.


### PR DESCRIPTION
Closes #

## What I did

`angularOptionsPlugin` decorates exactly one module - the resolved `preview.ts` - with the Angular
builder's global `styles` and, when zones are on, `zone.js`. It declared no `transform` filter, so
Vite invoked its hook once for every module in the graph, and every one of those calls did a
string comparison, found the id was not the preview file, and returned.

This is the same defect that #36098 fixes in the neighbouring `stylePreprocessorCheckPlugin`, in
the same file. It is split out because it is not a stylesheet change and it needed one thing that
the other did not: the gate reads `resolvedPreviewPath`, which the `config` hook assigned, and
Vite reads `transform.filter` once when the plugin is registered - before any `config` hook has
run. So the path has to be resolved earlier for a static filter to be expressible at all.

```
  angularOptionsPlugin(options)
        │
        ├── before ─── transform(code, id) ──── called for every module in the graph
        │                    │                  ~1 useful call, N-1 string compares
        │                    └── id.endsWith(previewPath) ? inject : return
        │
        └── after ──── transform.filter.id ──── Vite skips the hook unless the id matches
                             │                  1 call
                             └── handler() ──── same endsWith test, unchanged
```

`findConfigFile('preview', options.configDir)` moves from the `config` hook into the plugin
factory. It only ever needed `options`, which the factory already has. The `workspaceRoot` line
next to it stays in `config`, because that one reads `userConfig`.

The one decision worth reading:

```ts
// Vite matches `transform.filter` against the id the resolver produced, which on Windows can still
// carry backslashes, so either separator is accepted here.
const previewIdPattern = (previewPath: string) =>
  new RegExp(
    `${previewPath
      .split(/[\\/]/)
      .map((segment) => segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
      .join('[\\\\/]')}$`
  );
```

The pattern is anchored at the end and nowhere else, which is exactly the `endsWith` test the
handler performs, so the filter admits precisely the ids the handler would have accepted - no
more, no less. The handler keeps that test: the filter is an optimization, not the contract.

When the project has no preview file there is nothing to decorate and no path to build a pattern
from, so the plugin registers no `transform` hook at all.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Three tests in `code/frameworks/angular-vite/src/preset.test.ts`. Each one fails on its own
mutation, so none of them is decoration:

| Mutation applied to `preset.ts` | Suite result |
| --- | --- |
| none | 44 passed |
| filter widened to `/\.ts$/` | **1 failed** / 43 - `keeps Vite from calling the hook for anything but the preview file` |
| separator class dropped from the pattern | **1 failed** / 43 - `matches a Windows id that still carries backslashes` |
| transform registered even with no preview file | **1 failed** / 43 - `registers no transform hook at all when the project has no preview file` |

The existing `angularOptionsPlugin` tests reach the hook through a small helper now, because the
callable half of an object-form hook lives under `handler`.

#### Manual testing

1. Create an Angular sandbox: `yarn task --task sandbox --start-from auto --template angular-cli-latest/vite-ts`
2. Add a global stylesheet to the sandbox's `angular.json` under the Storybook builder's `styles`,
   for example `"styles": ["src/styles.css"]`, and put a visible rule in it such as
   `body { background: rebeccapurple; }`
3. Start the sandbox and open any story
4. The background rule applies, which is the injection this plugin performs - the filter must not
   have stopped it

To see the hook is no longer called for unrelated modules, add a `console.log(id)` as the first
line of the handler and start the sandbox before and after this change: before, it prints one line
per module in the graph; after, it prints once.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No user-facing behaviour changes, so nothing to document.

