### PR TITLE
CLI: Match Storybook instances across Windows drive-letter case

### DIFF
--- a/code/core/src/cli/tools/instances/project-path.test.ts
+++ b/code/core/src/cli/tools/instances/project-path.test.ts
@@ -1,27 +1,44 @@
-import { posix, win32 } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { describe, expect, it } from 'vitest';
-
+import { mockNodePath } from '../test-support/mock-node-path.ts';
 import { projectPathsEqual } from './project-path.ts';
 
+vi.mock('node:path', { spy: true });
+
 describe('projectPathsEqual', () => {
-  it('treats Windows drive-letter case and separators as the same path', () => {
-    expect(projectPathsEqual('C:/proj', 'c:\\proj', win32)).toBe(true);
-    expect(projectPathsEqual('C:/proj', 'C:\\proj', win32)).toBe(true);
-    expect(projectPathsEqual('C:/proj', 'c:/proj', win32)).toBe(true);
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it('treats Windows paths that differ only in letter case as the same path', () => {
-    expect(projectPathsEqual('C:/Users/Jeppe/Proj', 'c:/users/jeppe/proj', win32)).toBe(true);
+  describe('on Windows', () => {
+    beforeEach(() => {
+      mockNodePath('win32');
+    });
+
+    it('treats Windows drive-letter case and separators as the same path', () => {
+      expect(projectPathsEqual('C:/proj', 'c:\\proj')).toBe(true);
+      expect(projectPathsEqual('C:/proj', 'C:\\proj')).toBe(true);
+      expect(projectPathsEqual('C:/proj', 'c:/proj')).toBe(true);
+    });
+
+    it('treats Windows paths that differ only in letter case as the same path', () => {
+      expect(projectPathsEqual('C:/Users/Jeppe/Proj', 'c:/users/jeppe/proj')).toBe(true);
+    });
+
+    it('does not match different Windows paths', () => {
+      expect(projectPathsEqual('C:/proj', 'C:/other')).toBe(false);
+      expect(projectPathsEqual('C:/proj', 'D:/proj')).toBe(false);
+    });
   });
 
-  it('does not match different Windows paths', () => {
-    expect(projectPathsEqual('C:/proj', 'C:/other', win32)).toBe(false);
-    expect(projectPathsEqual('C:/proj', 'D:/proj', win32)).toBe(false);
-  });
+  describe('on POSIX', () => {
+    beforeEach(() => {
+      mockNodePath('posix');
+    });
 
-  it('keeps POSIX path compares byte-exact', () => {
-    expect(projectPathsEqual('/Users/x/foo', '/Users/x/foo', posix)).toBe(true);
-    expect(projectPathsEqual('/Users/x/foo', '/Users/x/Foo', posix)).toBe(false);
+    it('keeps POSIX path compares byte-exact', () => {
+      expect(projectPathsEqual('/Users/x/foo', '/Users/x/foo')).toBe(true);
+      expect(projectPathsEqual('/Users/x/foo', '/Users/x/Foo')).toBe(false);
+    });
   });
 });

--- a/code/core/src/cli/tools/instances/project-path.test.ts
+++ b/code/core/src/cli/tools/instances/project-path.test.ts
@@ -1,0 +1,27 @@
+import { posix, win32 } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { projectPathsEqual } from './project-path.ts';
+
+describe('projectPathsEqual', () => {
+  it('treats Windows drive-letter case and separators as the same path', () => {
+    expect(projectPathsEqual('C:/proj', 'c:\\proj', win32)).toBe(true);
+    expect(projectPathsEqual('C:/proj', 'C:\\proj', win32)).toBe(true);
+    expect(projectPathsEqual('C:/proj', 'c:/proj', win32)).toBe(true);
+  });
+
+  it('treats Windows paths that differ only in letter case as the same path', () => {
+    expect(projectPathsEqual('C:/Users/Jeppe/Proj', 'c:/users/jeppe/proj', win32)).toBe(true);
+  });
+
+  it('does not match different Windows paths', () => {
+    expect(projectPathsEqual('C:/proj', 'C:/other', win32)).toBe(false);
+    expect(projectPathsEqual('C:/proj', 'D:/proj', win32)).toBe(false);
+  });
+
+  it('keeps POSIX path compares byte-exact', () => {
+    expect(projectPathsEqual('/Users/x/foo', '/Users/x/foo', posix)).toBe(true);
+    expect(projectPathsEqual('/Users/x/foo', '/Users/x/Foo', posix)).toBe(false);
+  });
+});

--- a/code/core/src/cli/tools/instances/project-path.ts
+++ b/code/core/src/cli/tools/instances/project-path.ts
@@ -1,0 +1,20 @@
+import * as nodePath from 'node:path';
+
+export type ProjectPathImpl = Pick<typeof nodePath, 'resolve' | 'sep'>;
+
+function canonicalizeProjectPath(value: string, pathImpl: ProjectPathImpl = nodePath): string {
+  const resolved = pathImpl.resolve(value);
+  if (pathImpl.sep === '\\') {
+    // Windows resolve keeps the input drive-letter case; NTFS identity is case-insensitive.
+    return resolved.toLowerCase();
+  }
+  return resolved;
+}
+
+export function projectPathsEqual(
+  a: string,
+  b: string,
+  pathImpl: ProjectPathImpl = nodePath
+): boolean {
+  return canonicalizeProjectPath(a, pathImpl) === canonicalizeProjectPath(b, pathImpl);
+}

--- a/code/core/src/cli/tools/instances/project-path.ts
+++ b/code/core/src/cli/tools/instances/project-path.ts
@@ -1,20 +1,14 @@
-import * as nodePath from 'node:path';
+import * as path from 'node:path';
 
-export type ProjectPathImpl = Pick<typeof nodePath, 'resolve' | 'sep'>;
-
-function canonicalizeProjectPath(value: string, pathImpl: ProjectPathImpl = nodePath): string {
-  const resolved = pathImpl.resolve(value);
-  if (pathImpl.sep === '\\') {
+function canonicalizeProjectPath(value: string): string {
+  const resolved = path.resolve(value);
+  if (path.sep === '\\') {
     // Windows resolve keeps the input drive-letter case; NTFS identity is case-insensitive.
     return resolved.toLowerCase();
   }
   return resolved;
 }
 
-export function projectPathsEqual(
-  a: string,
-  b: string,
-  pathImpl: ProjectPathImpl = nodePath
-): boolean {
-  return canonicalizeProjectPath(a, pathImpl) === canonicalizeProjectPath(b, pathImpl);
+export function projectPathsEqual(a: string, b: string): boolean {
+  return canonicalizeProjectPath(a) === canonicalizeProjectPath(b);
 }

--- a/code/core/src/cli/tools/instances/resolve.test.ts
+++ b/code/core/src/cli/tools/instances/resolve.test.ts
@@ -1,5 +1,8 @@
+import { posix, win32 } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
+import { projectPathsEqual } from './project-path.ts';
 import { resolveInstance, selectInstances } from './resolve.ts';
 import type { McpStatus, StorybookInstanceRecord } from './types.ts';
 
@@ -657,5 +660,90 @@ describe('selectInstances', () => {
     });
     const result = selectInstances([foo, bar], { cwd: '/Users/x/projects/other', port: 6006 });
     expect(result).toEqual({ kind: 'match', matches: [bar, foo] });
+  });
+});
+
+describe('projectPathsEqual', () => {
+  it('treats Windows drive-letter case and separators as the same path', () => {
+    expect(projectPathsEqual('C:/proj', 'c:\\proj', win32)).toBe(true);
+    expect(projectPathsEqual('C:/proj', 'C:\\proj', win32)).toBe(true);
+    expect(projectPathsEqual('C:/proj', 'c:/proj', win32)).toBe(true);
+  });
+
+  it('treats Windows paths that differ only in letter case as the same path', () => {
+    expect(projectPathsEqual('C:/Users/Jeppe/Proj', 'c:/users/jeppe/proj', win32)).toBe(true);
+  });
+
+  it('does not match different Windows paths', () => {
+    expect(projectPathsEqual('C:/proj', 'C:/other', win32)).toBe(false);
+    expect(projectPathsEqual('C:/proj', 'D:/proj', win32)).toBe(false);
+  });
+
+  it('keeps POSIX path compares byte-exact', () => {
+    expect(projectPathsEqual('/Users/x/foo', '/Users/x/foo', posix)).toBe(true);
+    expect(projectPathsEqual('/Users/x/foo', '/Users/x/Foo', posix)).toBe(false);
+  });
+});
+
+describe('Windows instance matching', () => {
+  it('matches a recorded C:/ cwd against lowercase drive-letter and separator variants', () => {
+    const r = record('C:/dev/temp/qa-10.6/cases/react-vite');
+    for (const cwd of [
+      'C:\\dev\\temp\\qa-10.6\\cases\\react-vite',
+      'C:/dev/temp/qa-10.6/cases/react-vite',
+      'c:\\dev\\temp\\qa-10.6\\cases\\react-vite',
+      'c:/dev/temp/qa-10.6/cases/react-vite',
+    ]) {
+      expect(resolveInstance([r], { cwd }, win32)).toEqual({
+        kind: 'instance',
+        record: r,
+        matches: [r],
+      });
+    }
+  });
+
+  it('matches configDir across Windows drive-letter case when cwds differ', () => {
+    const r = record('C:/repo', 'ready', { configDir: 'C:/repo/packages/ui/.storybook' });
+    const result = resolveInstance(
+      [r],
+      {
+        cwd: 'c:/elsewhere',
+        configDir: 'c:\\repo\\packages\\ui\\.storybook',
+      },
+      win32
+    );
+    expect(result).toEqual({ kind: 'instance', record: r, matches: [r] });
+  });
+
+  it('does not match a different Windows path', () => {
+    const r = record('C:/proj');
+    const result = resolveInstance([r], { cwd: 'C:/other' }, win32);
+    expect(result.kind).toBe('intercept');
+    if (result.kind === 'intercept') {
+      expect(result.reason).toBe('no-instance');
+      expect(result.records).toEqual([r]);
+    }
+  });
+
+  it('keeps POSIX cwd compares byte-exact through resolveInstance', () => {
+    const r = record('/Users/x/foo');
+    expect(resolveInstance([r], { cwd: '/Users/x/foo' }, posix)).toEqual({
+      kind: 'instance',
+      record: r,
+      matches: [r],
+    });
+    const result = resolveInstance([r], { cwd: '/Users/x/Foo' }, posix);
+    expect(result.kind).toBe('intercept');
+    if (result.kind === 'intercept') {
+      expect(result.reason).toBe('no-instance');
+    }
+  });
+
+  it('selects the Windows instance whose cwd matches ignoring drive-letter case', () => {
+    const r = record('C:/proj');
+    expect(selectInstances([r], { cwd: 'c:\\proj' }, win32)).toEqual({
+      kind: 'match',
+      matches: [r],
+    });
   });
 });

--- a/code/core/src/cli/tools/instances/resolve.test.ts
+++ b/code/core/src/cli/tools/instances/resolve.test.ts
@@ -1,9 +1,10 @@
-import { posix, win32 } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { describe, expect, it } from 'vitest';
-
+import { mockNodePath } from '../test-support/mock-node-path.ts';
 import { resolveInstance, selectInstances } from './resolve.ts';
 import type { McpStatus, StorybookInstanceRecord } from './types.ts';
+
+vi.mock('node:path', { spy: true });
 
 let nextInstance = 0;
 
@@ -663,6 +664,14 @@ describe('selectInstances', () => {
 });
 
 describe('Windows instance matching', () => {
+  beforeEach(() => {
+    mockNodePath('win32');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('matches a recorded C:/ cwd against lowercase drive-letter and separator variants', () => {
     const r = record('C:/dev/temp/qa-10.6/cases/react-vite');
     for (const cwd of [
@@ -671,7 +680,7 @@ describe('Windows instance matching', () => {
       'c:\\dev\\temp\\qa-10.6\\cases\\react-vite',
       'c:/dev/temp/qa-10.6/cases/react-vite',
     ]) {
-      expect(resolveInstance([r], { cwd }, win32)).toEqual({
+      expect(resolveInstance([r], { cwd })).toEqual({
         kind: 'instance',
         record: r,
         matches: [r],
@@ -681,20 +690,16 @@ describe('Windows instance matching', () => {
 
   it('matches configDir across Windows drive-letter case when cwds differ', () => {
     const r = record('C:/repo', 'ready', { configDir: 'C:/repo/packages/ui/.storybook' });
-    const result = resolveInstance(
-      [r],
-      {
-        cwd: 'c:/elsewhere',
-        configDir: 'c:\\repo\\packages\\ui\\.storybook',
-      },
-      win32
-    );
+    const result = resolveInstance([r], {
+      cwd: 'c:/elsewhere',
+      configDir: 'c:\\repo\\packages\\ui\\.storybook',
+    });
     expect(result).toEqual({ kind: 'instance', record: r, matches: [r] });
   });
 
   it('does not match a different Windows path', () => {
     const r = record('C:/proj');
-    const result = resolveInstance([r], { cwd: 'C:/other' }, win32);
+    const result = resolveInstance([r], { cwd: 'C:/other' });
     expect(result.kind).toBe('intercept');
     if (result.kind === 'intercept') {
       expect(result.reason).toBe('no-instance');
@@ -702,25 +707,35 @@ describe('Windows instance matching', () => {
     }
   });
 
+  it('selects the Windows instance whose cwd matches ignoring drive-letter case', () => {
+    const r = record('C:/proj');
+    expect(selectInstances([r], { cwd: 'c:\\proj' })).toEqual({
+      kind: 'match',
+      matches: [r],
+    });
+  });
+});
+
+describe('POSIX instance matching', () => {
+  beforeEach(() => {
+    mockNodePath('posix');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('keeps POSIX cwd compares byte-exact through resolveInstance', () => {
     const r = record('/Users/x/foo');
-    expect(resolveInstance([r], { cwd: '/Users/x/foo' }, posix)).toEqual({
+    expect(resolveInstance([r], { cwd: '/Users/x/foo' })).toEqual({
       kind: 'instance',
       record: r,
       matches: [r],
     });
-    const result = resolveInstance([r], { cwd: '/Users/x/Foo' }, posix);
+    const result = resolveInstance([r], { cwd: '/Users/x/Foo' });
     expect(result.kind).toBe('intercept');
     if (result.kind === 'intercept') {
       expect(result.reason).toBe('no-instance');
     }
-  });
-
-  it('selects the Windows instance whose cwd matches ignoring drive-letter case', () => {
-    const r = record('C:/proj');
-    expect(selectInstances([r], { cwd: 'c:\\proj' }, win32)).toEqual({
-      kind: 'match',
-      matches: [r],
-    });
   });
 });

--- a/code/core/src/cli/tools/instances/resolve.test.ts
+++ b/code/core/src/cli/tools/instances/resolve.test.ts
@@ -2,7 +2,6 @@ import { posix, win32 } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { projectPathsEqual } from './project-path.ts';
 import { resolveInstance, selectInstances } from './resolve.ts';
 import type { McpStatus, StorybookInstanceRecord } from './types.ts';
 
@@ -660,28 +659,6 @@ describe('selectInstances', () => {
     });
     const result = selectInstances([foo, bar], { cwd: '/Users/x/projects/other', port: 6006 });
     expect(result).toEqual({ kind: 'match', matches: [bar, foo] });
-  });
-});
-
-describe('projectPathsEqual', () => {
-  it('treats Windows drive-letter case and separators as the same path', () => {
-    expect(projectPathsEqual('C:/proj', 'c:\\proj', win32)).toBe(true);
-    expect(projectPathsEqual('C:/proj', 'C:\\proj', win32)).toBe(true);
-    expect(projectPathsEqual('C:/proj', 'c:/proj', win32)).toBe(true);
-  });
-
-  it('treats Windows paths that differ only in letter case as the same path', () => {
-    expect(projectPathsEqual('C:/Users/Jeppe/Proj', 'c:/users/jeppe/proj', win32)).toBe(true);
-  });
-
-  it('does not match different Windows paths', () => {
-    expect(projectPathsEqual('C:/proj', 'C:/other', win32)).toBe(false);
-    expect(projectPathsEqual('C:/proj', 'D:/proj', win32)).toBe(false);
-  });
-
-  it('keeps POSIX path compares byte-exact', () => {
-    expect(projectPathsEqual('/Users/x/foo', '/Users/x/foo', posix)).toBe(true);
-    expect(projectPathsEqual('/Users/x/foo', '/Users/x/Foo', posix)).toBe(false);
   });
 });
 

--- a/code/core/src/cli/tools/instances/resolve.ts
+++ b/code/core/src/cli/tools/instances/resolve.ts
@@ -1,9 +1,8 @@
-import { resolve } from 'node:path';
-
 import {
   CLAUDE_AGENT_NAME,
   CLAUDE_PREVIEW_AGENT_NAME,
 } from '../../../shared/constants/agent-provenance.ts';
+import { projectPathsEqual, type ProjectPathImpl } from './project-path.ts';
 import type { InterceptReason, StorybookInstanceRecord } from './types.ts';
 
 export type ResolveResult =
@@ -44,8 +43,9 @@ export type ResolveTarget = {
  * Pick the Storybook instance that matches the target project. With an explicit `--config-dir`
  * (`configDirExplicit`), only records whose recorded `configDir` equals `target.configDir` match.
  * Otherwise a record matches when its recorded `cwd` equals `target.cwd` OR its recorded
- * `configDir` equals the defaulted `target.configDir`. All comparisons are exact-normalized with
- * no longest-prefix or fallback behaviour (milestone 2 of storybookjs/storybook#34826). The
+ * `configDir` equals the defaulted `target.configDir`. All comparisons use resolved paths
+ * (case-insensitive on Windows, byte-exact on POSIX) with no longest-prefix or fallback
+ * behaviour (milestone 2 of storybookjs/storybook#34826). The
  * configDir key exists for monorepos (storybookjs/storybook#35359): a dev server started at the
  * repo root with `-c packages/ui/.storybook` must be found by a CLI run from `packages/ui`, and
  * vice versa. Records from older Storybooks carry no `configDir` and can only match by cwd — so
@@ -74,9 +74,10 @@ export type ResolveTarget = {
  */
 export function resolveInstance(
   records: StorybookInstanceRecord[],
-  target: ResolveTarget
+  target: ResolveTarget,
+  pathImpl?: ProjectPathImpl
 ): ResolveResult {
-  const selection = selectInstances(records, target);
+  const selection = selectInstances(records, target, pathImpl);
   if (selection.kind === 'port-mismatch') {
     return {
       kind: 'intercept',
@@ -161,13 +162,14 @@ export type InstanceSelection =
  */
 export function selectInstances(
   records: StorybookInstanceRecord[],
-  target: ResolveTarget
+  target: ResolveTarget,
+  pathImpl?: ProjectPathImpl
 ): InstanceSelection {
   const { port: targetPort, agent: currentAgent } = target;
 
   if (targetPort != null) {
     const candidates = target.configDirExplicit
-      ? records.filter((record) => matchesTargetConfigDir(record, target))
+      ? records.filter((record) => matchesTargetConfigDir(record, target, pathImpl))
       : records;
     const matches = candidates.filter((record) => record.port === targetPort);
     if (matches.length === 0) {
@@ -178,7 +180,7 @@ export function selectInstances(
     return { kind: 'match', matches: [...matches].sort(byMostRecentlyStarted) };
   }
 
-  const projectMatches = listProjectMatches(records, target);
+  const projectMatches = listProjectMatches(records, target, pathImpl);
   if (projectMatches.length === 0) {
     return { kind: 'no-instance', records };
   }
@@ -188,24 +190,27 @@ export function selectInstances(
 /** Records whose cwd or configDir matches the target project, ignoring MCP status. */
 export function listProjectMatches(
   records: StorybookInstanceRecord[],
-  target: Pick<ResolveTarget, 'cwd' | 'configDir' | 'configDirExplicit'>
+  target: Pick<ResolveTarget, 'cwd' | 'configDir' | 'configDirExplicit'>,
+  pathImpl?: ProjectPathImpl
 ): StorybookInstanceRecord[] {
-  const normalisedCwd = resolve(target.cwd);
   return target.configDirExplicit
-    ? records.filter((record) => matchesTargetConfigDir(record, target))
+    ? records.filter((record) => matchesTargetConfigDir(record, target, pathImpl))
     : records.filter(
-        (record) => resolve(record.cwd) === normalisedCwd || matchesTargetConfigDir(record, target)
+        (record) =>
+          projectPathsEqual(record.cwd, target.cwd, pathImpl) ||
+          matchesTargetConfigDir(record, target, pathImpl)
       );
 }
 
 function matchesTargetConfigDir(
   record: StorybookInstanceRecord,
-  target: Pick<ResolveTarget, 'configDir'>
+  target: Pick<ResolveTarget, 'configDir'>,
+  pathImpl?: ProjectPathImpl
 ): boolean {
   return (
     target.configDir != null &&
     record.configDir != null &&
-    resolve(record.configDir) === resolve(target.configDir)
+    projectPathsEqual(record.configDir, target.configDir, pathImpl)
   );
 }
 

--- a/code/core/src/cli/tools/instances/resolve.ts
+++ b/code/core/src/cli/tools/instances/resolve.ts
@@ -2,7 +2,7 @@ import {
   CLAUDE_AGENT_NAME,
   CLAUDE_PREVIEW_AGENT_NAME,
 } from '../../../shared/constants/agent-provenance.ts';
-import { projectPathsEqual, type ProjectPathImpl } from './project-path.ts';
+import { projectPathsEqual } from './project-path.ts';
 import type { InterceptReason, StorybookInstanceRecord } from './types.ts';
 
 export type ResolveResult =
@@ -74,10 +74,9 @@ export type ResolveTarget = {
  */
 export function resolveInstance(
   records: StorybookInstanceRecord[],
-  target: ResolveTarget,
-  pathImpl?: ProjectPathImpl
+  target: ResolveTarget
 ): ResolveResult {
-  const selection = selectInstances(records, target, pathImpl);
+  const selection = selectInstances(records, target);
   if (selection.kind === 'port-mismatch') {
     return {
       kind: 'intercept',
@@ -162,14 +161,13 @@ export type InstanceSelection =
  */
 export function selectInstances(
   records: StorybookInstanceRecord[],
-  target: ResolveTarget,
-  pathImpl?: ProjectPathImpl
+  target: ResolveTarget
 ): InstanceSelection {
   const { port: targetPort, agent: currentAgent } = target;
 
   if (targetPort != null) {
     const candidates = target.configDirExplicit
-      ? records.filter((record) => matchesTargetConfigDir(record, target, pathImpl))
+      ? records.filter((record) => matchesTargetConfigDir(record, target))
       : records;
     const matches = candidates.filter((record) => record.port === targetPort);
     if (matches.length === 0) {
@@ -180,7 +178,7 @@ export function selectInstances(
     return { kind: 'match', matches: [...matches].sort(byMostRecentlyStarted) };
   }
 
-  const projectMatches = listProjectMatches(records, target, pathImpl);
+  const projectMatches = listProjectMatches(records, target);
   if (projectMatches.length === 0) {
     return { kind: 'no-instance', records };
   }
@@ -190,27 +188,24 @@ export function selectInstances(
 /** Records whose cwd or configDir matches the target project, ignoring MCP status. */
 export function listProjectMatches(
   records: StorybookInstanceRecord[],
-  target: Pick<ResolveTarget, 'cwd' | 'configDir' | 'configDirExplicit'>,
-  pathImpl?: ProjectPathImpl
+  target: Pick<ResolveTarget, 'cwd' | 'configDir' | 'configDirExplicit'>
 ): StorybookInstanceRecord[] {
   return target.configDirExplicit
-    ? records.filter((record) => matchesTargetConfigDir(record, target, pathImpl))
+    ? records.filter((record) => matchesTargetConfigDir(record, target))
     : records.filter(
         (record) =>
-          projectPathsEqual(record.cwd, target.cwd, pathImpl) ||
-          matchesTargetConfigDir(record, target, pathImpl)
+          projectPathsEqual(record.cwd, target.cwd) || matchesTargetConfigDir(record, target)
       );
 }
 
 function matchesTargetConfigDir(
   record: StorybookInstanceRecord,
-  target: Pick<ResolveTarget, 'configDir'>,
-  pathImpl?: ProjectPathImpl
+  target: Pick<ResolveTarget, 'configDir'>
 ): boolean {
   return (
     target.configDir != null &&
     record.configDir != null &&
-    projectPathsEqual(record.configDir, target.configDir, pathImpl)
+    projectPathsEqual(record.configDir, target.configDir)
   );
 }
 

--- a/code/core/src/cli/tools/sdk/create-tools.ts
+++ b/code/core/src/cli/tools/sdk/create-tools.ts
@@ -12,9 +12,10 @@ import type {
   ToolsetTransport,
 } from '../../../shared/open-service/toolset-definition.ts';
 import { parseToolsetMethodId } from '../../../shared/open-service/toolset-names.ts';
-import { toCatalogEntry } from './catalog.ts';
+import { projectPathsEqual } from '../instances/project-path.ts';
 import type { StorybookInstanceRecord } from '../instances/types.ts';
 import type { AttachedBootstrapResult } from './attached-runtime.ts';
+import { toCatalogEntry } from './catalog.ts';
 import { formatAttachFallback } from './attach-messages.ts';
 import { spawnChildHost } from './child-client.ts';
 import {
@@ -237,7 +238,7 @@ async function createLocalTools(
   const isChildHost = process.env.STORYBOOK_TOOLS_CHILD_HOST === 'true';
   const autoSpawn = isChildHost ? false : (options.autoSpawn ?? true);
 
-  if (cwd !== process.cwd()) {
+  if (!projectPathsEqual(cwd, process.cwd())) {
     if (!autoSpawn) {
       throw new ToolsRuntimeError({
         reason: 'mode-unavailable',

--- a/code/core/src/cli/tools/sdk/fidelity.test.ts
+++ b/code/core/src/cli/tools/sdk/fidelity.test.ts
@@ -1,9 +1,12 @@
 import { posix, win32 } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { StorybookInstanceRecord } from '../instances/types.ts';
+import { mockNodePath } from '../test-support/mock-node-path.ts';
 import { checkFidelity } from './fidelity.ts';
+
+vi.mock('node:path', { spy: true });
 
 const record: StorybookInstanceRecord = {
   schemaVersion: 1,
@@ -49,51 +52,66 @@ describe('checkFidelity', () => {
     });
   });
 
-  it('accepts a Windows cwd that differs only by drive-letter case or separators', () => {
-    const windowsRecord = { ...record, cwd: 'C:/repo' };
-    expect(checkFidelity(windowsRecord, { cwd: 'c:\\repo', version: '10.2.0' }, win32)).toEqual({
-      ok: true,
+  describe('on Windows', () => {
+    beforeEach(() => {
+      mockNodePath('win32');
     });
-    expect(checkFidelity(windowsRecord, { cwd: 'C:\\repo', version: '10.2.0' }, win32)).toEqual({
-      ok: true,
+
+    afterEach(() => {
+      vi.restoreAllMocks();
     });
-    expect(checkFidelity(windowsRecord, { cwd: 'c:/repo', version: '10.2.0' }, win32)).toEqual({
-      ok: true,
+
+    it('accepts a Windows cwd that differs only by drive-letter case or separators', () => {
+      const windowsRecord = { ...record, cwd: 'C:/repo' };
+      expect(checkFidelity(windowsRecord, { cwd: 'c:\\repo', version: '10.2.0' })).toEqual({
+        ok: true,
+      });
+      expect(checkFidelity(windowsRecord, { cwd: 'C:\\repo', version: '10.2.0' })).toEqual({
+        ok: true,
+      });
+      expect(checkFidelity(windowsRecord, { cwd: 'c:/repo', version: '10.2.0' })).toEqual({
+        ok: true,
+      });
+    });
+
+    it('accepts Windows cwds that differ only in letter case', () => {
+      expect(
+        checkFidelity(
+          { ...record, cwd: 'C:/Users/Jeppe/Proj' },
+          { cwd: 'c:/users/jeppe/proj', version: '10.2.0' }
+        )
+      ).toEqual({ ok: true });
+    });
+
+    it('rejects a different Windows cwd even when versions match', () => {
+      expect(
+        checkFidelity({ ...record, cwd: 'C:/repo' }, { cwd: 'C:/elsewhere', version: '10.2.0' })
+      ).toEqual({
+        ok: false,
+        kind: 'cwd',
+        processCwd: win32.resolve('C:/elsewhere'),
+        instanceCwd: win32.resolve('C:/repo'),
+      });
     });
   });
 
-  it('accepts Windows cwds that differ only in letter case', () => {
-    expect(
-      checkFidelity(
-        { ...record, cwd: 'C:/Users/Jeppe/Proj' },
-        { cwd: 'c:/users/jeppe/proj', version: '10.2.0' },
-        win32
-      )
-    ).toEqual({ ok: true });
-  });
-
-  it('rejects a different Windows cwd even when versions match', () => {
-    expect(
-      checkFidelity(
-        { ...record, cwd: 'C:/repo' },
-        { cwd: 'C:/elsewhere', version: '10.2.0' },
-        win32
-      )
-    ).toEqual({
-      ok: false,
-      kind: 'cwd',
-      processCwd: win32.resolve('C:/elsewhere'),
-      instanceCwd: win32.resolve('C:/repo'),
+  describe('on POSIX', () => {
+    beforeEach(() => {
+      mockNodePath('posix');
     });
-  });
 
-  it('keeps POSIX cwd compares byte-exact', () => {
-    expect(checkFidelity(record, { cwd: '/repo', version: '10.2.0' }, posix)).toEqual({ ok: true });
-    expect(checkFidelity(record, { cwd: '/Repo', version: '10.2.0' }, posix)).toEqual({
-      ok: false,
-      kind: 'cwd',
-      processCwd: posix.resolve('/Repo'),
-      instanceCwd: posix.resolve('/repo'),
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('keeps POSIX cwd compares byte-exact', () => {
+      expect(checkFidelity(record, { cwd: '/repo', version: '10.2.0' })).toEqual({ ok: true });
+      expect(checkFidelity(record, { cwd: '/Repo', version: '10.2.0' })).toEqual({
+        ok: false,
+        kind: 'cwd',
+        processCwd: posix.resolve('/Repo'),
+        instanceCwd: posix.resolve('/repo'),
+      });
     });
   });
 });

--- a/code/core/src/cli/tools/sdk/fidelity.test.ts
+++ b/code/core/src/cli/tools/sdk/fidelity.test.ts
@@ -1,3 +1,5 @@
+import { posix, win32 } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import type { StorybookInstanceRecord } from '../instances/types.ts';
@@ -44,6 +46,54 @@ describe('checkFidelity', () => {
       kind: 'version',
       callerVersion: '10.2.0',
       instanceVersion: 'unknown',
+    });
+  });
+
+  it('accepts a Windows cwd that differs only by drive-letter case or separators', () => {
+    const windowsRecord = { ...record, cwd: 'C:/repo' };
+    expect(checkFidelity(windowsRecord, { cwd: 'c:\\repo', version: '10.2.0' }, win32)).toEqual({
+      ok: true,
+    });
+    expect(checkFidelity(windowsRecord, { cwd: 'C:\\repo', version: '10.2.0' }, win32)).toEqual({
+      ok: true,
+    });
+    expect(checkFidelity(windowsRecord, { cwd: 'c:/repo', version: '10.2.0' }, win32)).toEqual({
+      ok: true,
+    });
+  });
+
+  it('accepts Windows cwds that differ only in letter case', () => {
+    expect(
+      checkFidelity(
+        { ...record, cwd: 'C:/Users/Jeppe/Proj' },
+        { cwd: 'c:/users/jeppe/proj', version: '10.2.0' },
+        win32
+      )
+    ).toEqual({ ok: true });
+  });
+
+  it('rejects a different Windows cwd even when versions match', () => {
+    expect(
+      checkFidelity(
+        { ...record, cwd: 'C:/repo' },
+        { cwd: 'C:/elsewhere', version: '10.2.0' },
+        win32
+      )
+    ).toEqual({
+      ok: false,
+      kind: 'cwd',
+      processCwd: win32.resolve('C:/elsewhere'),
+      instanceCwd: win32.resolve('C:/repo'),
+    });
+  });
+
+  it('keeps POSIX cwd compares byte-exact', () => {
+    expect(checkFidelity(record, { cwd: '/repo', version: '10.2.0' }, posix)).toEqual({ ok: true });
+    expect(checkFidelity(record, { cwd: '/Repo', version: '10.2.0' }, posix)).toEqual({
+      ok: false,
+      kind: 'cwd',
+      processCwd: posix.resolve('/Repo'),
+      instanceCwd: posix.resolve('/repo'),
     });
   });
 });

--- a/code/core/src/cli/tools/sdk/fidelity.ts
+++ b/code/core/src/cli/tools/sdk/fidelity.ts
@@ -1,5 +1,6 @@
-import { resolve } from 'node:path';
+import * as nodePath from 'node:path';
 
+import { projectPathsEqual, type ProjectPathImpl } from '../instances/project-path.ts';
 import type { StorybookInstanceRecord } from '../instances/types.ts';
 
 export type FidelityMatch = { ok: true };
@@ -17,12 +18,16 @@ export type FidelityResult = FidelityMatch | FidelityMismatch;
 
 export function checkFidelity(
   record: Pick<StorybookInstanceRecord, 'cwd' | 'storybookVersion'>,
-  { cwd, version }: { cwd: string; version: string }
+  { cwd, version }: { cwd: string; version: string },
+  pathImpl: ProjectPathImpl = nodePath
 ): FidelityResult {
-  const processCwd = resolve(cwd);
-  const instanceCwd = resolve(record.cwd);
-  if (processCwd !== instanceCwd) {
-    return { ok: false, kind: 'cwd', processCwd, instanceCwd };
+  if (!projectPathsEqual(cwd, record.cwd, pathImpl)) {
+    return {
+      ok: false,
+      kind: 'cwd',
+      processCwd: pathImpl.resolve(cwd),
+      instanceCwd: pathImpl.resolve(record.cwd),
+    };
   }
 
   const instanceVersion = record.storybookVersion;

--- a/code/core/src/cli/tools/sdk/fidelity.ts
+++ b/code/core/src/cli/tools/sdk/fidelity.ts
@@ -1,6 +1,6 @@
-import * as nodePath from 'node:path';
+import * as path from 'node:path';
 
-import { projectPathsEqual, type ProjectPathImpl } from '../instances/project-path.ts';
+import { projectPathsEqual } from '../instances/project-path.ts';
 import type { StorybookInstanceRecord } from '../instances/types.ts';
 
 export type FidelityMatch = { ok: true };
@@ -18,16 +18,12 @@ export type FidelityResult = FidelityMatch | FidelityMismatch;
 
 export function checkFidelity(
   record: Pick<StorybookInstanceRecord, 'cwd' | 'storybookVersion'>,
-  { cwd, version }: { cwd: string; version: string },
-  pathImpl: ProjectPathImpl = nodePath
+  { cwd, version }: { cwd: string; version: string }
 ): FidelityResult {
-  if (!projectPathsEqual(cwd, record.cwd, pathImpl)) {
-    return {
-      ok: false,
-      kind: 'cwd',
-      processCwd: pathImpl.resolve(cwd),
-      instanceCwd: pathImpl.resolve(record.cwd),
-    };
+  const processCwd = path.resolve(cwd);
+  const instanceCwd = path.resolve(record.cwd);
+  if (!projectPathsEqual(cwd, record.cwd)) {
+    return { ok: false, kind: 'cwd', processCwd, instanceCwd };
   }
 
   const instanceVersion = record.storybookVersion;

--- a/code/core/src/cli/tools/sdk/local-runtime.ts
+++ b/code/core/src/cli/tools/sdk/local-runtime.ts
@@ -24,6 +24,7 @@ import {
 } from '../../../shared/open-service/toolset-registry.ts';
 import { resolveStorybookConfigDir } from '../config-dir.ts';
 import type { ToolsTarget } from '../discover-instance.ts';
+import { projectPathsEqual } from '../instances/project-path.ts';
 import { ToolsRuntimeError } from './errors.ts';
 
 export type ToolsRuntime = {
@@ -54,7 +55,7 @@ export async function bootstrapToolsRuntime(
   deps: { setChangeDetectionHost?: typeof experimental_setChangeDetectionHost } = {}
 ): Promise<ToolsRuntime> {
   const cwd = resolve(target.cwd ?? process.cwd());
-  if (cwd !== process.cwd()) {
+  if (!projectPathsEqual(cwd, process.cwd())) {
     throw new ToolsRuntimeError({
       reason: 'mode-unavailable',
       message: `Local tools bootstrap requires process.cwd() to be the target project (${cwd}), not ${process.cwd()}.`,

--- a/code/core/src/cli/tools/test-support/mock-node-path.ts
+++ b/code/core/src/cli/tools/test-support/mock-node-path.ts
@@ -1,0 +1,14 @@
+import * as path from 'node:path';
+import { posix, win32 } from 'node:path';
+
+import { vi } from 'vitest';
+
+export function mockNodePath(kind: 'win32' | 'posix'): void {
+  const impl = kind === 'win32' ? win32 : posix;
+  if (path.sep === impl.sep) {
+    // Host `path.resolve` is this impl (`posix.resolve === resolve` on POSIX); mocking it recurses.
+    return;
+  }
+  vi.mocked(path.resolve).mockImplementation((...args) => impl.resolve(...args));
+  vi.spyOn(path, 'sep', 'get').mockReturnValue(impl.sep);
+}


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

On Windows, `storybook tools --cwd c:\project` did not attach to a live instance whose record stored `C:/project`. `node:path.resolve` keeps the input drive-letter case, so the reader treated them as different projects and fell back to local tools.

This change compares project cwd/configDir with a Windows-aware equality helper (case-insensitive after resolve, including `C:` vs `c:` and `\` vs `/`). POSIX compares stay byte-exact. The same helper is used for instance matching, attach fidelity, and the local vs child-host cwd check.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.
-->

Run these on native Windows. A Vite React Storybook is enough (sandbox or any local app).

1. From the project directory, start Storybook on a known port, e.g. `npx storybook dev -p 6106 --ci`. Wait until it is ready.
2. Confirm `%USERPROFILE%\.storybook\instances\*.json` for that process has `cwd` like `C:/...` (forward slashes, uppercase drive) and `mcp.status` of `ready`.
3. In a **different** directory (e.g. `%USERPROFILE%`), run each of these. `docs list` can stay on local fallback; watch **stderr** for attach:

   ```
   npx storybook tools --cwd C:\path\to\project docs list
   npx storybook tools --cwd C:/path/to/project docs list
   npx storybook tools --cwd c:\path\to\project docs list
   npx storybook tools --cwd c:/path/to/project docs list
   ```

4. Expected: none of the four print `Running Storybook instances that did not match this project` for this instance. Then `npx storybook tools --cwd c:\path\to\project stories preview --input "{\"stories\":[{\"storyId\":\"<a-real-story-id>\"}]}"` should return a URL on port 6106.

Worth extra scrutiny: a second Storybook on another path must still be reported as unmatched; POSIX path case (`/Users/x/foo` vs `/Users/x/Foo`) must still not match.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
