### PR TITLE
Build: Remove wall-clock timing from two unstable unit tests

### DIFF
--- a/code/frameworks/angular-vite/src/compodoc/generate-documentation.test.ts
+++ b/code/frameworks/angular-vite/src/compodoc/generate-documentation.test.ts
@@ -2,9 +2,11 @@
 // the atomicity of the publish, neither of which memfs models: it has no processes, and a rename it
 // performed would prove nothing about the rename Node performs on disk.
 import {
+  closeSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
+  openSync,
   readFileSync,
   readdirSync,
   realpathSync,
@@ -121,30 +123,32 @@ describe('generateDocumentation', () => {
     expect(args).toContain('tsconfig.doc.json');
   });
 
-  it('never exposes a half-written file to readers while the run is in flight', async () => {
-    // Excluding concurrent writers does not cover this: Compodoc truncates the file and grows it, so
-    // a reader parsing it mid-write gets a syntax error unless the publish is a rename.
-    mkdirSync(outputDir, { recursive: true });
-    writeFileSync(documentationJson(), JSON.stringify({ generation: 'previous' }));
+  // Windows refuses to rename over a path a reader still holds open, so the handle this asserts
+  // through cannot exist there.
+  it.skipIf(process.platform === 'win32')(
+    'never exposes a half-written file to readers while the run is in flight',
+    async () => {
+      // Excluding concurrent writers does not cover this: Compodoc truncates the file and grows it,
+      // so a reader parsing it mid-write gets a syntax error unless the publish is a rename.
+      mkdirSync(outputDir, { recursive: true });
+      writeFileSync(documentationJson(), JSON.stringify({ generation: 'previous' }));
 
-    const observations: Array<{ generation?: string } | string> = [];
-    const poll = setInterval(() => {
+      // A reader that opened the file before the run. Renaming over the path swaps the directory
+      // entry and leaves this descriptor on the old inode, so it keeps reading the whole previous
+      // document; truncating and growing the published path in place would corrupt it instead.
+      const reader = openSync(documentationJson(), 'r');
+
       try {
-        observations.push(readPublished());
-      } catch (error) {
-        observations.push(`unreadable: ${String(error)}`);
+        await generateDocumentation(options());
+
+        expect(JSON.parse(readFileSync(reader, 'utf8')).generation).toBe('previous');
+      } finally {
+        closeSync(reader);
       }
-    }, 1);
 
-    await generateDocumentation(options());
-    clearInterval(poll);
-
-    expect(observations.length).toBeGreaterThan(5);
-    expect(
-      observations.every((entry) => (entry as { generation?: string })?.generation === 'previous')
-    ).toBe(true);
-    expect(readPublished().generation).toBeUndefined();
-  });
+      expect(readPublished().generation).toBeUndefined();
+    }
+  );
 
   it('reports a failing run with the tail of its output', async () => {
     vi.stubEnv('STUB_EXIT_CODE', '2');

--- a/code/frameworks/vue3-vite/src/preset.test.ts
+++ b/code/frameworks/vue3-vite/src/preset.test.ts
@@ -7,8 +7,6 @@ import type { Options } from 'storybook/internal/types';
 import { vueComponentMeta } from './plugins/vue-component-meta.ts';
 import { vueDocgen } from './plugins/vue-docgen.ts';
 import { templateCompilation } from './plugins/vue-template.ts';
-// Statically, so the cost of this module graph is paid while the file is imported rather than
-// charged to whichever test happens to reach for it first.
 import { viteFinal } from './preset.ts';
 import type { FrameworkOptions } from './types.ts';
 

--- a/code/frameworks/vue3-vite/src/preset.test.ts
+++ b/code/frameworks/vue3-vite/src/preset.test.ts
@@ -7,6 +7,9 @@ import type { Options } from 'storybook/internal/types';
 import { vueComponentMeta } from './plugins/vue-component-meta.ts';
 import { vueDocgen } from './plugins/vue-docgen.ts';
 import { templateCompilation } from './plugins/vue-template.ts';
+// Statically, so the cost of this module graph is paid while the file is imported rather than
+// charged to whichever test happens to reach for it first.
+import { viteFinal } from './preset.ts';
 import type { FrameworkOptions } from './types.ts';
 
 // The real plugin factories build a vue-component-meta checker / vue-docgen-api parser, which is
@@ -40,7 +43,6 @@ const pluginNames = async (
   docgen: FrameworkOptions['docgen'],
   features?: Record<string, boolean>
 ) => {
-  const { viteFinal } = await import('./preset.ts');
   const config = await viteFinal!({}, optionsWith(docgen, features));
   return (config.plugins ?? []).map((plugin) => (plugin as { name: string }).name);
 };


### PR DESCRIPTION
Closes #

## What I did

Two unit tests on `next` assert on wall-clock behaviour rather than on the property they were written to protect, so they fail on a loaded CI machine and pass on a quiet one. Neither test is wrong about what it wants to prove; both reach for it through a timer. This replaces the timing in each with a direct observation, so the outcome no longer depends on how busy the runner is.

Captured from the run that failed on an unrelated PR:

```
generateDocumentation > never exposes a half-written file to readers while the run is in flight
AssertionError: expected 1 to be greater than 5
 ❯ src/compodoc/generate-documentation.test.ts:142:33
 run_time 0.330772314

viteFinal > adds the vue-component-meta docgen plugin when the docgen service is off
Error: Test timed out in 10000ms.
 ❯ src/preset.test.ts:52:4
 run_time 10.01262456
```

### 1. The compodoc test measured a timer instead of the publish

`generateDocumentation` writes Compodoc's output to a scratch path and `renameSync`s it into place, so a reader never sees a half-written file. The test sampled the published path from a 1 ms interval and required more than five samples. That count is a property of the event loop, not of the publish - under load the interval fired once, and the assertion failed on a run where the code was entirely correct.

A file descriptor opened before the run proves the same invariant with no clock in it:

```ts
// A reader that opened the file before the run. Renaming over the path swaps the directory
// entry and leaves this descriptor on the old inode, so it keeps reading the whole previous
// document; truncating and growing the published path in place would corrupt it instead.
const reader = openSync(documentationJson(), 'r');

try {
  await generateDocumentation(options());

  expect(JSON.parse(readFileSync(reader, 'utf8')).generation).toBe('previous');
} finally {
  closeSync(reader);
}
```

The test is skipped on Windows, which refuses to rename over a path a reader still holds open.

### 2. The vue3 test charged a cold module graph to a test budget

`pluginNames` did `await import('./preset.ts')` on every call, so whichever test ran first paid for the entire module graph inside its own 10 second `testTimeout`. Importing it statically moves that cost into the file's import phase, which `testTimeout` does not bound:

```
                import     tests
before            96 ms    1.40 s
after            1.38 s      43 ms
```

Same 13 tests, same assertions - only which phase pays.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

This PR *is* the test change. The relevant question is whether the rewritten compodoc test still fails when the behaviour it guards is removed, so I replaced the atomic publish with a plain copy and re-ran it:

```diff
-    renameSync(produced, join(outputDir, DOCUMENTATION_JSON));
+    writeFileSync(join(outputDir, DOCUMENTATION_JSON), readFileSync(produced, 'utf8'));
```

```
 × never exposes a half-written file to readers while the run is in flight 75ms
AssertionError: expected undefined to be 'previous'
 Test Files  1 failed (1)
      Tests  1 failed | 6 passed (7)
```

Restored, and green again at 7 passed. The vue3 change moves an import and asserts nothing new, so it has no mutation of its own.

#### Manual testing

1. From the repo root, run the two files and confirm they pass:
   `yarn test code/frameworks/angular-vite/src/compodoc/generate-documentation.test.ts code/frameworks/vue3-vite/src/preset.test.ts`
2. Confirm the compodoc test still bites: in `code/frameworks/angular-vite/src/compodoc/generate-documentation.ts`, replace the `renameSync(...)` publish on line 183 with a `writeFileSync`/`readFileSync` copy, re-run the first file, and check that `never exposes a half-written file to readers while the run is in flight` is the one test that fails. Restore the line.
3. Confirm the timing moved rather than disappeared: re-run the vue3 file and read vitest's duration line - `import` now carries the cost that `tests` used to.

Neither change touches product code, so there is no sandbox to open.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

Test-only change, nothing to document.
