### PR TITLE
CLI: Drop `skills get`/`skills list`, add `skills --all`

### DIFF
--- a/agent-eval/lib/shell-parse.ts
+++ b/agent-eval/lib/shell-parse.ts
@@ -20,7 +20,7 @@ export function workflowCallMatchesName(call: StorybookWorkflowCall, name: strin
   return (
     name === 'get-storybook-story-instructions' &&
     call.name === 'skills-get' &&
-    call.input.id === 'write-story'
+    (call.input.id === 'write-story' || call.input.id === 'all')
   );
 }
 
@@ -106,7 +106,8 @@ function parseStorybookCliWorkflowCalls(command: string): StorybookWorkflowCall[
       // is workflowCallMatchesName's concern. A help request prints usage instead
       // of the skill, so it does not count — same rule as the ai/tools branch below.
       const segment = segmentUntilSeparator(tokens, index + 2);
-      const [skillId, ...rest] = segment;
+      const [first, ...rest] = segment;
+      const skillId = first === '--all' ? 'all' : first;
       if (
         skillId !== undefined &&
         !skillId.startsWith('-') &&

--- a/agent-eval/lib/shell-parse.ts
+++ b/agent-eval/lib/shell-parse.ts
@@ -20,7 +20,7 @@ export function workflowCallMatchesName(call: StorybookWorkflowCall, name: strin
   return (
     name === 'get-storybook-story-instructions' &&
     call.name === 'skills-get' &&
-    (call.input.id === 'write-story' || call.input.id === 'all')
+    (call.input.id === 'write-story' || call.input.all === true)
   );
 }
 
@@ -107,15 +107,19 @@ function parseStorybookCliWorkflowCalls(command: string): StorybookWorkflowCall[
       // of the skill, so it does not count — same rule as the ai/tools branch below.
       const segment = segmentUntilSeparator(tokens, index + 2);
       const [first, ...rest] = segment;
-      const skillId = first === '--all' ? 'all' : first;
-      if (
-        skillId !== undefined &&
-        !skillId.startsWith('-') &&
+      const all = first === '--all' && rest.length === 0;
+      const single =
+        first !== undefined &&
+        !first.startsWith('-') &&
         !rest.includes('--all') &&
         !rest.includes('--help') &&
-        !rest.includes('-h')
-      ) {
-        calls.push({ name: 'skills-get', input: { id: skillId }, source: 'cli' });
+        !rest.includes('-h');
+      if (all || single) {
+        calls.push({
+          name: 'skills-get',
+          input: all ? { all: true } : { id: first },
+          source: 'cli',
+        });
         index += 1 + segment.length;
       }
       continue;

--- a/agent-eval/lib/shell-parse.ts
+++ b/agent-eval/lib/shell-parse.ts
@@ -111,6 +111,7 @@ function parseStorybookCliWorkflowCalls(command: string): StorybookWorkflowCall[
       if (
         skillId !== undefined &&
         !skillId.startsWith('-') &&
+        !rest.includes('--all') &&
         !rest.includes('--help') &&
         !rest.includes('-h')
       ) {

--- a/agent-eval/lib/shell-parse.ts
+++ b/agent-eval/lib/shell-parse.ts
@@ -8,7 +8,7 @@ export type StorybookWorkflowCall = {
   source: 'mcp' | 'storybook-ai' | 'cli';
 };
 
-// `storybook skills get write-story` serves the same document the MCP channel
+// `storybook skills write-story` serves the same document the MCP channel
 // exposes as the get-storybook-story-instructions tool. Assertions ask by that
 // historic name; this matcher owns the cross-channel equivalence. Remove the
 // alias once the MCP tool and the skill share one name (or the tool is
@@ -106,9 +106,8 @@ function parseStorybookCliWorkflowCalls(command: string): StorybookWorkflowCall[
       // is workflowCallMatchesName's concern. A help request prints usage instead
       // of the skill, so it does not count — same rule as the ai/tools branch below.
       const segment = segmentUntilSeparator(tokens, index + 2);
-      const [subcommand, skillId, ...rest] = segment;
+      const [skillId, ...rest] = segment;
       if (
-        subcommand === 'get' &&
         skillId !== undefined &&
         !skillId.startsWith('-') &&
         !rest.includes('--help') &&

--- a/agent-eval/lib/test-utils.test.ts
+++ b/agent-eval/lib/test-utils.test.ts
@@ -33,17 +33,23 @@ describe('parseStorybookWorkflowShellCommands', () => {
     ]);
   });
 
-  test('matches write-story and --all, but not other skills, to the historic instructions name', () => {
+  test('matches write-story and --all, but not other ids, to the historic instructions name', () => {
     const calls = parseStorybookWorkflowShellCommands([
       'npx storybook skills write-story',
       'npx storybook skills --all',
       'npx storybook skills stories',
+      'npx storybook skills all',
     ]);
 
-    expect(calls.map((call) => call.input.id)).toEqual(['write-story', 'all', 'stories']);
+    expect(calls.map((call) => call.input)).toEqual([
+      { id: 'write-story' },
+      { all: true },
+      { id: 'stories' },
+      { id: 'all' },
+    ]);
     expect(
       calls.map((call) => workflowCallMatchesName(call, 'get-storybook-story-instructions'))
-    ).toEqual([true, true, false]);
+    ).toEqual([true, true, false, false]);
   });
 
   test('does not record skills help requests, rejected --all combinations, or quoted mentions', () => {
@@ -51,6 +57,7 @@ describe('parseStorybookWorkflowShellCommands', () => {
       'npx storybook skills write-story --help',
       'npx storybook skills write-story -h && npx storybook skills --all --help',
       'npx storybook skills stories --all',
+      'npx storybook skills --all stories',
       "echo 'storybook skills write-story'",
     ]);
 

--- a/agent-eval/lib/test-utils.test.ts
+++ b/agent-eval/lib/test-utils.test.ts
@@ -33,21 +33,23 @@ describe('parseStorybookWorkflowShellCommands', () => {
     ]);
   });
 
-  test('matches only the write-story skill to the historic instructions name', () => {
+  test('matches write-story and --all, but not other skills, to the historic instructions name', () => {
     const calls = parseStorybookWorkflowShellCommands([
       'npx storybook skills write-story',
+      'npx storybook skills --all',
       'npx storybook skills stories',
     ]);
 
+    expect(calls.map((call) => call.input.id)).toEqual(['write-story', 'all', 'stories']);
     expect(
       calls.map((call) => workflowCallMatchesName(call, 'get-storybook-story-instructions'))
-    ).toEqual([true, false]);
+    ).toEqual([true, true, false]);
   });
 
   test('does not record skills help requests or quoted mentions as instruction fetches', () => {
     const calls = parseStorybookWorkflowShellCommands([
       'npx storybook skills write-story --help',
-      'npx storybook skills write-story -h && npx storybook skills --all',
+      'npx storybook skills write-story -h && npx storybook skills --all --help',
       "echo 'storybook skills write-story'",
     ]);
 

--- a/agent-eval/lib/test-utils.test.ts
+++ b/agent-eval/lib/test-utils.test.ts
@@ -46,10 +46,11 @@ describe('parseStorybookWorkflowShellCommands', () => {
     ).toEqual([true, true, false]);
   });
 
-  test('does not record skills help requests or quoted mentions as instruction fetches', () => {
+  test('does not record skills help requests, rejected --all combinations, or quoted mentions', () => {
     const calls = parseStorybookWorkflowShellCommands([
       'npx storybook skills write-story --help',
       'npx storybook skills write-story -h && npx storybook skills --all --help',
+      'npx storybook skills stories --all',
       "echo 'storybook skills write-story'",
     ]);
 

--- a/agent-eval/lib/test-utils.test.ts
+++ b/agent-eval/lib/test-utils.test.ts
@@ -20,11 +20,11 @@ import {
 } from './test-utils.ts';
 
 describe('parseStorybookWorkflowShellCommands', () => {
-  test('records `skills get <id>` invocations literally, with their skill id', () => {
+  test('records `skills <id>` invocations literally, with their skill id', () => {
     const calls = parseStorybookWorkflowShellCommands([
-      'npx storybook skills get write-story 2>&1 | grep -v "npm warn"',
-      'npx storybook skills get stories',
-      'npx storybook skills list',
+      'npx storybook skills write-story 2>&1 | grep -v "npm warn"',
+      'npx storybook skills stories',
+      'npx storybook skills',
     ]);
 
     expect(calls).toEqual([
@@ -35,8 +35,8 @@ describe('parseStorybookWorkflowShellCommands', () => {
 
   test('matches only the write-story skill to the historic instructions name', () => {
     const calls = parseStorybookWorkflowShellCommands([
-      'npx storybook skills get write-story',
-      'npx storybook skills get stories',
+      'npx storybook skills write-story',
+      'npx storybook skills stories',
     ]);
 
     expect(
@@ -46,9 +46,9 @@ describe('parseStorybookWorkflowShellCommands', () => {
 
   test('does not record skills help requests or quoted mentions as instruction fetches', () => {
     const calls = parseStorybookWorkflowShellCommands([
-      'npx storybook skills get write-story --help',
-      'npx storybook skills get write-story -h && npx storybook skills list',
-      "echo 'storybook skills get write-story'",
+      'npx storybook skills write-story --help',
+      'npx storybook skills write-story -h && npx storybook skills --all',
+      "echo 'storybook skills write-story'",
     ]);
 
     expect(calls).toHaveLength(0);

--- a/code/core/src/bin/core.ts
+++ b/code/core/src/bin/core.ts
@@ -251,7 +251,7 @@ const aiCommand = command('ai')
 aiCommand
   .command('setup')
   .description(
-    'Generate setup instructions to write stories for real components (deprecated: use `storybook skills get setup`)'
+    'Generate setup instructions to write stories for real components (deprecated: use `storybook skills setup`)'
   )
   .addOption(
     new Option('--package-manager <type>', 'Force package manager for installing deps').choices(

--- a/code/core/src/cli/ai/index.ts
+++ b/code/core/src/cli/ai/index.ts
@@ -17,7 +17,7 @@ export async function aiSetup(options: AiSetupOptions): Promise<void> {
   // contaminate the markdown output this command prints to stdout. Write directly to
   // stderr instead so piping `storybook ai setup` still yields clean markdown.
   process.stderr.write(
-    '`storybook ai setup` is deprecated and will be removed in a future release. Use `npx storybook skills get setup` instead.\n'
+    '`storybook ai setup` is deprecated and will be removed in a future release. Use `npx storybook skills setup` instead.\n'
   );
 
   const result = await getProjectInfo({

--- a/code/core/src/cli/ai/types.ts
+++ b/code/core/src/cli/ai/types.ts
@@ -15,6 +15,6 @@ export interface AiSetupOptions {
   runId: string;
 }
 
-// `ProjectInfo` now lives in `cli/skills/project-info.ts` (shared with the future `skills get setup`
+// `ProjectInfo` now lives in `cli/skills/project-info.ts` (shared with the `skills setup`
 // CLI command); re-exported here so existing `cli/ai` importers (e.g. `cli/ai/mcp/`) keep compiling.
 export type { ProjectInfo } from '../skills/project-info.ts';

--- a/code/core/src/cli/ai/types.ts
+++ b/code/core/src/cli/ai/types.ts
@@ -15,6 +15,5 @@ export interface AiSetupOptions {
   runId: string;
 }
 
-// `ProjectInfo` now lives in `cli/skills/project-info.ts` (shared with the `skills setup`
-// CLI command); re-exported here so existing `cli/ai` importers (e.g. `cli/ai/mcp/`) keep compiling.
+// Re-exported so `cli/ai/mcp/` importers keep compiling.
 export type { ProjectInfo } from '../skills/project-info.ts';

--- a/code/core/src/cli/skills/content/build-server-instructions.test.ts
+++ b/code/core/src/cli/skills/content/build-server-instructions.test.ts
@@ -285,7 +285,7 @@ describe('buildServerInstructions', () => {
       expect(instructions).not.toContain('stories-changed');
     });
 
-    it('renders the write-story skill cross-reference as a `storybook skills get` command', () => {
+    it('renders the write-story skill cross-reference as a `storybook skills` command', () => {
       const instructions = buildServerInstructions({
         transport: 'cli',
         devEnabled: true,
@@ -293,7 +293,7 @@ describe('buildServerInstructions', () => {
         docsEnabled: false,
       });
 
-      expect(instructions).toContain('npx storybook skills get write-story');
+      expect(instructions).toContain('npx storybook skills write-story');
       expect(instructions).not.toContain('get-storybook-story-instructions');
     });
 

--- a/code/core/src/cli/skills/content/skill-refs.test.ts
+++ b/code/core/src/cli/skills/content/skill-refs.test.ts
@@ -9,15 +9,15 @@ describe('getSkillRef', () => {
   });
 
   it('renders the skills CLI command on the CLI transport', () => {
-    expect(getSkillRef('cli')('write-story')).toBe('npx storybook skills get write-story');
-    expect(getSkillRef('cli')('stories')).toBe('npx storybook skills get stories');
-    expect(getSkillRef('cli')('setup')).toBe('npx storybook skills get setup');
+    expect(getSkillRef('cli')('write-story')).toBe('npx storybook skills write-story');
+    expect(getSkillRef('cli')('stories')).toBe('npx storybook skills stories');
+    expect(getSkillRef('cli')('setup')).toBe('npx storybook skills setup');
   });
 
   it('falls back to the CLI command for skills with no MCP tool equivalent', () => {
     // `stories` is delivered via MCP server instructions, not a callable tool,
     // so even the MCP transport names the CLI command as the reachable channel.
-    expect(getSkillRef('mcp')('stories')).toBe('npx storybook skills get stories');
+    expect(getSkillRef('mcp')('stories')).toBe('npx storybook skills stories');
   });
 });
 

--- a/code/core/src/cli/skills/content/skill-refs.ts
+++ b/code/core/src/cli/skills/content/skill-refs.ts
@@ -14,9 +14,9 @@ const MCP_SKILL_TOOL_NAMES: Partial<Record<SkillId, string>> = {
 
 /**
  * Renders a cross-reference to a skill in the transport's own vocabulary, mirroring `getToolName` for
- * toolset methods: the MCP tool name where one exists, the `skills get` command otherwise.
+ * toolset methods: the MCP tool name where one exists, the `storybook skills` command otherwise.
  */
 export function getSkillRef(transport: SkillTransport) {
   return (id: SkillId): string =>
-    (transport === 'mcp' && MCP_SKILL_TOOL_NAMES[id]) || `npx storybook skills get ${id}`;
+    (transport === 'mcp' && MCP_SKILL_TOOL_NAMES[id]) || `npx storybook skills ${id}`;
 }

--- a/code/core/src/cli/skills/content/skills.ts
+++ b/code/core/src/cli/skills/content/skills.ts
@@ -1,5 +1,5 @@
 /**
- * The Storybook skills: agent-facing instruction documents served by `storybook skills get <id>`
+ * The Storybook skills: agent-facing instruction documents served by `storybook skills <id>`
  * and, on the MCP side, by addon-mcp (server instructions and the story-instructions tool). The
  * ids are public CLI vocabulary — plugin stubs (M7) will reference them — so treat renames as
  * breaking.

--- a/code/core/src/cli/skills/project-info.ts
+++ b/code/core/src/cli/skills/project-info.ts
@@ -45,7 +45,7 @@ function parseMajorVersion(version: string): number | undefined {
 /**
  * Probes the target Storybook configuration and assembles the `ProjectInfo` the setup prompts
  * render from. Returns a discriminated result instead of throwing so callers (the `ai setup` CLI
- * today, `skills get setup` next) render their own failure message instead of duplicating logging.
+ * and `skills setup`) render their own failure message instead of duplicating logging.
  */
 export async function getProjectInfo(opts: {
   configDir?: string;

--- a/code/core/src/cli/skills/project-info.ts
+++ b/code/core/src/cli/skills/project-info.ts
@@ -42,11 +42,8 @@ function parseMajorVersion(version: string): number | undefined {
   return match ? parseInt(match[1], 10) : undefined;
 }
 
-/**
- * Probes the target Storybook configuration and assembles the `ProjectInfo` the setup prompts
- * render from. Returns a discriminated result instead of throwing so callers (the `ai setup` CLI
- * and `skills setup`) render their own failure message instead of duplicating logging.
- */
+// Returns a discriminated result instead of throwing so callers (the `ai setup` CLI and
+// `skills setup`) render their own failure message instead of duplicating logging.
 export async function getProjectInfo(opts: {
   configDir?: string;
   packageManager?: PackageManagerName;

--- a/code/core/src/cli/skills/register.test.ts
+++ b/code/core/src/cli/skills/register.test.ts
@@ -79,6 +79,7 @@ describe('registerSkillsCommand', () => {
     expect(vi.mocked(runSkillsCommand).mock.calls[0]?.[0]).toEqual({
       tokens: ['stories'],
       help: undefined,
+      all: undefined,
       target: { cwd: undefined, configDir: undefined },
     });
   });

--- a/code/core/src/cli/skills/register.test.ts
+++ b/code/core/src/cli/skills/register.test.ts
@@ -83,13 +83,21 @@ describe('registerSkillsCommand', () => {
     });
   });
 
-  it('keeps the `get <id>` spelling', async () => {
+  it('forwards `--all` as a flag, not a token', async () => {
+    vi.mocked(runSkillsCommand).mockResolvedValue({
+      output: 'everything',
+      exitCode: 0,
+      kind: 'get',
+      skill: 'all',
+    });
     const { program } = buildProgram();
-    await parse(program, ['skills', 'get', 'setup']);
+    await parse(program, ['skills', '--all']);
 
     expect(vi.mocked(runSkillsCommand).mock.calls[0]?.[0]).toMatchObject({
-      tokens: ['get', 'setup'],
+      tokens: [],
+      all: true,
     });
+    expect(telemetry).toHaveBeenCalledWith('skills-get', { skill: 'all' }, expect.anything());
   });
 
   it('does not intercept `help` as commander help', async () => {

--- a/code/core/src/cli/skills/register.test.ts
+++ b/code/core/src/cli/skills/register.test.ts
@@ -47,7 +47,6 @@ beforeEach(() => {
   vi.mocked(runSkillsCommand).mockResolvedValue({
     output: 'ok',
     exitCode: 0,
-    kind: 'get',
     skill: 'stories',
   });
   vi.mocked(withTelemetry).mockImplementation(async (_eventType, _options, run) => run());
@@ -88,7 +87,6 @@ describe('registerSkillsCommand', () => {
     vi.mocked(runSkillsCommand).mockResolvedValue({
       output: 'everything',
       exitCode: 0,
-      kind: 'get',
       skill: 'all',
     });
     const { program } = buildProgram();
@@ -111,7 +109,7 @@ describe('registerSkillsCommand', () => {
   });
 
   it('forwards `-h` after a skill id', async () => {
-    vi.mocked(runSkillsCommand).mockResolvedValue({ output: 'usage', exitCode: 0, kind: 'help' });
+    vi.mocked(runSkillsCommand).mockResolvedValue({ output: 'usage', exitCode: 0 });
     const { program } = buildProgram();
     await parse(program, ['skills', 'write-story', '-h']);
 

--- a/code/core/src/cli/skills/register.test.ts
+++ b/code/core/src/cli/skills/register.test.ts
@@ -110,12 +110,7 @@ describe('registerSkillsCommand', () => {
   });
 
   it('forwards `-h` after a skill id', async () => {
-    vi.mocked(runSkillsCommand).mockResolvedValue({
-      output: 'usage',
-      exitCode: 0,
-      kind: 'help',
-      skill: 'write-story',
-    });
+    vi.mocked(runSkillsCommand).mockResolvedValue({ output: 'usage', exitCode: 0, kind: 'help' });
     const { program } = buildProgram();
     await parse(program, ['skills', 'write-story', '-h']);
 

--- a/code/core/src/cli/skills/register.ts
+++ b/code/core/src/cli/skills/register.ts
@@ -61,7 +61,7 @@ export function registerSkillsCommand(
     const run = async () => {
       const result = await runSkillsCommand(invocation, defaultDeps());
       await printResult(result);
-      if (result.kind === 'get' && result.skill && result.exitCode === 0) {
+      if (result.skill) {
         await telemetry('skills-get', { skill: result.skill }, { configDir: cliOptions.configDir });
       }
     };

--- a/code/core/src/cli/skills/register.ts
+++ b/code/core/src/cli/skills/register.ts
@@ -28,8 +28,7 @@ type SkillsCommandOptions = {
   logfile?: string | boolean;
 };
 
-// `storybook skills [id]`: no id lists every skill, `<id>` prints it, `<id> --help` describes
-// it, `--all` prints every skill.
+// `storybook skills [id]`: no id lists every skill, `<id>` prints it, `--all` prints every skill.
 export function registerSkillsCommand(
   program: Command,
   skillsCommand: Command,
@@ -67,7 +66,7 @@ export function registerSkillsCommand(
         await telemetry('skills-get', { skill: result.skill }, { configDir: cliOptions.configDir });
       }
     };
-    if (intent.kind === 'catalog' || intent.kind === 'skill-help') {
+    if (intent.kind === 'catalog') {
       await run();
     } else {
       await withTelemetry('skills-get', { cliOptions, fallbackTelemetryState: true }, run).catch(

--- a/code/core/src/cli/skills/register.ts
+++ b/code/core/src/cli/skills/register.ts
@@ -28,7 +28,6 @@ type SkillsCommandOptions = {
   logfile?: string | boolean;
 };
 
-// `storybook skills [id]`: no id lists every skill, `<id>` prints it, `--all` prints every skill.
 export function registerSkillsCommand(
   program: Command,
   skillsCommand: Command,
@@ -58,7 +57,7 @@ export function registerSkillsCommand(
       all: options.all,
       target: { cwd: options.cwd, configDir: options.configDir },
     };
-    const intent = resolveSkillsIntent(invocation.tokens, invocation);
+    const intent = resolveSkillsIntent(invocation);
     const run = async () => {
       const result = await runSkillsCommand(invocation, defaultDeps());
       await printResult(result);

--- a/code/core/src/cli/skills/register.ts
+++ b/code/core/src/cli/skills/register.ts
@@ -21,6 +21,7 @@ type SkillsCommandOptions = {
   cwd?: string;
   configDir?: string;
   help?: boolean;
+  all?: boolean;
   /** From the shared command options in `bin/core.ts`; consumed by `withTelemetry`. */
   disableTelemetry?: boolean;
   /** From the shared command options in `bin/core.ts`; consumed by the failure handler. */
@@ -28,7 +29,7 @@ type SkillsCommandOptions = {
 };
 
 // `storybook skills [id]`: no id lists every skill, `<id>` prints it, `<id> --help` describes
-// it. `list` and `get <id>` remain accepted spellings.
+// it, `--all` prints every skill.
 export function registerSkillsCommand(
   program: Command,
   skillsCommand: Command,
@@ -55,9 +56,10 @@ export function registerSkillsCommand(
     const invocation = {
       tokens: tokens ?? [],
       help: options.help,
+      all: options.all,
       target: { cwd: options.cwd, configDir: options.configDir },
     };
-    const intent = resolveSkillsIntent(invocation.tokens, options.help);
+    const intent = resolveSkillsIntent(invocation.tokens, invocation);
     const run = async () => {
       const result = await runSkillsCommand(invocation, defaultDeps());
       await printResult(result);

--- a/code/core/src/cli/skills/run.test.ts
+++ b/code/core/src/cli/skills/run.test.ts
@@ -48,26 +48,23 @@ describe('resolveSkillsIntent', () => {
     });
   });
 
-  it('does not treat `help`, `list`, or `get` as subcommands', () => {
-    expect(resolveSkillsIntent({ tokens: ['help', 'stories'] })).toEqual({
-      kind: 'unknown',
-      id: 'help',
-    });
-    expect(resolveSkillsIntent({ tokens: ['list'] })).toEqual({ kind: 'unknown', id: 'list' });
-    expect(resolveSkillsIntent({ tokens: ['get', 'stories'] })).toEqual({
-      kind: 'unknown',
-      id: 'get',
-    });
+  it('rejects `help`, `list`, and `get` as unknown skills, naming the valid ids', () => {
+    for (const first of ['help', 'list', 'get']) {
+      expect(resolveSkillsIntent({ tokens: [first, 'stories'] })).toEqual({
+        kind: 'error',
+        message: `Unknown skill "${first}". Available skills: stories, write-story, setup.`,
+      });
+    }
   });
 
   it('rejects surplus positional arguments and an id combined with --all', () => {
     expect(resolveSkillsIntent({ tokens: ['stories', 'typo'] })).toEqual({
-      kind: 'invalid',
-      tokens: ['stories', 'typo'],
+      kind: 'error',
+      message: expect.stringContaining('Unexpected arguments: "typo"'),
     });
     expect(resolveSkillsIntent({ tokens: ['stories'], all: true })).toEqual({
-      kind: 'invalid',
-      tokens: ['stories'],
+      kind: 'error',
+      message: expect.stringContaining('takes no skill id'),
     });
   });
 });
@@ -77,7 +74,6 @@ describe('runSkillsCommand', () => {
     const d = deps();
     const result = await runSkillsCommand({ tokens: [], target: {} }, d);
     expect(result.exitCode).toBe(0);
-    expect(result.kind).toBe('help');
     expect(result.output).toContain('Usage: npx storybook skills [options] [id]');
     expect(result.output).toContain('stories');
     expect(result.output).toContain('write-story');

--- a/code/core/src/cli/skills/run.test.ts
+++ b/code/core/src/cli/skills/run.test.ts
@@ -27,39 +27,42 @@ const deps = () => ({
 });
 
 describe('resolveSkillsIntent', () => {
-  it('treats no args and `list` as the catalog', () => {
+  it('treats no args as the catalog', () => {
     expect(resolveSkillsIntent([])).toEqual({ kind: 'catalog' });
-    expect(resolveSkillsIntent(['list'])).toEqual({ kind: 'catalog' });
+    expect(resolveSkillsIntent([], { help: true })).toEqual({ kind: 'catalog' });
   });
 
-  it('prints a skill by id, including the `get <id>` spelling', () => {
+  it('prints a skill by id', () => {
     expect(resolveSkillsIntent(['stories'])).toEqual({ kind: 'get', id: 'stories' });
-    expect(resolveSkillsIntent(['get', 'setup'])).toEqual({ kind: 'get', id: 'setup' });
+    expect(resolveSkillsIntent(['setup'])).toEqual({ kind: 'get', id: 'setup' });
+  });
+
+  it('prints every skill on --all, unless help is also set', () => {
+    expect(resolveSkillsIntent([], { all: true })).toEqual({ kind: 'all' });
+    expect(resolveSkillsIntent([], { all: true, help: true })).toEqual({ kind: 'catalog' });
   });
 
   it('describes a skill when help is set', () => {
-    expect(resolveSkillsIntent(['write-story'], true)).toEqual({
-      kind: 'skill-help',
-      id: 'write-story',
-    });
-    expect(resolveSkillsIntent(['get', 'write-story'], true)).toEqual({
+    expect(resolveSkillsIntent(['write-story'], { help: true })).toEqual({
       kind: 'skill-help',
       id: 'write-story',
     });
   });
 
-  it('does not treat `help` as a subcommand', () => {
+  it('does not treat `help`, `list`, or `get` as subcommands', () => {
     expect(resolveSkillsIntent(['help', 'stories'])).toEqual({ kind: 'unknown', id: 'help' });
+    expect(resolveSkillsIntent(['list'])).toEqual({ kind: 'unknown', id: 'list' });
+    expect(resolveSkillsIntent(['get', 'stories'])).toEqual({ kind: 'unknown', id: 'get' });
   });
 
-  it('rejects surplus positional arguments', () => {
+  it('rejects surplus positional arguments and an id combined with --all', () => {
     expect(resolveSkillsIntent(['stories', 'typo'])).toEqual({
       kind: 'invalid',
       tokens: ['stories', 'typo'],
     });
-    expect(resolveSkillsIntent(['get', 'stories', 'typo'])).toEqual({
+    expect(resolveSkillsIntent(['stories'], { all: true })).toEqual({
       kind: 'invalid',
-      tokens: ['get', 'stories', 'typo'],
+      tokens: ['stories'],
     });
   });
 });
@@ -87,7 +90,7 @@ describe('runSkillsCommand', () => {
     expect(d.loadStorybook).not.toHaveBeenCalled();
   });
 
-  it('get stories assembles CLI-transport server instructions using the CLI review gate', async () => {
+  it('stories assembles CLI-transport server instructions using the CLI review gate', async () => {
     const d = deps();
     const result = await runSkillsCommand({ tokens: ['stories'], target: {} }, d);
     expect(result.exitCode).toBe(0);
@@ -116,15 +119,15 @@ describe('runSkillsCommand', () => {
     expect(stories.output).not.toContain('Documentation Workflow');
   });
 
-  it('get write-story assembles CLI-transport story instructions', async () => {
+  it('write-story assembles CLI-transport story instructions', async () => {
     const d = deps();
-    const result = await runSkillsCommand({ tokens: ['get', 'write-story'], target: {} }, d);
+    const result = await runSkillsCommand({ tokens: ['write-story'], target: {} }, d);
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain('@storybook/react');
     expect(result.output).toContain('npx storybook tools stories changed');
   });
 
-  it('get setup emits the setup markdown from the lightweight probe, without loading config', async () => {
+  it('setup emits the setup markdown from the lightweight probe, without loading config', async () => {
     const d = deps();
     const result = await runSkillsCommand({ tokens: ['setup'], target: {} }, d);
     expect(result.exitCode).toBe(0);
@@ -132,7 +135,7 @@ describe('runSkillsCommand', () => {
     expect(d.loadStorybook).not.toHaveBeenCalled();
   });
 
-  it('get setup reports the probe failure message and exits nonzero', async () => {
+  it('setup reports the probe failure message and exits nonzero', async () => {
     const d = deps();
     d.getProjectInfo.mockResolvedValue({ ok: false, message: 'Could not detect framework' });
     const result = await runSkillsCommand({ tokens: ['setup'], target: {} }, d);
@@ -140,7 +143,7 @@ describe('runSkillsCommand', () => {
     expect(result.errorOutput).toContain('Could not detect framework');
   });
 
-  it('get setup resolves configDir against the given cwd before probing, not process.cwd()', async () => {
+  it('setup resolves configDir against the given cwd before probing, not process.cwd()', async () => {
     const d = deps();
     const target = { cwd: '/some/other/project', configDir: 'custom-storybook' };
     await runSkillsCommand({ tokens: ['setup'], target }, d);
@@ -167,8 +170,24 @@ describe('runSkillsCommand', () => {
     expect(result.errorOutput).toContain('setup');
   });
 
-  it('`get` without an id behaves like unknown id', async () => {
-    const result = await runSkillsCommand({ tokens: ['get'], target: {} }, deps());
+  it('--all prints every skill in full, loading the configuration once', async () => {
+    const d = deps();
+    const result = await runSkillsCommand({ tokens: [], all: true, target: {} }, d);
+    expect(result.exitCode).toBe(0);
+    expect(result.skill).toBe('all');
+    expect(result.output).toContain('# Storybook Setup');
+    expect(result.output).toContain('npx storybook tools stories changed');
+    expect(result.output).toContain('@storybook/react');
+    expect(d.loadStorybook).toHaveBeenCalledTimes(1);
+    expect(d.getProjectInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it('--all fails as a whole when the configuration cannot be loaded', async () => {
+    const d = deps();
+    d.loadStorybook.mockRejectedValue(new Error('Cannot find module .storybook/main.ts'));
+    const result = await runSkillsCommand({ tokens: [], all: true, target: {} }, d);
     expect(result.exitCode).toBe(1);
+    expect(result.output).toBe('');
+    expect(result.errorOutput).toContain('Cannot find module .storybook/main.ts');
   });
 });

--- a/code/core/src/cli/skills/run.test.ts
+++ b/code/core/src/cli/skills/run.test.ts
@@ -28,36 +28,44 @@ const deps = () => ({
 
 describe('resolveSkillsIntent', () => {
   it('treats no args as the catalog', () => {
-    expect(resolveSkillsIntent([])).toEqual({ kind: 'catalog' });
-    expect(resolveSkillsIntent([], { help: true })).toEqual({ kind: 'catalog' });
+    expect(resolveSkillsIntent({ tokens: [] })).toEqual({ kind: 'catalog' });
+    expect(resolveSkillsIntent({ tokens: [], help: true })).toEqual({ kind: 'catalog' });
   });
 
   it('prints a skill by id', () => {
-    expect(resolveSkillsIntent(['stories'])).toEqual({ kind: 'get', id: 'stories' });
-    expect(resolveSkillsIntent(['setup'])).toEqual({ kind: 'get', id: 'setup' });
+    expect(resolveSkillsIntent({ tokens: ['stories'] })).toEqual({ kind: 'get', id: 'stories' });
+    expect(resolveSkillsIntent({ tokens: ['setup'] })).toEqual({ kind: 'get', id: 'setup' });
   });
 
   it('prints every skill on --all, unless help is also set', () => {
-    expect(resolveSkillsIntent([], { all: true })).toEqual({ kind: 'all' });
-    expect(resolveSkillsIntent([], { all: true, help: true })).toEqual({ kind: 'catalog' });
+    expect(resolveSkillsIntent({ tokens: [], all: true })).toEqual({ kind: 'all' });
+    expect(resolveSkillsIntent({ tokens: [], all: true, help: true })).toEqual({ kind: 'catalog' });
   });
 
   it('treats help as the catalog even after a skill id', () => {
-    expect(resolveSkillsIntent(['write-story'], { help: true })).toEqual({ kind: 'catalog' });
+    expect(resolveSkillsIntent({ tokens: ['write-story'], help: true })).toEqual({
+      kind: 'catalog',
+    });
   });
 
   it('does not treat `help`, `list`, or `get` as subcommands', () => {
-    expect(resolveSkillsIntent(['help', 'stories'])).toEqual({ kind: 'unknown', id: 'help' });
-    expect(resolveSkillsIntent(['list'])).toEqual({ kind: 'unknown', id: 'list' });
-    expect(resolveSkillsIntent(['get', 'stories'])).toEqual({ kind: 'unknown', id: 'get' });
+    expect(resolveSkillsIntent({ tokens: ['help', 'stories'] })).toEqual({
+      kind: 'unknown',
+      id: 'help',
+    });
+    expect(resolveSkillsIntent({ tokens: ['list'] })).toEqual({ kind: 'unknown', id: 'list' });
+    expect(resolveSkillsIntent({ tokens: ['get', 'stories'] })).toEqual({
+      kind: 'unknown',
+      id: 'get',
+    });
   });
 
   it('rejects surplus positional arguments and an id combined with --all', () => {
-    expect(resolveSkillsIntent(['stories', 'typo'])).toEqual({
+    expect(resolveSkillsIntent({ tokens: ['stories', 'typo'] })).toEqual({
       kind: 'invalid',
       tokens: ['stories', 'typo'],
     });
-    expect(resolveSkillsIntent(['stories'], { all: true })).toEqual({
+    expect(resolveSkillsIntent({ tokens: ['stories'], all: true })).toEqual({
       kind: 'invalid',
       tokens: ['stories'],
     });

--- a/code/core/src/cli/skills/run.test.ts
+++ b/code/core/src/cli/skills/run.test.ts
@@ -42,11 +42,8 @@ describe('resolveSkillsIntent', () => {
     expect(resolveSkillsIntent([], { all: true, help: true })).toEqual({ kind: 'catalog' });
   });
 
-  it('describes a skill when help is set', () => {
-    expect(resolveSkillsIntent(['write-story'], { help: true })).toEqual({
-      kind: 'skill-help',
-      id: 'write-story',
-    });
+  it('treats help as the catalog even after a skill id', () => {
+    expect(resolveSkillsIntent(['write-story'], { help: true })).toEqual({ kind: 'catalog' });
   });
 
   it('does not treat `help`, `list`, or `get` as subcommands', () => {
@@ -77,16 +74,6 @@ describe('runSkillsCommand', () => {
     expect(result.output).toContain('stories');
     expect(result.output).toContain('write-story');
     expect(result.output).toContain('setup');
-    expect(d.loadStorybook).not.toHaveBeenCalled();
-  });
-
-  it('describes one skill on `--help` without loading config', async () => {
-    const d = deps();
-    const result = await runSkillsCommand({ tokens: ['write-story'], help: true, target: {} }, d);
-    expect(result.exitCode).toBe(0);
-    expect(result.kind).toBe('help');
-    expect(result.output).toContain('Usage: npx storybook skills write-story [options]');
-    expect(result.output).toContain('Prints the full instructions as markdown.');
     expect(d.loadStorybook).not.toHaveBeenCalled();
   });
 

--- a/code/core/src/cli/skills/run.ts
+++ b/code/core/src/cli/skills/run.ts
@@ -14,17 +14,23 @@ export const SKILLS_OPTION_SPECS = [
     flags: '-c, --config-dir <dir-name>',
     description: 'Storybook config directory of the target Storybook',
   },
+  { flags: '--all', description: 'Print every skill in full' },
   {
     flags: '-h, --help',
     description: 'Show every skill, or one skill with its description',
   },
 ] as const;
 
+type SkillsOptionSpec = (typeof SKILLS_OPTION_SPECS)[number];
+
 export type SkillsRunInput = {
   tokens: string[];
   help?: boolean;
-  target: { cwd?: string; configDir?: string };
+  all?: boolean;
+  target: SkillsTarget;
 };
+
+type SkillsTarget = { cwd?: string; configDir?: string };
 
 export type SkillsRunKind = 'help' | 'get';
 
@@ -33,8 +39,8 @@ export type SkillsRunResult = {
   errorOutput?: string;
   exitCode: number;
   kind: SkillsRunKind;
-  /** For telemetry: which skill was served, when the run got that far. */
-  skill?: SkillId;
+  /** For telemetry: which skill was served (or `all`), when the run got that far. */
+  skill?: SkillId | 'all';
 };
 
 export type SkillsRunDeps = {
@@ -53,26 +59,23 @@ export type SkillsIntent =
   | { kind: 'catalog' }
   | { kind: 'skill-help'; id: SkillId }
   | { kind: 'get'; id: SkillId }
+  | { kind: 'all' }
   | { kind: 'invalid'; tokens: string[] }
-  | { kind: 'unknown'; id?: string };
+  | { kind: 'unknown'; id: string };
 
-export function resolveSkillsIntent(tokens: string[], help = false): SkillsIntent {
-  const [first, second] = tokens;
-  if (first === undefined) {
-    return { kind: 'catalog' };
+export function resolveSkillsIntent(
+  tokens: string[],
+  { help = false, all = false }: { help?: boolean; all?: boolean } = {}
+): SkillsIntent {
+  const [id, ...rest] = tokens;
+  if (id === undefined) {
+    return all && !help ? { kind: 'all' } : { kind: 'catalog' };
   }
-  if (first === 'list') {
-    return tokens.length === 1 ? { kind: 'catalog' } : { kind: 'invalid', tokens };
-  }
-  if (first !== 'get' && !isSkillId(first)) {
-    return { kind: 'unknown', id: first };
-  }
-  if (tokens.length > (first === 'get' ? 2 : 1)) {
-    return { kind: 'invalid', tokens };
-  }
-  const id = first === 'get' ? second : first;
-  if (id === undefined || !isSkillId(id)) {
+  if (!isSkillId(id)) {
     return { kind: 'unknown', id };
+  }
+  if (rest.length > 0 || all) {
+    return { kind: 'invalid', tokens };
   }
   return help ? { kind: 'skill-help', id } : { kind: 'get', id };
 }
@@ -81,7 +84,7 @@ export async function runSkillsCommand(
   input: SkillsRunInput,
   deps: SkillsRunDeps
 ): Promise<SkillsRunResult> {
-  const intent = resolveSkillsIntent(input.tokens, input.help);
+  const intent = resolveSkillsIntent(input.tokens, input);
   if (intent.kind === 'catalog') {
     return { output: renderCatalogHelp(), exitCode: 0, kind: 'help' };
   }
@@ -89,64 +92,86 @@ export async function runSkillsCommand(
     return { output: renderSkillHelp(intent.id), exitCode: 0, kind: 'help', skill: intent.id };
   }
   if (intent.kind === 'invalid') {
-    return {
-      output: '',
-      errorOutput: `Unexpected arguments: ${intent.tokens.map((token) => `"${token}"`).join(' ')}.`,
-      exitCode: 1,
-      kind: 'get',
-    };
+    return failure(
+      `Unexpected arguments: ${intent.tokens.map((token) => `"${token}"`).join(' ')}. Run \`npx storybook skills --help\` for usage.`
+    );
   }
   if (intent.kind === 'unknown') {
-    return {
-      output: '',
-      errorOutput: `Unknown skill${intent.id ? ` "${intent.id}"` : ''}. Available skills: ${SKILL_IDS.join(', ')}.`,
-      exitCode: 1,
-      kind: 'get',
-    };
+    return failure(`Unknown skill "${intent.id}". Available skills: ${SKILL_IDS.join(', ')}.`);
+  }
+  if (intent.kind === 'all') {
+    const setup = await serveSetup(input.target, deps);
+    if (!setup.ok) {
+      return failure(setup.message, 'all');
+    }
+    const loaded = await loadInputs(input.target, deps);
+    if (!loaded.ok) {
+      return failure(loaded.message, 'all');
+    }
+    const output = SKILL_IDS.map((id) =>
+      id === 'setup' ? setup.markdown : assemble(id, loaded.inputs)
+    ).join('\n\n---\n\n');
+    return { output, exitCode: 0, kind: 'get', skill: 'all' };
   }
 
   const { id } = intent;
-
   if (id === 'setup') {
-    // The setup skill only needs the lightweight project-info probe, not a full preset load, so
-    // it never pays for `loadStorybook`. Resolve against `target.cwd` the same way the
-    // config-loading branch below does — a relative `configDir` must not be probed against this
-    // process's cwd when `--cwd` points the run at a different project.
-    const probed: ProjectInfoResult = await deps.getProjectInfo({
-      configDir: resolveStorybookConfigDir(input.target),
-    });
-    if (!probed.ok) {
-      return { output: '', errorOutput: probed.message, exitCode: 1, kind: 'get', skill: id };
-    }
-    const { markdown } = await deps.getSetupMarkdown(probed.projectInfo);
-    return { output: markdown, exitCode: 0, kind: 'get', skill: id };
+    const setup = await serveSetup(input.target, deps);
+    return setup.ok
+      ? { output: setup.markdown, exitCode: 0, kind: 'get', skill: id }
+      : failure(setup.message, id);
   }
+  const loaded = await loadInputs(input.target, deps);
+  return loaded.ok
+    ? { output: assemble(id, loaded.inputs), exitCode: 0, kind: 'get', skill: id }
+    : failure(loaded.message, id);
+}
 
-  const configDir = resolveStorybookConfigDir(input.target);
-  let inputs: SkillInputs;
+function failure(message: string, skill?: SkillId | 'all'): SkillsRunResult {
+  return { output: '', errorOutput: message, exitCode: 1, kind: 'get', skill };
+}
+
+// The setup skill only needs the lightweight project-info probe, not a full preset load, so it
+// never pays for `loadStorybook`. Resolve against `target.cwd` the same way `loadInputs` does — a
+// relative `configDir` must not be probed against this process's cwd when `--cwd` points the run
+// at a different project.
+async function serveSetup(
+  target: SkillsTarget,
+  deps: SkillsRunDeps
+): Promise<{ ok: true; markdown: string } | { ok: false; message: string }> {
+  const probed: ProjectInfoResult = await deps.getProjectInfo({
+    configDir: resolveStorybookConfigDir(target),
+  });
+  if (!probed.ok) {
+    return { ok: false, message: probed.message };
+  }
+  const { markdown } = await deps.getSetupMarkdown(probed.projectInfo);
+  return { ok: true, markdown };
+}
+
+async function loadInputs(
+  target: SkillsTarget,
+  deps: SkillsRunDeps
+): Promise<{ ok: true; inputs: SkillInputs } | { ok: false; message: string }> {
   try {
-    const storybook = await deps.loadStorybook({ configDir });
-    inputs = await deps.resolveSkillInputs(storybook);
+    const storybook = await deps.loadStorybook({ configDir: resolveStorybookConfigDir(target) });
+    return { ok: true, inputs: await deps.resolveSkillInputs(storybook) };
   } catch (error) {
     // Reduce to one clean line, matching `cli/tools/run.ts`'s equivalent bootstrap failure: an
     // agent piping this output should not see a raw Node stack trace for an everyday "wrong
     // directory" mistake.
     return {
-      output: '',
-      errorOutput: `Could not load the Storybook configuration for this project: ${
+      ok: false,
+      message: `Could not load the Storybook configuration for this project: ${
         error instanceof Error ? error.message : String(error)
       }`,
-      exitCode: 1,
-      kind: 'get',
-      skill: id,
     };
   }
-  return { output: assemble(id, inputs), exitCode: 0, kind: 'get', skill: id };
 }
 
-function optionLines(): string[] {
-  const column = Math.max(...SKILLS_OPTION_SPECS.map((spec) => spec.flags.length)) + 2;
-  return SKILLS_OPTION_SPECS.map((spec) => `  ${spec.flags.padEnd(column)}${spec.description}`);
+function optionLines(specs: readonly SkillsOptionSpec[] = SKILLS_OPTION_SPECS): string[] {
+  const column = Math.max(...specs.map((spec) => spec.flags.length)) + 2;
+  return specs.map((spec) => `  ${spec.flags.padEnd(column)}${spec.description}`);
 }
 
 function skillLines(): string[] {
@@ -166,7 +191,8 @@ function renderCatalogHelp(): string {
     'Skills:',
     ...skillLines(),
     '',
-    'Print a skill with `npx storybook skills <id>`. `npx storybook skills <id> --help` shows one description.',
+    'Print a skill with `npx storybook skills <id>`, or every skill with `npx storybook skills --all`.',
+    '`npx storybook skills <id> --help` shows one description.',
   ].join('\n');
 }
 
@@ -179,7 +205,7 @@ function renderSkillHelp(id: SkillId): string {
     'Prints the full instructions as markdown.',
     '',
     'Options:',
-    ...optionLines(),
+    ...optionLines(SKILLS_OPTION_SPECS.filter((spec) => spec.flags !== '--all')),
   ].join('\n');
 }
 

--- a/code/core/src/cli/skills/run.ts
+++ b/code/core/src/cli/skills/run.ts
@@ -15,13 +15,8 @@ export const SKILLS_OPTION_SPECS = [
     description: 'Storybook config directory of the target Storybook',
   },
   { flags: '--all', description: 'Print every skill in full' },
-  {
-    flags: '-h, --help',
-    description: 'Show every skill, or one skill with its description',
-  },
+  { flags: '-h, --help', description: 'Show this usage and every skill' },
 ] as const;
-
-type SkillsOptionSpec = (typeof SKILLS_OPTION_SPECS)[number];
 
 export type SkillsRunInput = {
   tokens: string[];
@@ -57,7 +52,6 @@ export type SkillsRunDeps = {
 
 export type SkillsIntent =
   | { kind: 'catalog' }
-  | { kind: 'skill-help'; id: SkillId }
   | { kind: 'get'; id: SkillId }
   | { kind: 'all' }
   | { kind: 'invalid'; tokens: string[] }
@@ -68,8 +62,11 @@ export function resolveSkillsIntent(
   { help = false, all = false }: { help?: boolean; all?: boolean } = {}
 ): SkillsIntent {
   const [id, ...rest] = tokens;
+  if (help) {
+    return { kind: 'catalog' };
+  }
   if (id === undefined) {
-    return all && !help ? { kind: 'all' } : { kind: 'catalog' };
+    return all ? { kind: 'all' } : { kind: 'catalog' };
   }
   if (!isSkillId(id)) {
     return { kind: 'unknown', id };
@@ -77,7 +74,7 @@ export function resolveSkillsIntent(
   if (rest.length > 0 || all) {
     return { kind: 'invalid', tokens };
   }
-  return help ? { kind: 'skill-help', id } : { kind: 'get', id };
+  return { kind: 'get', id };
 }
 
 export async function runSkillsCommand(
@@ -87,9 +84,6 @@ export async function runSkillsCommand(
   const intent = resolveSkillsIntent(input.tokens, input);
   if (intent.kind === 'catalog') {
     return { output: renderCatalogHelp(), exitCode: 0, kind: 'help' };
-  }
-  if (intent.kind === 'skill-help') {
-    return { output: renderSkillHelp(intent.id), exitCode: 0, kind: 'help', skill: intent.id };
   }
   if (intent.kind === 'invalid') {
     return failure(
@@ -169,9 +163,9 @@ async function loadInputs(
   }
 }
 
-function optionLines(specs: readonly SkillsOptionSpec[] = SKILLS_OPTION_SPECS): string[] {
-  const column = Math.max(...specs.map((spec) => spec.flags.length)) + 2;
-  return specs.map((spec) => `  ${spec.flags.padEnd(column)}${spec.description}`);
+function optionLines(): string[] {
+  const column = Math.max(...SKILLS_OPTION_SPECS.map((spec) => spec.flags.length)) + 2;
+  return SKILLS_OPTION_SPECS.map((spec) => `  ${spec.flags.padEnd(column)}${spec.description}`);
 }
 
 function skillLines(): string[] {
@@ -192,20 +186,6 @@ function renderCatalogHelp(): string {
     ...skillLines(),
     '',
     'Print a skill with `npx storybook skills <id>`, or every skill with `npx storybook skills --all`.',
-    '`npx storybook skills <id> --help` shows one description.',
-  ].join('\n');
-}
-
-function renderSkillHelp(id: SkillId): string {
-  return [
-    `Usage: npx storybook skills ${id} [options]`,
-    '',
-    SKILLS[id].blurb,
-    '',
-    'Prints the full instructions as markdown.',
-    '',
-    'Options:',
-    ...optionLines(SKILLS_OPTION_SPECS.filter((spec) => spec.flags !== '--all')),
   ].join('\n');
 }
 

--- a/code/core/src/cli/skills/run.ts
+++ b/code/core/src/cli/skills/run.ts
@@ -6,7 +6,7 @@ import { buildStoryInstructions } from './content/build-story-instructions.ts';
 import type { getSetupMarkdownOutput } from './content/setup-prompts/index.ts';
 import { SKILLS, SKILL_IDS, isSkillId, type SkillId } from './content/skills.ts';
 import type { SkillInputs, resolveSkillInputs } from './inputs.ts';
-import type { ProjectInfoResult, getProjectInfo } from './project-info.ts';
+import type { getProjectInfo } from './project-info.ts';
 
 export const SKILLS_OPTION_SPECS = [
   { flags: '--cwd <path>', description: 'Project directory of the target Storybook' },
@@ -22,18 +22,13 @@ export type SkillsRunInput = {
   tokens: string[];
   help?: boolean;
   all?: boolean;
-  target: SkillsTarget;
+  target: { cwd?: string; configDir?: string };
 };
-
-type SkillsTarget = { cwd?: string; configDir?: string };
-
-export type SkillsRunKind = 'help' | 'get';
 
 export type SkillsRunResult = {
   output: string;
   errorOutput?: string;
   exitCode: number;
-  kind: SkillsRunKind;
   // For telemetry: which skill was served (or `all`), when the run got that far.
   skill?: SkillId | 'all';
 };
@@ -52,10 +47,9 @@ export type SkillsRunDeps = {
 
 export type SkillsIntent =
   | { kind: 'catalog' }
-  | { kind: 'get'; id: SkillId }
   | { kind: 'all' }
-  | { kind: 'invalid'; tokens: string[] }
-  | { kind: 'unknown'; id: string };
+  | { kind: 'get'; id: SkillId }
+  | { kind: 'error'; message: string };
 
 export function resolveSkillsIntent({
   tokens,
@@ -70,10 +64,22 @@ export function resolveSkillsIntent({
     return all ? { kind: 'all' } : { kind: 'catalog' };
   }
   if (!isSkillId(id)) {
-    return { kind: 'unknown', id };
+    return {
+      kind: 'error',
+      message: `Unknown skill "${id}". Available skills: ${SKILL_IDS.join(', ')}.`,
+    };
   }
-  if (rest.length > 0 || all) {
-    return { kind: 'invalid', tokens };
+  if (all) {
+    return {
+      kind: 'error',
+      message: `\`--all\` prints every skill and takes no skill id; drop "${id}" or \`--all\`.`,
+    };
+  }
+  if (rest.length > 0) {
+    return {
+      kind: 'error',
+      message: `Unexpected arguments: ${rest.map((token) => `"${token}"`).join(' ')}. Run \`npx storybook skills --help\` for usage.`,
+    };
   }
   return { kind: 'get', id };
 }
@@ -84,94 +90,74 @@ export async function runSkillsCommand(
 ): Promise<SkillsRunResult> {
   const intent = resolveSkillsIntent(input);
   if (intent.kind === 'catalog') {
-    return { output: renderCatalogHelp(), exitCode: 0, kind: 'help' };
+    return { output: renderCatalogHelp(), exitCode: 0 };
   }
-  if (intent.kind === 'invalid') {
-    return failure(
-      `Unexpected arguments: ${intent.tokens.map((token) => `"${token}"`).join(' ')}. Run \`npx storybook skills --help\` for usage.`
-    );
+  if (intent.kind === 'error') {
+    return { output: '', errorOutput: intent.message, exitCode: 1 };
   }
-  if (intent.kind === 'unknown') {
-    return failure(`Unknown skill "${intent.id}". Available skills: ${SKILL_IDS.join(', ')}.`);
-  }
-  if (intent.kind === 'all') {
-    const setup = await serveSetup(input.target, deps);
-    if (!setup.ok) {
-      return failure(setup.message);
-    }
-    const loaded = await loadInputs(input.target, deps);
-    if (!loaded.ok) {
-      return failure(loaded.message);
-    }
-    const output = SKILL_IDS.map((id) =>
-      id === 'setup' ? setup.markdown : assemble(id, loaded.inputs)
-    ).join('\n\n---\n\n');
-    return { output, exitCode: 0, kind: 'get', skill: 'all' };
-  }
-
-  const { id } = intent;
-  if (id === 'setup') {
-    const setup = await serveSetup(input.target, deps);
-    return setup.ok
-      ? { output: setup.markdown, exitCode: 0, kind: 'get', skill: id }
-      : failure(setup.message);
-  }
-  const loaded = await loadInputs(input.target, deps);
-  return loaded.ok
-    ? { output: assemble(id, loaded.inputs), exitCode: 0, kind: 'get', skill: id }
-    : failure(loaded.message);
-}
-
-function failure(message: string): SkillsRunResult {
-  return { output: '', errorOutput: message, exitCode: 1, kind: 'get' };
-}
-
-// The setup skill only needs the lightweight project-info probe, not a full preset load, so it
-// never pays for `loadStorybook`. Resolve against `target.cwd` the same way `loadInputs` does — a
-// relative `configDir` must not be probed against this process's cwd when `--cwd` points the run
-// at a different project.
-async function serveSetup(
-  target: SkillsTarget,
-  deps: SkillsRunDeps
-): Promise<{ ok: true; markdown: string } | { ok: false; message: string }> {
-  const probed: ProjectInfoResult = await deps.getProjectInfo({
-    configDir: resolveStorybookConfigDir(target),
-  });
-  if (!probed.ok) {
-    return { ok: false, message: probed.message };
-  }
-  const { markdown } = await deps.getSetupMarkdown(probed.projectInfo);
-  return { ok: true, markdown };
-}
-
-async function loadInputs(
-  target: SkillsTarget,
-  deps: SkillsRunDeps
-): Promise<{ ok: true; inputs: SkillInputs } | { ok: false; message: string }> {
   try {
-    const storybook = await deps.loadStorybook({ configDir: resolveStorybookConfigDir(target) });
-    return { ok: true, inputs: await deps.resolveSkillInputs(storybook) };
+    const ids = intent.kind === 'all' ? SKILL_IDS : [intent.id];
+    const docs = await serveSkills(ids, resolveStorybookConfigDir(input.target), deps);
+    return {
+      output: docs.join('\n\n---\n\n'),
+      exitCode: 0,
+      skill: intent.kind === 'all' ? 'all' : intent.id,
+    };
+  } catch (error) {
+    if (error instanceof SkillsError) {
+      return { output: '', errorOutput: error.message, exitCode: 1 };
+    }
+    throw error;
+  }
+}
+
+// An expected failure: its message is printed to stderr with exit code 1, without a stack trace.
+class SkillsError extends Error {}
+
+async function serveSkills(
+  ids: readonly SkillId[],
+  configDir: string,
+  deps: SkillsRunDeps
+): Promise<string[]> {
+  let inputs: SkillInputs | undefined;
+  const docs: string[] = [];
+  for (const id of ids) {
+    if (id === 'setup') {
+      docs.push(await serveSetup(configDir, deps));
+    } else {
+      inputs ??= await loadInputs(configDir, deps);
+      docs.push(assemble(id, inputs));
+    }
+  }
+  return docs;
+}
+
+async function serveSetup(configDir: string, deps: SkillsRunDeps): Promise<string> {
+  const probed = await deps.getProjectInfo({ configDir });
+  if (!probed.ok) {
+    throw new SkillsError(probed.message);
+  }
+  return (await deps.getSetupMarkdown(probed.projectInfo)).markdown;
+}
+
+async function loadInputs(configDir: string, deps: SkillsRunDeps): Promise<SkillInputs> {
+  try {
+    return await deps.resolveSkillInputs(await deps.loadStorybook({ configDir }));
   } catch (error) {
     // Reduce to one clean line, matching `cli/tools/run.ts`'s equivalent bootstrap failure: an
     // agent piping this output should not see a raw Node stack trace for an everyday "wrong
     // directory" mistake.
-    return {
-      ok: false,
-      message: `Could not load the Storybook configuration for this project: ${
+    throw new SkillsError(
+      `Could not load the Storybook configuration for this project: ${
         error instanceof Error ? error.message : String(error)
-      }`,
-    };
+      }`
+    );
   }
 }
 
-function optionLines(): string[] {
-  const column = Math.max(...SKILLS_OPTION_SPECS.map((spec) => spec.flags.length)) + 2;
-  return SKILLS_OPTION_SPECS.map((spec) => `  ${spec.flags.padEnd(column)}${spec.description}`);
-}
-
-function skillLines(): string[] {
-  const column = Math.max(...SKILL_IDS.map((id) => id.length)) + 2;
-  return SKILL_IDS.map((id) => `  ${id.padEnd(column)}${SKILLS[id].blurb}`);
+function table(rows: [string, string][]): string[] {
+  const column = Math.max(...rows.map(([key]) => key.length)) + 2;
+  return rows.map(([key, text]) => `  ${key.padEnd(column)}${text}`);
 }
 
 function renderCatalogHelp(): string {
@@ -181,10 +167,10 @@ function renderCatalogHelp(): string {
     'Agent skills served by this Storybook.',
     '',
     'Options:',
-    ...optionLines(),
+    ...table(SKILLS_OPTION_SPECS.map((spec) => [spec.flags, spec.description])),
     '',
     'Skills:',
-    ...skillLines(),
+    ...table(SKILL_IDS.map((id) => [id, SKILLS[id].blurb])),
     '',
     'Print a skill with `npx storybook skills <id>`, or every skill with `npx storybook skills --all`.',
   ].join('\n');

--- a/code/core/src/cli/skills/run.ts
+++ b/code/core/src/cli/skills/run.ts
@@ -34,7 +34,7 @@ export type SkillsRunResult = {
   errorOutput?: string;
   exitCode: number;
   kind: SkillsRunKind;
-  /** For telemetry: which skill was served (or `all`), when the run got that far. */
+  // For telemetry: which skill was served (or `all`), when the run got that far.
   skill?: SkillId | 'all';
 };
 
@@ -57,10 +57,11 @@ export type SkillsIntent =
   | { kind: 'invalid'; tokens: string[] }
   | { kind: 'unknown'; id: string };
 
-export function resolveSkillsIntent(
-  tokens: string[],
-  { help = false, all = false }: { help?: boolean; all?: boolean } = {}
-): SkillsIntent {
+export function resolveSkillsIntent({
+  tokens,
+  help,
+  all,
+}: Pick<SkillsRunInput, 'tokens' | 'help' | 'all'>): SkillsIntent {
   const [id, ...rest] = tokens;
   if (help) {
     return { kind: 'catalog' };
@@ -81,7 +82,7 @@ export async function runSkillsCommand(
   input: SkillsRunInput,
   deps: SkillsRunDeps
 ): Promise<SkillsRunResult> {
-  const intent = resolveSkillsIntent(input.tokens, input);
+  const intent = resolveSkillsIntent(input);
   if (intent.kind === 'catalog') {
     return { output: renderCatalogHelp(), exitCode: 0, kind: 'help' };
   }
@@ -96,11 +97,11 @@ export async function runSkillsCommand(
   if (intent.kind === 'all') {
     const setup = await serveSetup(input.target, deps);
     if (!setup.ok) {
-      return failure(setup.message, 'all');
+      return failure(setup.message);
     }
     const loaded = await loadInputs(input.target, deps);
     if (!loaded.ok) {
-      return failure(loaded.message, 'all');
+      return failure(loaded.message);
     }
     const output = SKILL_IDS.map((id) =>
       id === 'setup' ? setup.markdown : assemble(id, loaded.inputs)
@@ -113,16 +114,16 @@ export async function runSkillsCommand(
     const setup = await serveSetup(input.target, deps);
     return setup.ok
       ? { output: setup.markdown, exitCode: 0, kind: 'get', skill: id }
-      : failure(setup.message, id);
+      : failure(setup.message);
   }
   const loaded = await loadInputs(input.target, deps);
   return loaded.ok
     ? { output: assemble(id, loaded.inputs), exitCode: 0, kind: 'get', skill: id }
-    : failure(loaded.message, id);
+    : failure(loaded.message);
 }
 
-function failure(message: string, skill?: SkillId | 'all'): SkillsRunResult {
-  return { output: '', errorOutput: message, exitCode: 1, kind: 'get', skill };
+function failure(message: string): SkillsRunResult {
+  return { output: '', errorOutput: message, exitCode: 1, kind: 'get' };
 }
 
 // The setup skill only needs the lightweight project-info probe, not a full preset load, so it

--- a/code/lib/claude-plugin/skills/stories/SKILL.md
+++ b/code/lib/claude-plugin/skills/stories/SKILL.md
@@ -13,7 +13,7 @@ Run the Storybook dev server and every Storybook CLI command from the same worki
 
 For docs, props, or usage questions, use `npx storybook tools docs list` followed by `npx storybook tools docs show` before inspecting source files. Fall back to source inspection only when the documentation commands are unavailable or return no relevant documentation.
 
-Run `npx storybook skills get stories` and read the output in its **entirety** to get the **mandatory, ordered workflow** for working on UI changes, writing stories, and keeping stories in sync with every frontend component you create, modify, or delete. This workflow explains how to write stories, preview stories, and display a curated Storybook review.
+Run `npx storybook skills stories` and read the output in its **entirety** to get the **mandatory, ordered workflow** for working on UI changes, writing stories, and keeping stories in sync with every frontend component you create, modify, or delete. This workflow explains how to write stories, preview stories, and display a curated Storybook review.
 
 Before invoking any `npx storybook tools` command for the first time in a session, run it with `--help` appended and read the output fully. The workflow only names the commands; each command's argument shape and usage rules (which fields to include when) live in its own help output. Never guess a command's arguments from its name — a validation error only reports missing required fields, not the optional fields the workflow expects you to provide.
 

--- a/code/lib/claude-plugin/skills/storybook-setup/SKILL.md
+++ b/code/lib/claude-plugin/skills/storybook-setup/SKILL.md
@@ -8,6 +8,6 @@ Prerequisites:
 1. Confirm Storybook exists (`package.json`, `.storybook/`). If not, switch to `/storybook-init`.
 2. Storybook must be at least 10.6. (While 10.6 is unreleased, `next` satisfies this — 10.6.0-alpha.x. Any canary build, `0.0.0-pr-*`, also qualifies.) If it is older, or upgrade/repair is needed first, switch to `/storybook-upgrade`, but only if the user explicitly approved a Storybook upgrade.
 
-Run `npx storybook skills get setup` from the project root (or the Storybook package in a monorepo).
+Run `npx storybook skills setup` from the project root (or the Storybook package in a monorepo).
 
 **Follow the printed Markdown precisely.** Do not substitute your own plan.

--- a/code/lib/codex-plugin/plugins/storybook/skills/setup/SKILL.md
+++ b/code/lib/codex-plugin/plugins/storybook/skills/setup/SKILL.md
@@ -8,6 +8,6 @@ Prerequisites:
 1. Confirm Storybook exists (`package.json`, `.storybook/`). If not, switch to `$storybook:init`.
 2. Storybook must be at least 10.6. (While 10.6 is unreleased, `next` satisfies this — 10.6.0-alpha.x. Any canary build, `0.0.0-pr-*`, also qualifies.) If it is older, or upgrade/repair is needed first, switch to `$storybook:upgrade`, but only if the user explicitly approved a Storybook upgrade.
 
-Run `npx storybook skills get setup` from the project root (or the Storybook package in a monorepo).
+Run `npx storybook skills setup` from the project root (or the Storybook package in a monorepo).
 
 **Follow the printed Markdown precisely.** Do not substitute your own plan.

--- a/code/lib/codex-plugin/plugins/storybook/skills/stories/SKILL.md
+++ b/code/lib/codex-plugin/plugins/storybook/skills/stories/SKILL.md
@@ -15,7 +15,7 @@ Run the Storybook dev server and every Storybook CLI command from the same worki
 
 For docs, props, or usage questions, use `npx storybook tools docs list` followed by `npx storybook tools docs show` before inspecting source files. Fall back to source inspection only when the documentation commands are unavailable or return no relevant documentation.
 
-Run `npx storybook skills get stories` and read the output in its **entirety** to get the **mandatory, ordered workflow** for working on UI changes, writing stories, and keeping stories in sync with every frontend component you create, modify, or delete. This workflow explains how to write stories, preview stories, and display a curated Storybook review.
+Run `npx storybook skills stories` and read the output in its **entirety** to get the **mandatory, ordered workflow** for working on UI changes, writing stories, and keeping stories in sync with every frontend component you create, modify, or delete. This workflow explains how to write stories, preview stories, and display a curated Storybook review.
 
 Before invoking any `npx storybook tools` command for the first time in a session, run it with `--help` appended and read the output fully. The workflow only names the commands; each command's argument shape and usage rules (which fields to include when) live in its own help output. Never guess a command's arguments from its name — a validation error only reports missing required fields, not the optional fields the workflow expects you to provide.
 

--- a/code/lib/create-storybook/src/commands/FinalizationCommand.test.ts
+++ b/code/lib/create-storybook/src/commands/FinalizationCommand.test.ts
@@ -22,7 +22,7 @@ describe('FinalizationCommand', () => {
       logfile: undefined,
       showAgentFollowUp: false,
       showAiInstructions: false,
-      setupSkillCommand: 'npx storybook skills get setup',
+      setupSkillCommand: 'npx storybook skills setup',
     });
 
     vi.mocked(getProjectRoot).mockReturnValue('/test/project');
@@ -119,7 +119,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: true,
         showAiInstructions: true,
-        setupSkillCommand: 'pnpm exec storybook skills get setup',
+        setupSkillCommand: 'pnpm exec storybook skills setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -129,7 +129,7 @@ describe('FinalizationCommand', () => {
         expect.stringContaining('is not entirely set up yet')
       );
       expect(logger.step).toHaveBeenCalledWith(
-        expect.stringContaining('pnpm exec storybook skills get setup')
+        expect.stringContaining('pnpm exec storybook skills setup')
       );
       const logCalls = vi.mocked(logger.log).mock.calls.map((c) => String(c[0]));
       expect(logCalls.some((msg) => msg.includes('https://storybook.js.org/llms.txt'))).toBe(true);
@@ -141,7 +141,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: true,
-        setupSkillCommand: 'npx storybook skills get setup',
+        setupSkillCommand: 'npx storybook skills setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -160,7 +160,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: false,
-        setupSkillCommand: 'npx storybook skills get setup',
+        setupSkillCommand: 'npx storybook skills setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -185,7 +185,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: true,
-        setupSkillCommand: 'npx storybook skills get setup',
+        setupSkillCommand: 'npx storybook skills setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -195,7 +195,7 @@ describe('FinalizationCommand', () => {
         expect.stringContaining('To finalize setting up with AI')
       );
       expect(logger.step).toHaveBeenCalledWith(
-        expect.stringContaining('npx storybook skills get setup')
+        expect.stringContaining('npx storybook skills setup')
       );
     });
 
@@ -204,7 +204,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: false,
-        setupSkillCommand: 'npx storybook skills get setup',
+        setupSkillCommand: 'npx storybook skills setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -219,7 +219,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: true,
         showAiInstructions: true,
-        setupSkillCommand: 'npx storybook skills get setup',
+        setupSkillCommand: 'npx storybook skills setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -240,7 +240,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: false,
-        setupSkillCommand: 'npx storybook skills get setup',
+        setupSkillCommand: 'npx storybook skills setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -255,7 +255,7 @@ describe('FinalizationCommand', () => {
         logfile: undefined,
         showAgentFollowUp: false,
         showAiInstructions: false,
-        setupSkillCommand: 'npx storybook skills get setup',
+        setupSkillCommand: 'npx storybook skills setup',
       });
       vi.mocked(find.up).mockReturnValue(undefined);
 
@@ -274,7 +274,7 @@ describe('FinalizationCommand', () => {
         showAgentFollowUp: true,
         showAiInstructions: false,
         logfile: undefined,
-        setupSkillCommand: 'npx storybook skills get setup',
+        setupSkillCommand: 'npx storybook skills setup',
       });
 
       // Agent mode should show agent-specific message
@@ -290,7 +290,7 @@ describe('FinalizationCommand', () => {
         showAgentFollowUp: false,
         showAiInstructions: true,
         logfile: undefined,
-        setupSkillCommand: 'npx storybook skills get setup',
+        setupSkillCommand: 'npx storybook skills setup',
       });
 
       expect(logger.step).toHaveBeenCalledWith(
@@ -306,7 +306,7 @@ describe('FinalizationCommand', () => {
         showAiInstructions: false,
         logfile: undefined,
         storybookCommand: 'yarn storybook',
-        setupSkillCommand: 'npx storybook skills get setup',
+        setupSkillCommand: 'npx storybook skills setup',
       });
 
       expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('yarn storybook'));

--- a/code/lib/create-storybook/src/commands/FinalizationCommand.ts
+++ b/code/lib/create-storybook/src/commands/FinalizationCommand.ts
@@ -13,7 +13,7 @@ export type FinalizationCommandOptions = {
   showAgentFollowUp: boolean;
   /** When true, show the "paste this prompt to your AI agent" instructions */
   showAiInstructions: boolean;
-  /** Package-manager-aware `storybook skills get setup` command shown to agents */
+  /** Package-manager-aware `storybook skills setup` command shown to agents */
   setupSkillCommand: string;
 };
 

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -190,7 +190,7 @@ export async function doInitiate(options: CommandOptions): Promise<
     showAiInstructions: hasAiFeature,
     logfile: options.logfile,
     storybookCommand,
-    setupSkillCommand: packageManager.getPackageCommand(['storybook', 'skills', 'get', 'setup']),
+    setupSkillCommand: packageManager.getPackageCommand(['storybook', 'skills', 'setup']),
   });
 
   // Step 9: Track telemetry (pass configDir so RN `.rnstorybook` metadata is resolved)

--- a/code/lib/create-storybook/src/services/FeatureCompatibilityService.ts
+++ b/code/lib/create-storybook/src/services/FeatureCompatibilityService.ts
@@ -33,7 +33,7 @@ export class FeatureCompatibilityService {
     );
   }
 
-  /** Check if AI-assisted setup (storybook skills get setup) is supported for this project configuration */
+  /** Check if AI-assisted setup (storybook skills setup) is supported for this project configuration */
   static supportsAISetupFeature(
     renderer: SupportedRenderer,
     builder: SupportedBuilder,


### PR DESCRIPTION
Closes #

## What I did

Follow-up to #36121, which added `storybook skills <id>` but kept `skills get <id>` and `skills list` as accepted spellings, and left the plugins and other agent-facing text pointing at `skills get`. This lands the shape we agreed on in Slack so agents only ever see one way to fetch a skill:

| Command | Behavior |
| --- | --- |
| `storybook skills` | Usage plus every skill with its blurb |
| `storybook skills --help` | Same as above |
| `storybook skills <id>` | Print one skill in full |
| `storybook skills --all` | Print every skill in full (config is loaded once) |
| ~~`storybook skills get <id>`~~ | Removed: exits 1 with `Unknown skill "get"` |
| ~~`storybook skills list`~~ | Removed: exits 1 with `Unknown skill "list"` |
| ~~`storybook skills help`~~ | Never a subcommand; unchanged |
| ~~`storybook skills <id> --help`~~ | Removed: `--help` now always prints the catalog, so there is exactly one help view |

Every reference to the old spellings is updated: the Claude and Codex plugin `SKILL.md` files, the `getSkillRef` cross-references rendered inside the skills themselves, the `storybook init` outro (`setupSkillCommand`), the `storybook ai setup` deprecation notices, and the agent-eval shell parser. The parser now records `skills <id>` invocations, credits a bare `skills --all` as a write-story instructions fetch, and ignores `--all` combined with a skill id in either order since the CLI rejects those. Prerelease changelog entries are left as-is, and the `skills-get` telemetry event keeps its name (`--all` reports `skill: 'all'`).

Internally, `cli/skills/run.ts` now serves `<id>` and `--all` through one path: `serveSkills` takes a list of ids, probes project info for `setup`, and loads the Storybook config once for the rest. Expected failures (unknown skill, bad arguments, config that cannot be loaded, setup probe failure) are one `SkillsError` caught in a single place and printed as a one-line message with exit code 1; anything else still propagates to the CLI failure handler. The intent resolver carries the error message itself, so `--all` combined with an id gets its own message instead of a generic one.

Not in scope, per the same thread: reshaping `storybook tools` output is deferred to the next SC.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

From `code/` in this checkout after `yarn nx compile core`:

1. `node core/dist/bin/dispatcher.js skills` prints usage, the `--all` option, and the three skills with blurbs. `skills --help` prints the same.
2. `node core/dist/bin/dispatcher.js skills stories` prints the stories skill; `skills setup` and `skills write-story` likewise.
3. `node core/dist/bin/dispatcher.js skills --all` prints all three skills separated by `---`.
4. `node core/dist/bin/dispatcher.js skills get stories` and `skills list` exit 1 with an "Unknown skill" message naming the valid ids.
5. `node core/dist/bin/dispatcher.js skills stories --all` exits 1 saying `--all` takes no skill id; `skills stories typo` exits 1 with an "Unexpected arguments" message.
6. `node core/dist/bin/dispatcher.js skills stories --help` prints the same catalog as `skills --help`, without loading config.
7. Check that `skills stories` output references `npx storybook skills write-story` (not `skills get`).

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No docs page covers the `skills` CLI yet, and `skills get`/`skills list` only ever shipped in 10.6 prereleases, so no MIGRATION entry.

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
