### PR TITLE
Addon Vitest: Disable project config inheritance

### DIFF
--- a/code/addons/vitest/src/updateVitestFile.config.4.test.ts
+++ b/code/addons/vitest/src/updateVitestFile.config.4.test.ts
@@ -76,7 +76,7 @@ describe('updateConfigFile', () => {
       -     projects: ['packages/*']
       - 
       +     projects: ['packages/*', {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -157,7 +157,7 @@ describe('updateConfigFile', () => {
       -     projects: ['packages/*']
       - 
       +     projects: ['packages/*', {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -270,7 +270,7 @@ describe('updateConfigFile', () => {
       +           hideSkippedTests: true
       +         }
       +       }, {
-      +         extends: true,
+      +         extends: false,
       +         plugins: [
       +         // The plugin will run tests for the stories defined in your Storybook config
       +         // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -398,7 +398,7 @@ describe('updateConfigFile', () => {
       +         globals: true
       +       }
       +     }, {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -482,7 +482,7 @@ describe('updateConfigFile', () => {
       +   plugins: [viteReact()],
       +   test: {
       +     projects: [{
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -563,7 +563,7 @@ describe('updateConfigFile', () => {
               some: 'config'
         
       +     }, {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -646,7 +646,7 @@ describe('updateConfigFile', () => {
       +         globals: true
       +       }
       +     }, {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -721,7 +721,7 @@ describe('updateConfigFile', () => {
       +   plugins: [react()],
       +   test: {
       +     projects: [{
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -808,7 +808,7 @@ describe('updateConfigFile', () => {
       +         environment: 'jsdom'
       +       }
       +     }, {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -890,7 +890,7 @@ describe('updateConfigFile', () => {
       +         environment: 'jsdom'
       +       }
       +     }, {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -966,7 +966,7 @@ describe('updateConfigFile', () => {
       +   plugins: [react()],
       +   test: {
       +     projects: [{
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -1050,7 +1050,7 @@ describe('updateConfigFile', () => {
       +         globals: true
       +       }
       +     }, {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -1139,7 +1139,7 @@ describe('updateConfigFile', () => {
               }
         
       +     }, {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -1238,7 +1238,7 @@ describe('updateConfigFile', () => {
       +         include: ['**/*.test.ts']
       +       }
       +     }, {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -1337,7 +1337,7 @@ describe('updateConfigFile', () => {
       +         include: ['**/*.test.ts']
       +       }
       +     }, {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -1416,7 +1416,7 @@ describe('updateConfigFile', () => {
       +         include: ['**/*.test.ts']
       +       }
       +     }, {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -1499,7 +1499,7 @@ describe('updateConfigFile', () => {
       +         include: ['**/*.test.ts']
       +       }
       +     }, {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -1581,7 +1581,7 @@ describe('updateConfigFile', () => {
       +         include: ['**/*.test.ts']
       +       }
       +     }, {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -1664,7 +1664,7 @@ describe('updateConfigFile', () => {
       +         include: ['**/*.test.ts']
       +       }
       +     }, {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -1748,7 +1748,7 @@ describe('updateConfigFile', () => {
       +         include: ['**/*.test.ts']
       +       }
       +     }, {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -1827,7 +1827,7 @@ describe('updateConfigFile', () => {
       +         include: ['**/*.test.ts']
       +       }
       +     }, {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -1911,7 +1911,7 @@ describe('updateConfigFile', () => {
       +         include: ['**/*.test.ts']
       +       }
       +     }, {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -1994,7 +1994,7 @@ describe('updateConfigFile', () => {
       +         include: ['**/*.test.ts']
       +       }
       +     }, {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -2077,7 +2077,7 @@ describe('updateConfigFile', () => {
       +         include: ['**/*.test.ts']
       +       }
       +     }, {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -2207,7 +2207,7 @@ describe('updateConfigFile', () => {
       +         testTimeout: 120000
       +       }
       +     }, {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -2315,7 +2315,7 @@ describe('updateConfigFile', () => {
       +         maxWorkers: 4
       +       }
       +     }, {
-      +       extends: true,
+      +       extends: false,
       +       plugins: [
       +       // The plugin will run tests for the stories defined in your Storybook config
       +       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest

--- a/code/addons/vitest/templates/vitest.config.4.template.ts
+++ b/code/addons/vitest/templates/vitest.config.4.template.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   test: {
     projects: [
       {
-        extends: true,
+        extends: false,
         plugins: [
           // The plugin will run tests for the stories defined in your Storybook config
           // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest


### PR DESCRIPTION
Closes #36082

## What I did

Changed the Vitest 4+ config template to explicitly set `projects[].extends` to `false`. This keeps Storybook's generated test project isolated when Vitest 5 changes the default to `true`.

I also updated the inline snapshots that cover generated Vitest config output.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No separate manual test should be necessary here. The config-generation unit suite covers the template across the supported merge scenarios and asserts the resulting project configuration.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

AI assistance disclosure: I used Codex to help inspect the code path, update the implementation and snapshots, and run the checks. I reviewed the final diff and test results before submitting.