### PR TITLE
Core: Clean Up Paused Animations After AfterEach Failure

### DIFF
--- a/code/core/src/preview-api/modules/store/csf/portable-stories.browser.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/portable-stories.browser.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment happy-dom
+import { afterEach, expect, it, vi } from 'vitest';
+
+import { composeStory } from './portable-stories.ts';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.head.querySelectorAll('style').forEach((style) => style.remove());
+});
+
+it('restores animations when afterEach throws', async () => {
+  vi.stubGlobal('__vitest_browser__', true);
+
+  const story = composeStory(
+    { render: () => {} },
+    {},
+    {
+      afterEach: async () => {
+        throw new Error('afterEach failed');
+      },
+      mount: (context) => async () => context.canvas,
+    }
+  );
+
+  await expect(story.run()).rejects.toThrow('afterEach failed');
+
+  expect(document.head.textContent).not.toContain('animation-play-state: paused');
+});

--- a/code/core/src/preview-api/modules/store/csf/portable-stories.ts
+++ b/code/core/src/preview-api/modules/store/csf/portable-stories.ts
@@ -360,7 +360,9 @@ async function runStory<TRenderer extends Renderer>(
     await waitForAnimations(context.abortSignal);
   }
 
-  await story.applyAfterEach(context);
-
-  await cleanUp?.();
+  try {
+    await story.applyAfterEach(context);
+  } finally {
+    await cleanUp?.();
+  }
 }


### PR DESCRIPTION
Closes #36097

## What I did

- Guaranteed that the cleanup returned by `pauseAnimations()` runs when a portable story’s `applyAfterEach` hook throws.
- Preserved propagation of the original `afterEach` error.
- Added a browser-environment regression test confirming the document-wide animation pause stylesheet does not leak into subsequent stories.

AI assistance disclosure: Codex assisted with investigation, implementation, testing, and review. I reviewed and submitted the contribution.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No additional manual testing is necessary. The regression test directly reproduces the browser behavior by running a portable story whose `afterEach` hook throws and verifying that `document.head` no longer contains the injected `animation-play-state: paused` stylesheet.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)