### PR TITLE
React: Carry a story file's own declarations into the static code snippet

### DIFF
--- a/code/addons/docs/src/blocks/blocks/SourceLocalHelper.stories.tsx
+++ b/code/addons/docs/src/blocks/blocks/SourceLocalHelper.stories.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Button } from '../examples/Button';
+
+const buttonRowGap = 8;
+
+const ButtonRow = ({ label }: { label: string }) => (
+  <div style={{ display: 'flex', gap: buttonRowGap }}>
+    <Button label={label} />
+    <Button label={label} primary />
+  </div>
+);
+
+/**
+ * Fixture for the story-docs e2e (`code/e2e-internal/story-docs.spec.ts`): the render function names
+ * a wrapper and a constant this file declares, which the snippet has to carry with it.
+ */
+const meta = {
+  component: Button,
+  tags: ['autodocs'],
+  args: { label: 'Local helper' },
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    docs: {
+      codePanel: true,
+    },
+  },
+} satisfies Meta<typeof Button>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const WithLocalWrapper: Story = {
+  render: (args) => <ButtonRow label={args.label} />,
+};

--- a/code/core/src/csf-tools/story-shape/free-names.ts
+++ b/code/core/src/csf-tools/story-shape/free-names.ts
@@ -1,0 +1,34 @@
+import { traverse, types as t } from 'storybook/internal/babel';
+
+/**
+ * Names a node reaches for from outside itself. ES globals count as resolved, since they mean the
+ * same wherever the snippet lands.
+ */
+export const freeNames = (node: t.Node): Set<string> => {
+  const statement = t.isStatement(node)
+    ? node
+    : t.isExpression(node)
+      ? t.expressionStatement(node)
+      : t.isObjectMethod(node)
+        ? t.expressionStatement(t.objectExpression([node]))
+        : undefined;
+
+  if (statement === undefined) {
+    throw new Error(
+      `Cannot read the names a ${node.type} depends on: it is not a statement or an expression`
+    );
+  }
+
+  // The clone keeps this traversal from binding scope information to nodes the story file's own
+  // program still owns.
+  const wrapped = t.file(t.program([t.cloneNode(statement, true) as t.Statement]));
+  const names = new Set<string>();
+  traverse(wrapped, {
+    ReferencedIdentifier(path) {
+      if (!path.scope.hasBinding(path.node.name)) {
+        names.add(path.node.name);
+      }
+    },
+  });
+  return names;
+};

--- a/code/core/src/csf-tools/story-shape/index.ts
+++ b/code/core/src/csf-tools/story-shape/index.ts
@@ -1,3 +1,4 @@
+export { freeNames } from './free-names.ts';
 export {
   buildImportStatements,
   resolveComponentImport,

--- a/code/core/src/csf-tools/story-shape/resolve-arg-value.ts
+++ b/code/core/src/csf-tools/story-shape/resolve-arg-value.ts
@@ -1,7 +1,8 @@
 // Reads an arg value written as a name through to the definition it refers to, and reports what
 // printing the result still depends on.
-import { type NodePath, traverse, types as t } from 'storybook/internal/babel';
+import { type NodePath, types as t } from 'storybook/internal/babel';
 
+import { freeNames } from './free-names.ts';
 import { type ImportRef } from './import-statements.ts';
 import { type ImportBinding, collectImportBindings } from './imports.ts';
 import { type ReferenceContext, resolveArgsRecord } from './resolve-members.ts';
@@ -189,34 +190,4 @@ const followValue = (node: t.Node, ctx: ReferenceContext, seen: Set<string>): t.
   }
   seen.add(node.name);
   return followValue(unwrapExpression(binding.path.node.init), ctx, seen);
-};
-
-/**
- * Names an expression reaches for from outside itself. ES globals count as resolved, since they
- * mean the same wherever the snippet lands.
- */
-const freeNames = (node: t.Node): Set<string> => {
-  const expression = t.isExpression(node)
-    ? node
-    : t.isObjectMethod(node)
-      ? t.objectExpression([node])
-      : undefined;
-  if (expression === undefined) {
-    throw new Error(`Cannot read the names a ${node.type} depends on: it is not an expression`);
-  }
-
-  // The clone keeps this traversal from binding scope information to nodes the story file's own
-  // program still owns.
-  const wrapped = t.file(
-    t.program([t.expressionStatement(t.cloneNode(expression, true) as t.Expression)])
-  );
-  const names = new Set<string>();
-  traverse(wrapped, {
-    ReferencedIdentifier(path) {
-      if (!path.scope.hasBinding(path.node.name)) {
-        names.add(path.node.name);
-      }
-    },
-  });
-  return names;
 };

