### PR TITLE
Tools: Fix Windows installation matching

### DIFF
--- a/code/core/src/cli/tools/sdk/installation.test.ts
+++ b/code/core/src/cli/tools/sdk/installation.test.ts
@@ -3,9 +3,11 @@ import { realpathSync } from 'node:fs';
 import { vol } from 'memfs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { mockNodePath } from '../test-support/mock-node-path.ts';
 import { checkInstallation } from './installation.ts';
 
 vi.mock('node:fs', { spy: true });
+vi.mock('node:path', { spy: true });
 
 beforeEach(async () => {
   vol.reset();
@@ -56,6 +58,18 @@ describe('checkInstallation', () => {
 
     expect(
       checkInstallation({ storybookPath: '/project/node_modules/storybook' }, '/store/storybook')
+    ).toEqual({ ok: true });
+  });
+
+  it('attaches Windows paths that differ only by letter case', () => {
+    mockNodePath('win32');
+    vol.fromNestedJSON({ '/project/node_modules/storybook/package.json': '{"name":"storybook"}' });
+
+    expect(
+      checkInstallation(
+        { storybookPath: '/project/node_modules/storybook' },
+        '/PROJECT/NODE_MODULES/STORYBOOK'
+      )
     ).toEqual({ ok: true });
   });
 

--- a/code/core/src/cli/tools/sdk/installation.ts
+++ b/code/core/src/cli/tools/sdk/installation.ts
@@ -3,6 +3,7 @@ import { realpathSync } from 'node:fs';
 import { normalize } from 'pathe';
 
 import type { StorybookInstanceRecord } from '../instances/types.ts';
+import { projectPathsEqual } from '../instances/project-path.ts';
 
 export type InstallationCheck =
   | { ok: true }
@@ -30,7 +31,7 @@ export function checkInstallation(
     return { ok: false, reason: 'unknown-installation' };
   }
 
-  if (instancePath !== callerPath) {
+  if (!projectPathsEqual(instancePath, callerPath)) {
     return { ok: false, reason: 'different-installation', callerPath, instancePath };
   }
 

--- a/code/e2e-internal/tools-attach.spec.ts
+++ b/code/e2e-internal/tools-attach.spec.ts
@@ -1,9 +1,10 @@
 import { execFile } from 'child_process';
-import { mkdir } from 'fs/promises';
-import { tmpdir } from 'os';
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'fs/promises';
+import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 import { promisify } from 'util';
 import process from 'process';
+import { pathToFileURL } from 'url';
 
 import { expect, test } from '@playwright/test';
 
@@ -43,6 +44,22 @@ async function runTools(args: string[], cwd = process.cwd(), extraEnv: NodeJS.Pr
       output: `${failure.stdout ?? ''}${failure.stderr ?? ''}`,
     };
   }
+}
+
+async function findInstanceRecord(port: number) {
+  const registryDir = join(homedir(), '.storybook', 'instances');
+  for (const filename of await readdir(registryDir)) {
+    if (!filename.endsWith('.json')) {
+      continue;
+    }
+    const path = join(registryDir, filename);
+    const contents = await readFile(path, 'utf8');
+    const record = JSON.parse(contents) as { port: number; storybookPath?: string };
+    if (record.port === port) {
+      return { path, contents, record };
+    }
+  }
+  throw new Error(`No running Storybook instance record found on port ${port}.`);
 }
 
 const REVIEW_INPUT = JSON.stringify({
@@ -115,6 +132,78 @@ test.describe('storybook tools attach', () => {
     expect(list.output).toContain('example-button');
   });
 
+  test('respawns through the running instance installation when it differs from the caller', async () => {
+    test.skip(
+      !runsAgainstDevServer,
+      'Live attach requires the running Storybook channel, which the static E2E job does not serve.'
+    );
+    const port = Number(new URL(process.env.STORYBOOK_URL || 'http://localhost:6006').port);
+    const instance = await findInstanceRecord(port);
+
+    const cacheDir = join(process.cwd(), 'node_modules', '.cache');
+    await mkdir(cacheDir, { recursive: true });
+    const temporaryDir = await mkdtemp(join(cacheDir, 'storybook-tools-installation-'));
+    const recordedStorybookPath = join(temporaryDir, 'storybook');
+    try {
+      await mkdir(recordedStorybookPath);
+      await writeFile(
+        join(recordedStorybookPath, 'package.json'),
+        JSON.stringify({
+          name: 'storybook',
+          type: 'module',
+          exports: { './internal/tools/child-host': './child-host.mjs' },
+        }),
+        'utf8'
+      );
+      const childHostUrl = pathToFileURL(
+        join(process.cwd(), 'core', 'dist', 'cli', 'tools', 'sdk', 'child-host.js')
+      ).href;
+      await writeFile(
+        join(recordedStorybookPath, 'child-host.mjs'),
+        `import { writeFile } from 'node:fs/promises';
+await writeFile(${JSON.stringify(instance.path)}, ${JSON.stringify(instance.contents)}, 'utf8');
+const { runChildHost } = await import(${JSON.stringify(childHostUrl)});
+await runChildHost();
+`,
+        'utf8'
+      );
+      await writeFile(
+        instance.path,
+        `${JSON.stringify({ ...instance.record, storybookPath: recordedStorybookPath }, null, 2)}\n`,
+        'utf8'
+      );
+
+      const scriptPath = join(temporaryDir, 'run-tools.mjs');
+      const sdkUrl = pathToFileURL(
+        join(process.cwd(), 'core', 'dist', 'cli', 'tools', 'sdk', 'index.js')
+      ).href;
+      await writeFile(
+        scriptPath,
+        `import { createTools } from ${JSON.stringify(sdkUrl)};
+const tools = await createTools({ cwd: process.cwd(), mode: 'attached', port: Number(process.argv[2]) });
+try {
+  const catalog = await tools.describe({ toolset: 'stories' });
+  process.stdout.write(\`TOOLS_RESULT=\${JSON.stringify({ host: tools.host, toolset: catalog.toolsets[0]?.id })}\\n\`);
+} finally {
+  await tools.close();
+}
+`,
+        'utf8'
+      );
+      const { stdout, stderr } = await execFileAsync(process.execPath, [scriptPath, String(port)], {
+        cwd: process.cwd(),
+        env: { ...process.env, STORYBOOK_DISABLE_TELEMETRY: '1' },
+        timeout: 60_000,
+        maxBuffer: 16 * 1024 * 1024,
+      });
+
+      expect(`${stdout}${stderr}`).toContain('TOOLS_RESULT={"host":"child","toolset":"stories"}');
+    } finally {
+      await writeFile(instance.path, instance.contents, 'utf8');
+      await rm(temporaryDir, { recursive: true, force: true });
+    }
+  });
+
   test('--no-attach forces local and intercepts requiresDevServer tools', async () => {
     const list = await runTools(['--no-attach', 'docs', 'list']);
     expect(list.exitCode, list.output).toBe(0);
@@ -134,7 +223,10 @@ test.describe('storybook tools attach', () => {
   test('auto mode falls back to local silently when no instance matches', async () => {
     const emptyHome = join(tmpdir(), `storybook-tools-attach-empty-home-${process.pid}`);
     await mkdir(emptyHome, { recursive: true });
-    const result = await runTools(['docs', 'list'], process.cwd(), { HOME: emptyHome });
+    const result = await runTools(['docs', 'list'], process.cwd(), {
+      HOME: emptyHome,
+      USERPROFILE: emptyHome,
+    });
 
     expect(result.exitCode, result.output).toBe(0);
     expect(result.output).toContain('example-button');

--- a/code/e2e-internal/tools-attach.spec.ts
+++ b/code/e2e-internal/tools-attach.spec.ts
@@ -1,10 +1,9 @@
 import { execFile } from 'child_process';
-import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'fs/promises';
-import { homedir, tmpdir } from 'os';
+import { mkdir } from 'fs/promises';
+import { tmpdir } from 'os';
 import { join } from 'path';
 import { promisify } from 'util';
 import process from 'process';
-import { pathToFileURL } from 'url';
 
 import { expect, test } from '@playwright/test';
 
@@ -44,22 +43,6 @@ async function runTools(args: string[], cwd = process.cwd(), extraEnv: NodeJS.Pr
       output: `${failure.stdout ?? ''}${failure.stderr ?? ''}`,
     };
   }
-}
-
-async function findInstanceRecord(port: number) {
-  const registryDir = join(homedir(), '.storybook', 'instances');
-  for (const filename of await readdir(registryDir)) {
-    if (!filename.endsWith('.json')) {
-      continue;
-    }
-    const path = join(registryDir, filename);
-    const contents = await readFile(path, 'utf8');
-    const record = JSON.parse(contents) as { port: number; storybookPath?: string };
-    if (record.port === port) {
-      return { path, contents, record };
-    }
-  }
-  throw new Error(`No running Storybook instance record found on port ${port}.`);
 }
 
 const REVIEW_INPUT = JSON.stringify({
@@ -130,78 +113,6 @@ test.describe('storybook tools attach', () => {
     const list = await runTools(['--attach', 'docs', 'list']);
     expect(list.exitCode, list.output).toBe(0);
     expect(list.output).toContain('example-button');
-  });
-
-  test('respawns through the running instance installation when it differs from the caller', async () => {
-    test.skip(
-      !runsAgainstDevServer,
-      'Live attach requires the running Storybook channel, which the static E2E job does not serve.'
-    );
-    const port = Number(new URL(process.env.STORYBOOK_URL || 'http://localhost:6006').port);
-    const instance = await findInstanceRecord(port);
-
-    const cacheDir = join(process.cwd(), 'node_modules', '.cache');
-    await mkdir(cacheDir, { recursive: true });
-    const temporaryDir = await mkdtemp(join(cacheDir, 'storybook-tools-installation-'));
-    const recordedStorybookPath = join(temporaryDir, 'storybook');
-    try {
-      await mkdir(recordedStorybookPath);
-      await writeFile(
-        join(recordedStorybookPath, 'package.json'),
-        JSON.stringify({
-          name: 'storybook',
-          type: 'module',
-          exports: { './internal/tools/child-host': './child-host.mjs' },
-        }),
-        'utf8'
-      );
-      const childHostUrl = pathToFileURL(
-        join(process.cwd(), 'core', 'dist', 'cli', 'tools', 'sdk', 'child-host.js')
-      ).href;
-      await writeFile(
-        join(recordedStorybookPath, 'child-host.mjs'),
-        `import { writeFile } from 'node:fs/promises';
-await writeFile(${JSON.stringify(instance.path)}, ${JSON.stringify(instance.contents)}, 'utf8');
-const { runChildHost } = await import(${JSON.stringify(childHostUrl)});
-await runChildHost();
-`,
-        'utf8'
-      );
-      await writeFile(
-        instance.path,
-        `${JSON.stringify({ ...instance.record, storybookPath: recordedStorybookPath }, null, 2)}\n`,
-        'utf8'
-      );
-
-      const scriptPath = join(temporaryDir, 'run-tools.mjs');
-      const sdkUrl = pathToFileURL(
-        join(process.cwd(), 'core', 'dist', 'cli', 'tools', 'sdk', 'index.js')
-      ).href;
-      await writeFile(
-        scriptPath,
-        `import { createTools } from ${JSON.stringify(sdkUrl)};
-const tools = await createTools({ cwd: process.cwd(), mode: 'attached', port: Number(process.argv[2]) });
-try {
-  const catalog = await tools.describe({ toolset: 'stories' });
-  process.stdout.write(\`TOOLS_RESULT=\${JSON.stringify({ host: tools.host, toolset: catalog.toolsets[0]?.id })}\\n\`);
-} finally {
-  await tools.close();
-}
-`,
-        'utf8'
-      );
-      const { stdout, stderr } = await execFileAsync(process.execPath, [scriptPath, String(port)], {
-        cwd: process.cwd(),
-        env: { ...process.env, STORYBOOK_DISABLE_TELEMETRY: '1' },
-        timeout: 60_000,
-        maxBuffer: 16 * 1024 * 1024,
-      });
-
-      expect(`${stdout}${stderr}`).toContain('TOOLS_RESULT={"host":"child","toolset":"stories"}');
-    } finally {
-      await writeFile(instance.path, instance.contents, 'utf8');
-      await rm(temporaryDir, { recursive: true, force: true });
-    }
   });
 
   test('--no-attach forces local and intercepts requiresDevServer tools', async () => {


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

- Compare Storybook installation roots with platform-aware path identity, so Windows paths that differ only by letter case stay the same installation. Discovery already matched case-insensitively, so a byte-exact compare here could send the CLI into a child-host respawn against its own installation.
- Isolate the empty-registry E2E case with both `HOME` and `USERPROFILE`. On Windows `os.homedir()` reads `USERPROFILE`, so setting only `HOME` left the test pointed at the real instance registry.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

1. Compile core: `yarn nx compile core`.
2. Run the unit tests: `yarn vitest run code/core/src/cli/tools/sdk/installation.test.ts`. All cases pass, including the new Windows case-difference case.
3. On Windows, start the internal UI: `cd code; yarn storybook:ui --ci`.
4. In another terminal, run `cd code; yarn playwright test -c e2e-internal/playwright.config.ts e2e-internal/tools-attach.spec.ts --workers=1 -g "auto mode falls back"`. The test passes. Without the `USERPROFILE` change it fails on Windows, because the fake home does not hide the real instance registry.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
