### PR TITLE
Addon-vitest: Filter Storybook instrumentation from reported stack traces

### DIFF
--- a/code/addons/vitest/src/node/test-manager.test.ts
+++ b/code/addons/vitest/src/node/test-manager.test.ts
@@ -350,6 +350,46 @@ describe('TestManager', () => {
     ]);
   });
 
+  it('should describe failures with the source-mapped frames rather than the raw browser stack', async () => {
+    const testManager = await TestManager.start(options);
+    const failedResult = {
+      state: 'failed',
+      errors: [
+        {
+          message:
+            '\n\x1B[34mClick to debug the error directly in Storybook: http://localhost:6006/?path=/story/story--one\x1B[39m\n\nexpect(element).toBeInTheDocument()',
+          stack:
+            'Error: expect(element).toBeInTheDocument()\n    at Proxy.expectWrapper (http://localhost:6006/deps/storybook_test.js?v=8c5dc1d5:13691:16)',
+          stacks: [
+            {
+              method: 'toBeInTheDocument',
+              file: '/project/src/stories/Page.stories.ts',
+              line: 30,
+              column: 60,
+            },
+          ],
+        },
+      ],
+    } as unknown as TestResult;
+
+    await testManager.runTestsWithState({
+      storyIds: ['story--one'],
+      triggeredBy: 'global',
+      callback: async () => {
+        testManager.onTestCaseResult({ storyId: 'story--one', testResult: failedResult });
+        testManager.onTestRunEnd({ totalTestCount: 1, unhandledErrors: [] });
+      },
+    });
+
+    expect(mockComponentTestStatusStore.set).toHaveBeenCalledWith([
+      expect.objectContaining({
+        storyId: 'story--one',
+        description:
+          'expect(element).toBeInTheDocument()\n    at toBeInTheDocument (/project/src/stories/Page.stories.ts:30:60)',
+      }),
+    ]);
+  });
+
   it('should filter tests', async () => {
     vitest.globTestSpecifications.mockImplementation(() => tests);
     const testManager = await TestManager.start(options);

--- a/code/addons/vitest/src/node/test-manager.ts
+++ b/code/addons/vitest/src/node/test-manager.ts
@@ -1,3 +1,4 @@
+import type { TestError } from 'vitest';
 import type { TestResult, TestState } from 'vitest/node';
 
 import type { experimental_UniversalStore } from 'storybook/internal/core-server';
@@ -36,6 +37,27 @@ export type TestManagerOptions = {
   onError?: (message: string, error: Error) => void;
   onReady?: () => void;
 };
+
+/** Matches the banner that vitest-plugin/setup-file.ts prepends to the message of failed stories. */
+const DEBUG_BANNER_RE =
+  /\n?(?:\x1B\[\d+m)?Click to debug the error directly in Storybook: [^\n]*\n+/g;
+
+/**
+ * `error.stack` holds the raw browser stack, pointing at the Vite URLs of Storybook's pre-bundled
+ * internals. Vitest replaces it with `error.stacks`: source-mapped frames with Storybook's
+ * instrumentation filtered out, matching what its own terminal output shows.
+ */
+function formatError(error: TestError): string {
+  if (!error.stacks?.length) {
+    return error.stack || error.message || '';
+  }
+  const message = (error.message ?? '').replace(DEBUG_BANNER_RE, '');
+  const frames = error.stacks.map(
+    ({ method, file, line, column }) =>
+      `    at ${method || '<anonymous>'} (${file}:${line}:${column})`
+  );
+  return [message, ...frames].join('\n');
+}
 
 const testStateToStatusValueMap: Record<TestState | 'warning', StatusValue> = {
   pending: 'status-value:pending',
@@ -225,7 +247,7 @@ export class TestManager {
       typeId: STATUS_TYPE_ID_COMPONENT_TEST,
       value: testStateToStatusValueMap[testResult.state],
       title: 'Component tests',
-      description: testResult.errors?.map((error) => error.stack || error.message).join('\n') ?? '',
+      description: testResult.errors?.map(formatError).join('\n') ?? '',
       sidebarContextMenu: false,
     }));
 

--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -49,6 +49,7 @@ import {
 import type { InternalOptions, UserOptions } from './types.ts';
 import { requiresProjectAnnotations } from './utils.ts';
 import { AgentTelemetryReporter } from './agent-telemetry-reporter.ts';
+import { isStorybookInternalFrame } from './stack-frames.ts';
 
 const WORKING_DIR = process.cwd();
 
@@ -345,6 +346,14 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
         cacheDir: resolvePathInStorybookCache('sb-vitest', projectId),
         test: {
           expect: { requireAssertions: false },
+
+          onStackTrace: (error, frame) => {
+            if (isStorybookInternalFrame(frame.file)) {
+              return false;
+            }
+            return nonMutableInputConfig.test?.onStackTrace?.(error, frame) ?? true;
+          },
+
           setupFiles: [
             ...internalSetupFiles,
             // if the existing setupFiles is a string, we have to include it otherwise we're overwriting it

--- a/code/addons/vitest/src/vitest-plugin/stack-frames.test.ts
+++ b/code/addons/vitest/src/vitest-plugin/stack-frames.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { isStorybookInternalFrame } from './stack-frames.ts';
+
+describe('isStorybookInternalFrame', () => {
+  it.each([
+    '/project/node_modules/storybook/dist/test/index.js',
+    '/project/node_modules/storybook/dist/instrumenter/index.js',
+    '/project/node_modules/storybook/dist/_browser-chunks/chunk-ORWLP677.js',
+    '/project/node_modules/@storybook/addon-vitest/dist/vitest-plugin/test-utils.js',
+    'C:\\project\\node_modules\\storybook\\dist\\instrumenter\\index.js',
+    '/project/node_modules/.cache/storybook/10.6.0/hash/sb-vitest/deps/storybook_test.js',
+    '/project/node_modules/.cache/storybook/10.6.0/hash/sb-vitest/deps/@storybook_addon-vitest_internal_test-utils.js?v=777b44a5',
+  ])('filters out %s', (file) => {
+    expect(isStorybookInternalFrame(file)).toBe(true);
+  });
+
+  it.each([
+    '/project/src/stories/Page.stories.ts',
+    '/project/src/stories/Page.tsx',
+    '/project/.storybook/preview.ts',
+    '/project/node_modules/@testing-library/dom/dist/index.js',
+    '/project/node_modules/.cache/storybook/10.6.0/hash/sb-vitest/deps/react-dom_client.js',
+    undefined,
+  ])('keeps %s', (file) => {
+    expect(isStorybookInternalFrame(file)).toBe(false);
+  });
+});

--- a/code/addons/vitest/src/vitest-plugin/stack-frames.ts
+++ b/code/addons/vitest/src/vitest-plugin/stack-frames.ts
@@ -1,0 +1,19 @@
+/**
+ * Storybook instruments `expect`, `userEvent` and Testing Library so the Interactions panel can
+ * replay a play function step by step. Every instrumented call therefore sits behind a handful of
+ * wrapper frames inside Storybook's own bundles, which push the failing line in the story far down
+ * the stack trace Vitest reports.
+ *
+ * These patterns match those bundles in the shapes a frame can take: the published package layout
+ * after source maps are applied, and the pre-bundled dependency files Vite serves when no source
+ * map is available.
+ */
+const INTERNAL_FRAME_PATTERNS = [
+  /[\\/]storybook[\\/]dist[\\/]/,
+  /[\\/]@storybook[\\/][^\\/]+[\\/]dist[\\/]/,
+  /[\\/]deps[\\/]@?storybook[@_]/,
+];
+
+export function isStorybookInternalFrame(file: string | undefined): boolean {
+  return !!file && INTERNAL_FRAME_PATTERNS.some((pattern) => pattern.test(file));
+}


### PR DESCRIPTION
## What I did

<!-- Briefly describe what your PR does -->

A failing `expect` in a play function reported seven frames of Storybook plumbing above the story that triggered it, which also made Vitest print its code excerpt from inside `Instrumenter.invoke` instead of from the story file:

```
 ❯ Proxy.expectWrapper node_modules/storybook/dist/test/index.js:13691:16
 ❯ Proxy.<anonymous> node_modules/storybook/dist/test/index.js:13211:17
 ❯ Proxy.methodWrapper node_modules/storybook/dist/test/index.js:7705:24
 ❯ Instrumenter.invoke node_modules/storybook/dist/instrumenter/index.js:322:22
 ❯ Instrumenter.intercept node_modules/storybook/dist/instrumenter/index.js:243:139
 ❯ Instrumenter.track node_modules/storybook/dist/instrumenter/index.js:238:378
 ❯ Proxy.toBeInTheDocument node_modules/storybook/dist/instrumenter/index.js:224:263
 ❯ toBeInTheDocument src/stories/Page.stories.ts:30:60
```

Instrumenting `expect`, `userEvent` and Testing Library is what lets the Interactions panel replay a play function step by step, so those wrapper frames are unavoidable; they just should not be reported. The Interactions panel was already unaffected because it renders matcher diffs rather than stacks.

**Terminal, IDE and CI output.** Vitest parses `error.stack` once per failure, source-maps each frame, drops frames matching its ignore list and caches the result on `error.stacks`, which every reporter then reads. Storybook's bundles were not in that ignore list. The Vitest project config the `storybookTest` plugin returns now registers a `test.onStackTrace` hook that filters them, chaining to any hook the user already configured. After this change the first frame is the story, so the code excerpt points there too.

**MCP and tools CLI output.** That path is separate: it read the raw `error.stack` string, which in browser mode is a list of `http://localhost:PORT/.../sb-vitest/deps/chunk-*.js` URLs. `TestManager` now builds the component test status description from `error.stacks`, so consumers get source-mapped file paths with the instrumentation already filtered. Since that switch takes the message from `error.message`, which carries the ANSI \"Click to debug\" banner that `setup-file.ts` prepends, the banner is stripped there.

The frame predicate matches Storybook's bundles in the shapes a frame can take: the published `storybook/dist` and `@storybook/*/dist` layouts after source maps are applied, and the pre-bundled `deps/storybook_*` files Vite serves when no source map is available.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

1. Set up a sandbox with the Vitest addon: `yarn task sandbox --template react-vite/default-ts --start-from auto`
2. In `src/stories/Page.stories.ts`, make the `LoggedIn` story fail by changing `await expect(loginButton).not.toBeInTheDocument();` to `await expect(loginButton).toBeInTheDocument();`
3. Run `npx vitest run`
4. Expected: the failure lists `❯ toBeInTheDocument src/stories/Page.stories.ts:30:60` as its first frame and prints the code excerpt from that story file. No frames from `node_modules/storybook/dist/test/index.js`, `node_modules/storybook/dist/instrumenter/index.js` or `@storybook/addon-vitest/dist/...` should appear.
5. Replace the assertion with a plain runtime error (for example `throw new Error('boom')` in the play function, or a component that throws during render) and confirm the reported stack is still useful and points at project code.
6. Add `onStackTrace: (error, frame) => { console.log('user hook', frame.file); return true; }` to `test` in the Vitest config, run `npx vitest run` again, and confirm the hook still logs, i.e. a user-configured hook is not shadowed.
7. Agent-facing output: with Storybook running (`yarn storybook`), run `npx storybook tools test run --stories '[{\"storyId\":\"example-page--logged-in\"}]'`. The failing story section should show the assertion message followed by source-mapped file paths, not `http://localhost:PORT/...` URLs, and no instrumentation frames.
8. Storybook UI: open the Component tests panel for the failing story and confirm the failure text still reads sensibly and does not include a raw \"Click to debug the error directly in Storybook\" line.

Most likely to regress: the frame matching is path-based, so Windows paths deserve a look (covered by a unit test, but worth confirming on a real Windows run); the status description format changed, which is what both the Storybook UI and the agent tooling display.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->