--- a/code/e2e-internal/story-docs.spec.ts
+++ b/code/e2e-internal/story-docs.spec.ts
@@ -22,6 +22,9 @@ const docsPath = '/docs/addons-docs-codepanel--docs';
 const defaultStoryBlockId = 'story--addons-docs-codepanel--default';
 const primaryStoryBlockId = `${defaultStoryBlockId}--primary`;
 const componentId = 'addons-docs-codepanel';
+// Renders through a wrapper declared in its own file; see SourceLocalHelper.stories.tsx.
+const localHelperStoryPath =
+  '/story/addons-docs-blocks-blocks-sourcelocalhelper--with-local-wrapper';
 const storyDocsStaticPath = `/services/core/story-docs/${componentId}.json`;
 
 const E2E_STORY_DOCS_HOT_UPDATE_LABEL_BEFORE = 'e2eStoryDocsBefore';
@@ -128,6 +131,23 @@ async function gotoAutodocsPage(page: Page) {
   await expectExperimentalDocgenServer(page);
   await waitForPreviewReady(page);
 }
+
+test.describe('story-docs snippet dependencies', () => {
+  test.setTimeout(90_000);
+
+  test('carries a locally declared wrapper into the Code panel', async ({ page }) => {
+    await page.goto(`${storybookUrl}/?path=${localHelperStoryPath}`);
+    await expectExperimentalDocgenServer(page);
+    await waitForPreviewReady(page);
+    await openCodePanel(page);
+
+    const codePanel = page.getByRole('tabpanel', { name: 'Code' });
+    await expect(codePanel).toContainText('const buttonRowGap = 8', {
+      timeout: PREVIEW_STORY_TIMEOUT,
+    });
+    await expect(codePanel).toContainText('const ButtonRow', { timeout: PREVIEW_STORY_TIMEOUT });
+  });
+});
 
 test.describe('story-docs open service', () => {
   test.describe.configure({ mode: 'serial' });

--- a/code/renderers/react/src/componentManifest/buildReactComponentDocgen.ts
+++ b/code/renderers/react/src/componentManifest/buildReactComponentDocgen.ts
@@ -230,9 +230,19 @@ export function buildStoryDocsFromResolved({
     filePath: storyPath,
     ...openStoryReferences(),
   });
-  // An arg value that kept the name another module gave it only compiles once the import block
-  // names that module too. `packageName` rewriting is for the component, so those refs opt out of it.
-  const argRefs = storyEntries.imports.map((ref) => ({ ...ref, isPackage: true }));
+  // A snippet name that kept the module another file gave it only compiles once the import block
+  // names that module too. `packageName` rewriting is for the component, so those refs opt out of
+  // it - which is also why a name the component refs already cover has to be dropped here: the two
+  // would otherwise bucket under different sources and print the same import twice.
+  // Matching on the local name alone is deliberate: a namespace component (`Accordion.Root` via
+  // `import * as Accordion`) rewrites to a named import, so its exported name no longer matches the
+  // `*` the snippet ref carries, yet the component ref already covers the binding.
+  const componentLocalNames = new Set(
+    allComponents.flatMap((ref) => (ref.localImportName ? [ref.localImportName] : []))
+  );
+  const argRefs = storyEntries.imports
+    .filter((ref) => !ref.localImportName || !componentLocalNames.has(ref.localImportName))
+    .map((ref) => ({ ...ref, isPackage: true }));
   const imports =
     buildImportStatements({ refs: [...allComponents, ...argRefs], packageName })
       .join('\n')

--- a/code/renderers/react/src/componentManifest/collectSnippetDependencies.test.ts
+++ b/code/renderers/react/src/componentManifest/collectSnippetDependencies.test.ts
@@ -1,0 +1,251 @@
+import { expect, test } from 'vitest';
+
+import { loadCsf } from 'storybook/internal/csf-tools';
+
+import { dedent } from 'ts-dedent';
+
+import { getCodeSnippet, printSnippet } from './generateCodeSnippet.ts';
+
+function snippetFor(body: string) {
+  const code = dedent`
+    import { Button } from './Button';
+
+    const meta = { component: Button };
+    export default meta;
+
+    ${body}
+  `;
+  const csf = loadCsf(code, { makeTitle: () => 'title' }).parse();
+  const name = Object.keys(csf._storyExports)[0];
+  const snippet = getCodeSnippet(csf, name, csf._meta?.component);
+
+  return {
+    code: printSnippet(snippet),
+    imports: snippet.imports.map((ref) => `${ref.importName} from ${ref.importId}`),
+  };
+}
+
+test('emits a local wrapper component the story renders', () => {
+  expect(
+    snippetFor(dedent`
+      const ButtonWrapper = ({ label }) => <Button>{label}</Button>;
+      export const Test = () => <ButtonWrapper label="foo" />;
+    `)
+  ).toMatchInlineSnapshot(`
+    {
+      "code": "const ButtonWrapper = ({ label }) => <Button>{label}</Button>;
+    const Test = () => <ButtonWrapper label="foo" />;",
+      "imports": [
+        "Button from ./Button",
+      ],
+    }
+  `);
+});
+
+test('emits a transitive local chain in source order', () => {
+  expect(
+    snippetFor(dedent`
+      const spacing = 8;
+      const ButtonWrapper = ({ label }) => <Button style={{ margin: spacing }}>{label}</Button>;
+      export const Test = () => <ButtonWrapper label="foo" />;
+    `)
+  ).toMatchInlineSnapshot(`
+    {
+      "code": "const spacing = 8;
+    const ButtonWrapper = ({ label }) => <Button style={{ margin: spacing }}>{label}</Button>;
+    const Test = () => <ButtonWrapper label="foo" />;",
+      "imports": [
+        "Button from ./Button",
+      ],
+    }
+  `);
+});
+
+test('leaves out a module-scope name a helper parameter shadows', () => {
+  expect(
+    snippetFor(dedent`
+      const label = 'shadowed';
+      const ButtonWrapper = ({ label }) => <Button>{label}</Button>;
+      export const Test = () => <ButtonWrapper label="foo" />;
+    `)
+  ).toMatchInlineSnapshot(`
+    {
+      "code": "const ButtonWrapper = ({ label }) => <Button>{label}</Button>;
+    const Test = () => <ButtonWrapper label="foo" />;",
+      "imports": [
+        "Button from ./Button",
+      ],
+    }
+  `);
+});
+
+test('imports a non-component name rather than inlining source for it', () => {
+  expect(
+    snippetFor(dedent`
+      import { spec } from './specs';
+      export const Test = () => <Button>{spec.title}</Button>;
+    `)
+  ).toMatchInlineSnapshot(`
+    {
+      "code": "const Test = () => <Button>{spec.title}</Button>;",
+      "imports": [
+        "Button from ./Button",
+        "spec from ./specs",
+      ],
+    }
+  `);
+});
+
+test('skips globals and intrinsic elements', () => {
+  expect(
+    snippetFor(dedent`
+      export const Test = () => <div>{Math.max(1, document.title.length)}</div>;
+    `)
+  ).toMatchInlineSnapshot(`
+    {
+      "code": "const Test = () => <div>{Math.max(1, document.title.length)}</div>;",
+      "imports": [],
+    }
+  `);
+});
+
+test('emits each declaration once when two of them reference each other', () => {
+  expect(
+    snippetFor(dedent`
+      const first = () => second();
+      const second = () => first();
+      export const Test = () => <Button>{first()}</Button>;
+    `)
+  ).toMatchInlineSnapshot(`
+    {
+      "code": "const first = () => second();
+    const second = () => first();
+    const Test = () => <Button>{first()}</Button>;",
+      "imports": [
+        "Button from ./Button",
+      ],
+    }
+  `);
+});
+
+test('emits nothing extra for a story that references nothing outside itself', () => {
+  expect(
+    snippetFor(dedent`
+      export const Test = { args: { label: 'x' } };
+    `)
+  ).toMatchInlineSnapshot(`
+    {
+      "code": "const Test = () => <Button label="x" />;",
+      "imports": [
+        "Button from ./Button",
+      ],
+    }
+  `);
+});
+
+test('strips the export keyword from a helper the story file also exports', () => {
+  const code = dedent`
+    import { Button } from './Button';
+
+    const meta = { component: Button, includeStories: ['Test'] };
+    export default meta;
+
+    export const ButtonWrapper = ({ label }) => <Button>{label}</Button>;
+    export const Test = () => <ButtonWrapper label="foo" />;
+  `;
+  const csf = loadCsf(code, { makeTitle: () => 'title' }).parse();
+  const snippet = getCodeSnippet(csf, 'Test', csf._meta?.component);
+
+  expect(printSnippet(snippet)).toMatchInlineSnapshot(`
+      "const ButtonWrapper = ({ label }) => <Button>{label}</Button>;
+      const Test = () => <ButtonWrapper label="foo" />;"
+    `);
+});
+
+test('emits a component declared in the story file instead of importing it', () => {
+  const code = dedent`
+    const Card = ({ label }: { label: string }) => <section>{label}</section>;
+
+    const meta = { component: Card };
+    export default meta;
+
+    export const Test = { args: { label: 'x' } };
+  `;
+  const csf = loadCsf(code, { makeTitle: () => 'title' }).parse();
+  const snippet = getCodeSnippet(csf, 'Test', csf._meta?.component);
+
+  expect({
+    code: printSnippet(snippet),
+    imports: snippet.imports.map((ref) => `${ref.importName} from ${ref.importId}`),
+  }).toMatchInlineSnapshot(`
+    {
+      "code": "const Card = ({ label }: { label: string }) => <section>{label}</section>;
+
+    const Test = () => <Card label="x" />;",
+      "imports": [],
+    }
+  `);
+});
+
+test('drops the incomplete-snippet warning for a name the snippet now declares', () => {
+  const code = dedent`
+    import { Button } from './Button';
+
+    const meta = { component: Button };
+    export default meta;
+
+    const spacing = 8;
+    export const Test = { args: { style: { margin: spacing } } };
+  `;
+  const csf = loadCsf(code, { makeTitle: () => 'title' }).parse();
+  const snippet = getCodeSnippet(csf, 'Test', csf._meta?.component);
+
+  expect(printSnippet(snippet)).toMatchInlineSnapshot(`
+    "const spacing = 8;
+    const Test = () => <Button style={{ margin: spacing }} />;"
+  `);
+  expect(snippet.unresolved).toEqual([]);
+});
+
+test('keeps a warning for a spread it still cannot read', () => {
+  const code = dedent`
+    import { Button } from './Button';
+
+    const meta = { component: Button };
+    export default meta;
+
+    export const Test = { args: { ...buildArgs() } };
+  `;
+  const csf = loadCsf(code, { makeTitle: () => 'title' }).parse();
+
+  expect(getCodeSnippet(csf, 'Test', csf._meta?.component).unresolved).toEqual(['...buildArgs()']);
+});
+
+test('leaves a sibling story config out of the snippet', () => {
+  const code = dedent`
+    import { Button } from './Button';
+
+    const meta = { component: Button };
+    export default meta;
+
+    export const Base = { args: { label: 'x' } };
+    export const Test = () => <Button {...Base.args} />;
+  `;
+  const csf = loadCsf(code, { makeTitle: () => 'title' }).parse();
+
+  expect(printSnippet(getCodeSnippet(csf, 'Test', csf._meta?.component))).toMatchInlineSnapshot(
+    `"const Test = () => <Button {...Base.args} />;"`
+  );
+});
+
+test('narrows a multi-declarator statement to the name the snippet asked for', () => {
+  expect(
+    snippetFor(dedent`
+      const gap = 4, unrelated = sideEffect();
+      export const Test = () => <Button style={{ gap }} />;
+    `).code
+  ).toMatchInlineSnapshot(`
+    "const gap = 4;
+    const Test = () => <Button style={{ gap }} />;"
+  `);
+});

--- a/code/renderers/react/src/componentManifest/collectSnippetDependencies.ts
+++ b/code/renderers/react/src/componentManifest/collectSnippetDependencies.ts
@@ -1,0 +1,126 @@
+import { type NodePath, types as t } from 'storybook/internal/babel';
+import {
+  type CsfFile,
+  type ImportRef,
+  collectImportBindings,
+  freeNames,
+} from 'storybook/internal/csf-tools';
+
+/** What a snippet still reaches for in the story file it was extracted from. */
+export interface SnippetDependencies {
+  /** Module-scope declarations to print above the story, in source order. */
+  declarations: t.Statement[];
+  /** Imports the snippet needs for the names another module owns. */
+  imports: ImportRef[];
+  /** Names this pass closed, so a warning does not claim they are still missing. */
+  resolved: Set<string>;
+}
+
+/**
+ * Close the gap between the names a snippet prints and what it declares.
+ *
+ * Only the story file's own module scope is read: a name it imports becomes an import ref, a name
+ * it declares is carried over as the declaration was authored, and anything else - a global, an
+ * intrinsic element, a name bound inside the snippet - is left alone.
+ */
+export function collectSnippetDependencies(
+  node: t.Statement,
+  csf: CsfFile,
+  storyName: string
+): SnippetDependencies {
+  const program = csf._file.path;
+  const bindings = collectImportBindings(program);
+
+  const imports: ImportRef[] = [];
+  const resolved = new Set<string>();
+  const hoisted = new Map<number, t.Statement>();
+  // A name bound to another story resolves to a CSF config object, not to example code, so
+  // printing it would put Storybook's own plumbing in the snippet.
+  const seen = new Set<string>(
+    [
+      csf._metaVariableName,
+      ...Object.entries(csf._stories).map(([key, story]) => story.localName ?? key),
+    ].filter(Boolean) as string[]
+  );
+  seen.add(storyName);
+  const pending = [...freeNames(node)];
+
+  while (pending.length > 0) {
+    const name = pending.shift()!;
+    if (seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+
+    const imported = bindings.get(name);
+    if (imported) {
+      imports.push({
+        localImportName: name,
+        importId: imported.importId,
+        importName: imported.importName,
+        ...(imported.importName === '*' ? { namespace: name } : {}),
+        // `packageName` rewriting exists for the documented component; these names stay with the
+        // module the story file read them from.
+        isPackage: true,
+      });
+      resolved.add(name);
+      continue;
+    }
+
+    const binding = program.scope.getBinding(name);
+    if (!binding) {
+      continue;
+    }
+    const index = moduleStatementIndex(binding.path, program);
+    if (index === undefined || hoisted.has(index)) {
+      continue;
+    }
+    const declaration = declarationOf(program.node.body[index], binding.path);
+    if (!declaration) {
+      continue;
+    }
+    hoisted.set(index, declaration);
+    resolved.add(name);
+    pending.push(...freeNames(declaration));
+  }
+
+  return {
+    declarations: [...hoisted.entries()]
+      .sort(([a], [b]) => a - b)
+      .map(([, statement]) => statement),
+    imports,
+    resolved,
+  };
+}
+
+function moduleStatementIndex(path: NodePath, program: NodePath<t.Program>): number | undefined {
+  let current: NodePath | null = path;
+  while (current && !current.parentPath?.isProgram()) {
+    current = current.parentPath;
+  }
+  const index = current ? program.node.body.indexOf(current.node as t.Statement) : -1;
+  return index === -1 ? undefined : index;
+}
+
+// A hoisted declaration is printed on its own, so an `export` keyword that meant something in the
+// story file would not compile in the snippet. A statement declaring several names is narrowed to
+// the one the snippet asked for, so its siblings - and whatever they in turn name - stay out.
+function declarationOf(
+  statement: t.Statement | undefined,
+  binding: NodePath
+): t.Statement | undefined {
+  const declaration = t.isExportNamedDeclaration(statement)
+    ? (statement.declaration ?? undefined)
+    : t.isImportDeclaration(statement) || t.isExportDefaultDeclaration(statement)
+      ? undefined
+      : statement;
+
+  if (
+    t.isVariableDeclaration(declaration) &&
+    declaration.declarations.length > 1 &&
+    binding.isVariableDeclarator()
+  ) {
+    return t.variableDeclaration(declaration.kind, [binding.node]);
+  }
+  return declaration;
+}

--- a/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
+++ b/code/renderers/react/src/componentManifest/generateCodeSnippet.test.tsx
@@ -1,20 +1,19 @@
 import { expect, test } from 'vitest';
 
-import { recast, types as t } from 'storybook/internal/babel';
 import { loadCsf } from 'storybook/internal/csf-tools';
 
 import { dedent } from 'ts-dedent';
 
-import { getCodeSnippet } from './generateCodeSnippet.ts';
+import { getCodeSnippet, printSnippet } from './generateCodeSnippet.ts';
 
 function generateExample(code: string) {
   const csf = loadCsf(code, { makeTitle: (userTitle?: string) => userTitle ?? 'title' }).parse();
 
-  const snippets = Object.keys(csf._storyExports).map(
-    (name) => getCodeSnippet(csf, name, csf._meta?.component ?? 'ComponentTitle').node
-  );
-
-  return recast.print(t.program(snippets)).code;
+  return Object.keys(csf._storyExports)
+    .map((name) =>
+      printSnippet(getCodeSnippet(csf, name, csf._meta?.component ?? 'ComponentTitle'))
+    )
+    .join('\n');
 }
 
 /** Snippet plus what it still depends on, for the cases that resolve names rather than values. */
@@ -24,7 +23,7 @@ function generateResolved(code: string) {
   return Object.keys(csf._storyExports).map((name) => {
     const snippet = getCodeSnippet(csf, name, csf._meta?.component ?? 'ComponentTitle');
     return {
-      snippet: recast.print(snippet.node).code,
+      snippet: printSnippet(snippet),
       imports: snippet.imports.map((ref) => `${ref.importName} from ${ref.importId}`),
       unresolved: snippet.unresolved,
     };
@@ -787,6 +786,27 @@ test("a spread of a CSF4 story's args contributes the args it does not override"
   `);
 });
 
+test('a render naming a local wrapper carries the wrapper and what it reads', () => {
+  const input = withCSF3(dedent`
+    const label = 'foo';
+    const ButtonWrapper = ({ label }) => <Button>{label}</Button>;
+    export const Test: Story = { render: () => <ButtonWrapper label={label} /> };
+  `);
+  expect(generateResolved(input)).toMatchInlineSnapshot(`
+    [
+      {
+        "imports": [
+          "Button from @design-system/button",
+        ],
+        "snippet": "const label = 'foo';
+    const ButtonWrapper = ({ label }) => <Button>{label}</Button>;
+    const Test = () => <ButtonWrapper label={label} />;",
+        "unresolved": [],
+      },
+    ]
+  `);
+});
+
 test('an arg naming a local const carries the value, not the name', () => {
   const input = withCSF3(dedent`
     const LOCAL_LABEL = 'local';
@@ -795,7 +815,9 @@ test('an arg naming a local const carries the value, not the name', () => {
   expect(generateResolved(input)).toMatchInlineSnapshot(`
     [
       {
-        "imports": [],
+        "imports": [
+          "Button from @design-system/button",
+        ],
         "snippet": "const Default = () => <Button label="local">Click me</Button>;",
         "unresolved": [],
       },
@@ -813,6 +835,7 @@ test('an arg naming an imported value keeps the name and reports the import it n
       {
         "imports": [
           "IMPORTED_LABEL from ./constants",
+          "Button from @design-system/button",
         ],
         "snippet": "const Default = () => <Button label={IMPORTED_LABEL}>Click me</Button>;",
         "unresolved": [],
@@ -828,7 +851,9 @@ test('args assembled at runtime are reported rather than dropped', () => {
   expect(generateResolved(input)).toMatchInlineSnapshot(`
     [
       {
-        "imports": [],
+        "imports": [
+          "Button from @design-system/button",
+        ],
         "snippet": "const Default = () => <Button label="runtime">Click me</Button>;",
         "unresolved": [
           "...buildArgs()",
@@ -862,7 +887,9 @@ test('a meta-level spread that may carry args is reported', () => {
   expect(generateResolved(input)).toMatchInlineSnapshot(`
     [
       {
-        "imports": [],
+        "imports": [
+          "Button from @design-system/button",
+        ],
         "snippet": "const Default = () => <Button label="x" />;",
         "unresolved": [
           "...sharedMeta()",

--- a/code/renderers/react/src/componentManifest/generateCodeSnippet.ts
+++ b/code/renderers/react/src/componentManifest/generateCodeSnippet.ts
@@ -1,4 +1,4 @@
-import { type NodePath, types as t } from 'storybook/internal/babel';
+import { type NodePath, recast, types as t } from 'storybook/internal/babel';
 import {
   createStoryArgsResolver,
   type CsfFile,
@@ -11,6 +11,7 @@ import {
   type StoryArgsResolver,
 } from 'storybook/internal/csf-tools';
 
+import { collectSnippetDependencies } from './collectSnippetDependencies.ts';
 import { invariant } from './utils.ts';
 
 function renderFunctionOf(resolution: RenderResolution) {
@@ -23,7 +24,9 @@ function renderFunctionOf(resolution: RenderResolution) {
 /** A story's snippet, and what showing it as a complete example still depends on. */
 export interface CodeSnippet {
   node: t.VariableDeclaration | t.FunctionDeclaration;
-  /** Imports the snippet needs beyond the component, from arg values that kept a name. */
+  /** Story-file declarations the snippet names, to print above it in source order. */
+  declarations: t.Statement[];
+  /** Imports the snippet needs for the names it prints but the story file does not declare. */
   imports: ImportRef[];
   /** What a static pass could not read, in the source text it was written as. */
   unresolved: string[];
@@ -36,11 +39,25 @@ export function getCodeSnippet(
   resolver: StoryArgsResolver = createStoryArgsResolver(csf)
 ): CodeSnippet {
   const { args, imports, unresolved } = resolver.resolve(storyName);
+  const node = buildSnippetNode(csf, storyName, componentName, args, resolver.ctx);
+  const dependencies = collectSnippetDependencies(node, csf, storyName);
+  const covered = new Set(imports.map((ref) => ref.localImportName));
   return {
-    node: buildSnippetNode(csf, storyName, componentName, args, resolver.ctx),
-    imports,
-    unresolved,
+    node,
+    declarations: dependencies.declarations,
+    imports: [
+      ...imports,
+      ...dependencies.imports.filter((ref) => !covered.has(ref.localImportName)),
+    ],
+    // A name reported as unreadable while resolving args is readable after all once the snippet
+    // carries its declaration or its import, and warning about it would contradict the output.
+    unresolved: unresolved.filter((source) => !dependencies.resolved.has(source)),
   };
+}
+
+/** Prints a snippet with the declarations it depends on, which is the only complete form of it. */
+export function printSnippet(snippet: CodeSnippet): string {
+  return recast.print(t.program([...snippet.declarations, snippet.node])).code;
 }
 
 function buildSnippetNode(

--- a/code/renderers/react/src/componentManifest/resolveComponents.ts
+++ b/code/renderers/react/src/componentManifest/resolveComponents.ts
@@ -1,4 +1,3 @@
-import { recast } from 'storybook/internal/babel';
 import { storyNameFromExport } from 'storybook/internal/csf/csf-utils';
 import type { ImportRef, StoryReferences } from 'storybook/internal/csf-tools';
 import {
@@ -8,7 +7,7 @@ import {
   unresolvedWarning,
 } from 'storybook/internal/csf-tools';
 
-import { getCodeSnippet } from './generateCodeSnippet.ts';
+import { getCodeSnippet, printSnippet } from './generateCodeSnippet.ts';
 import {
   type ComponentRef,
   type DocgenEngine,
@@ -145,7 +144,7 @@ export interface ResolvedStory {
   error?: { name: string; message: string };
 }
 
-/** Every story's snippet, plus the imports they need beyond the components in the file. */
+/** Every story's snippet, plus the imports the snippets need for names other modules own. */
 export interface ExtractedStorySnippets {
   stories: ResolvedStory[];
   imports: ImportRef[];
@@ -180,7 +179,7 @@ export function extractStorySnippets(
         return {
           id: story.id,
           name,
-          snippet: recast.print(snippet.node).code,
+          snippet: printSnippet(snippet),
           description,
           summary,
           ...(warning ? { warning } : {}),

--- a/code/renderers/react/src/enrichCsf.ts
+++ b/code/renderers/react/src/enrichCsf.ts
@@ -1,11 +1,11 @@
-import { type NodePath, recast, types as t } from 'storybook/internal/babel';
+import { types as t } from 'storybook/internal/babel';
 import { getPrettier } from 'storybook/internal/common';
 import { type CsfFile } from 'storybook/internal/csf-tools';
 import type { PresetPropertyFn } from 'storybook/internal/types';
 
 import { join } from 'pathe';
 
-import { getCodeSnippet } from './componentManifest/generateCodeSnippet.ts';
+import { getCodeSnippet, printSnippet } from './componentManifest/generateCodeSnippet.ts';
 
 export const enrichCsf: PresetPropertyFn<'experimental_enrichCsf'> = async (input, options) => {
   const features = await options.presets.apply('features');
@@ -18,10 +18,10 @@ export const enrichCsf: PresetPropertyFn<'experimental_enrichCsf'> = async (inpu
         return;
       }
       const { format } = await getPrettier();
-      let node;
+      let source;
       let snippet;
       try {
-        node = getCodeSnippet(csfSource, key, csfSource._meta?.component).node;
+        source = printSnippet(getCodeSnippet(csfSource, key, csfSource._meta?.component));
       } catch (e) {
         if (!(e instanceof Error)) {
           return;
@@ -31,8 +31,8 @@ export const enrichCsf: PresetPropertyFn<'experimental_enrichCsf'> = async (inpu
 
       try {
         // TODO read the user config
-        if (!snippet && node) {
-          snippet = await format(recast.print(node).code, {
+        if (!snippet && source) {
+          snippet = await format(source, {
             filepath: join(process.cwd(), 'component.tsx'),
           });
         }


### PR DESCRIPTION
Closes #

<!-- No GitHub issue; this was reported internally with a real story file from the astryx repo. -->

## What I did

When a React story renders through a helper that is declared in the story file itself - a small wrapper component, a spec object, a style constant - the statically generated code snippet printed that name and then never declared or imported it. The snippet in the Docs "Show code" block and in the Code panel therefore did not compile, and nothing warned about it.

The snippet now carries what it names. After the snippet node is built, every name it still reaches for from outside itself is resolved against the story file's module scope: a name bound to an import joins the import block, a name bound to a module-scope declaration is emitted above the story exactly as it was authored, transitively and in source order.

```
story file AST
      |
      | resolve args, build the story node          (unchanged)
      v
  snippet node ── freeNames(node) ──> [ThemedVegaChart, residualGraphSpec]
      |                                       |
      |                          for each name, look it up in the story file
      |                                       |
      |                  import binding ──────┴────── module-scope declaration
      |                        |                              |
      |                   ImportRef                   hoist the declaration,
      |                        |                      then repeat on its own
      |                        |                          free names
      v                        v                              v
   printSnippet(...)  ==  import block + declarations + the story
```

### The bug, captured

Reduced from the reported story file. Same input, run through `extractStorySnippets` on `next` and on this branch:

```jsx
// VegaLiteRanges.stories.tsx
import { VegaChart } from '@astryxdesign/vega';
import { residualGraphSpec } from './specs';

const meta: Meta<typeof VegaChart> = { component: VegaChart };
export default meta;

const ThemedVegaChart = ({ spec }) => <VegaChart spec={spec} theme="astryx" />;

export const ResidualGraph: StoryObj<typeof VegaChart> = {
  render: (args) => (
    <div style={{ width: '100%', maxWidth: 720 }}>
      <ThemedVegaChart spec={residualGraphSpec} {...args} />
    </div>
  ),
};
```

Before, on `next` - `ThemedVegaChart` and `residualGraphSpec` are both undefined in the snippet, and the import list is empty:

```jsx
const ResidualGraph = () => <div style={{ width: '100%', maxWidth: 720 }}>
    <ThemedVegaChart spec={residualGraphSpec} />
</div>;

// imports: []
```

After, on this branch:

```jsx
const ThemedVegaChart = ({ spec }) => <VegaChart spec={spec} theme="astryx" />;

const ResidualGraph = () => <div style={{ width: '100%', maxWidth: 720 }}>
    <ThemedVegaChart spec={residualGraphSpec} />
</div>;

// imports: ["residualGraphSpec from ./specs", "VegaChart from @astryxdesign/vega"]
```

And here is the same thing through the actual UI, taken from the new fixture story in the internal Storybook running with `STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER=true`:

```jsx
import { Button } from '@storybook/addon-docs';

const buttonRowGap = 8;

const ButtonRow = ({ label }: { label: string }) => (
  <div style={{ display: 'flex', gap: buttonRowGap }}>
    <Button label={label} />
    <Button label={label} primary />
  </div>
);

const WithLocalWrapper = () => <ButtonRow label="Local helper" />;
```

### Why this shape and not "unfold the wrapper"

The report offered two acceptable outcomes: print the source as it is, or inline `<ButtonWrapper label="foo" />` into `<Button>foo</Button>`. I went with the first one, and I want to be explicit about why, because the second one is the more tempting of the two.

Unfolding only works for a wrapper that is a pure, single-expression component. It cannot express hooks, conditionals, or default props, it needs collision-safe renaming for every substituted prop, and - the part that decided it for me - it does nothing at all for the non-component locals. In the reported file, `residualGraphSpec` is just as undefined as `ThemedVegaChart` is. Hoisting the declarations fixes both halves with one rule, and it is deterministic. If we still want the unfolded form later, it can sit on top of this.

The one thing that needed care is shadowing. In `const ButtonWrapper = ({ label }) => <Button>{label}</Button>`, the `label` inside the wrapper is its own parameter, so it must not be what drags a module-level `const label` into the snippet:

```ts
// code/core/src/csf-tools/story-shape/free-names.ts
traverse(wrapped, {
  ReferencedIdentifier(path) {
    if (!path.scope.hasBinding(path.node.name)) {
      names.add(path.node.name);
    }
  },
});
```

That analysis already existed, privately, inside `resolve-arg-value.ts` for a different purpose. It is now its own module and widened to accept statements, so both callers share one implementation rather than drifting apart.

### Things that deliberately stay out of the snippet

- A name bound to **another story** is not example code, it is CSF plumbing. Without this, a story doing `<Button {...Base.args} />` would print `const Base = { args: { label: 'x' } };` above itself.
- A statement declaring several names is narrowed to the one that was asked for, so `const gap = 4, unrelated = sideEffect();` contributes `const gap = 4;` and nothing else.
- Globals, JSX intrinsics, and anything bound inside the snippet resolve to nothing and are left alone.

One user-visible detail worth calling out: `unresolvedWarning` used to report a name like `spacing` as "could not be resolved statically". Now that the snippet declares it, that warning would contradict what the reader sees, so a name this pass closes is dropped from `unresolved`. A spread it genuinely still cannot read, such as `...buildArgs()`, keeps its warning.

### Known limitation

A hoisted helper keeps its TypeScript annotations, but the types they name are neither hoisted nor imported - `const Wrap = (p: Props) => ...` still references an undeclared `Props`. Babel's `ReferencedIdentifier` does not visit type positions, so closing this means a separate pass over `TSTypeReference` names inside the dependency collector. It is a fairly contained follow-up and I would rather not widen `freeNames` semantics for it in this PR, since `isSelfContained` depends on them. The snippet is still strictly better than what `next` prints today, though.

Separately, and pre-existing: a story whose `render` takes no parameters is not an "args story", so the Source block and Code panel skip the generated snippet entirely and fall back to `originalSource`. None of this reaches such a story. That one is worth a decision of its own.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [x] unit tests
- [ ] integration tests
- [x] end-to-end tests

`collectSnippetDependencies.test.ts` covers the wrapper, the transitive chain, parameter shadowing, imported non-component names, globals and intrinsics, mutual references, the exported-helper case, a component declared in the story file, the warning reconciliation, the sibling-story exclusion, and the multi-declarator narrowing. `SourceLocalHelper.stories.tsx` is the fixture, and `story-docs.spec.ts` asserts the hoisted declarations reach the Code panel.

#### Manual testing

1. Start the internal Storybook with the docgen server on: `cd code && STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER=true yarn storybook:ui`
2. Open `addons/docs/blocks/blocks/SourceLocalHelper` → `With Local Wrapper`.
3. On the Docs page, click "Show code".
4. Expect the snippet to contain `const buttonRowGap = 8;` and the full `const ButtonRow = ...` declaration above `const WithLocalWrapper = ...`, and every identifier it prints to be either declared there or covered by the import line at the top.
5. Open the "Code" panel in the manager for the same story and expect the same content.
6. On `next`, steps 3-5 show only `const WithLocalWrapper = () => <ButtonRow label="Local helper" />;`, with `ButtonRow` and `buttonRowGap` nowhere to be found.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No docs change: this is a bug fix in snippet generation, and the documented behaviour ("a render function is the basis for the code snippet") is unchanged. It just produces a snippet that compiles now.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
