### PR TITLE
Docs: Nest setConfig layout and UI options for Storybook 11

### DIFF
--- a/docs/_snippets/storybook-config-layout.md
+++ b/docs/_snippets/storybook-config-layout.md
@@ -2,15 +2,19 @@
 import { addons } from 'storybook/manager-api';
 
 addons.setConfig({
-  navSize: 300,
-  bottomPanelHeight: 300,
-  rightPanelWidth: 300,
-  panelPosition: 'bottom',
-  enableShortcuts: true,
-  showToolbar: true,
+  layout: {
+    navSize: 300,
+    bottomPanelHeight: 300,
+    rightPanelWidth: 300,
+    panelPosition: 'bottom',
+    showToolbar: true,
+    initialActive: 'sidebar',
+  },
+  ui: {
+    enableShortcuts: true,
+  },
   theme: undefined,
   selectedPanel: undefined,
-  initialActive: 'sidebar',
   layoutCustomisations: {
     showSidebar(state, defaultValue) {
       return state.storyId === 'landing' ? false : defaultValue;
@@ -37,15 +41,19 @@ addons.setConfig({
 import { addons, type State } from 'storybook/manager-api';
 
 addons.setConfig({
-  navSize: 300,
-  bottomPanelHeight: 300,
-  rightPanelWidth: 300,
-  panelPosition: 'bottom',
-  enableShortcuts: true,
-  showToolbar: true,
+  layout: {
+    navSize: 300,
+    bottomPanelHeight: 300,
+    rightPanelWidth: 300,
+    panelPosition: 'bottom',
+    showToolbar: true,
+    initialActive: 'sidebar',
+  },
+  ui: {
+    enableShortcuts: true,
+  },
   theme: undefined,
   selectedPanel: undefined,
-  initialActive: 'sidebar',
   layoutCustomisations: {
     showSidebar(state: State, defaultValue: boolean) {
       return state.storyId === 'landing' ? false : defaultValue;

--- a/docs/addons/addons-api.mdx
+++ b/docs/addons/addons-api.mdx
@@ -175,14 +175,15 @@ This method allows you to override the default Storybook UI configuration (e.g.,
 
 The following table details how to use the API values:
 
-| Name              | Type   | Description                                        | Example Value                       |
-| ----------------- | ------ | -------------------------------------------------- | ----------------------------------- |
-| **layout**        | Object | Layout options, see below                          | `{ navSize: 300 }`                  |
-| **ui**            | Object | UI options, see below                              | `{ enableShortcuts: true }`         |
-| **theme**         | Object | Storybook Theme, see next section                  | `undefined`                         |
-| **selectedPanel** | String | Id to select an addon panel                        | `storybook/actions/panel`           |
-| **sidebar**       | Object | Sidebar options, see below                         | `{ showRoots: false }`              |
-| **toolbar**       | Object | Modify the tools in the toolbar using the addon id | `{ fullscreen: { hidden: false } }` |
+| Name                     | Type   | Description                                                                                                                           | Example Value                                                                                 |
+| ------------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| **layout**               | Object | Layout options, see below                                                                                                             | `{ navSize: 300 }`                                                                            |
+| **ui**                   | Object | UI options, see below                                                                                                                 | `{ enableShortcuts: true }`                                                                   |
+| **theme**                | Object | Storybook Theme, see next section                                                                                                     | `undefined`                                                                                   |
+| **selectedPanel**        | String | Id to select an addon panel                                                                                                           | `storybook/actions/panel`                                                                     |
+| **layoutCustomisations** | Object | Functions that show or hide UI elements per story, see [Features and behavior](../configure/user-interface/features-and-behavior.mdx) | `{ showSidebar: ({ viewMode }, defaultValue) => viewMode === 'docs' ? false : defaultValue }` |
+| **sidebar**              | Object | Sidebar options, see below                                                                                                            | `{ showRoots: false }`                                                                        |
+| **toolbar**              | Object | Modify the tools in the toolbar using the addon id                                                                                    | `{ fullscreen: { hidden: false } }`                                                           |
 
 The following options are configurable under the `layout` namespace:
 

--- a/docs/addons/addons-api.mdx
+++ b/docs/addons/addons-api.mdx
@@ -175,19 +175,39 @@ This method allows you to override the default Storybook UI configuration (e.g.,
 
 The following table details how to use the API values:
 
-| Name                  | Type            | Description                                             | Example Value                       |
-| --------------------- | --------------- | ------------------------------------------------------- | ----------------------------------- |
-| **navSize**           | Number (pixels) | The size of the sidebar that shows a list of stories    | `300`                               |
-| **bottomPanelHeight** | Number (pixels) | The size of the addon panel when in the bottom position | `200`                               |
-| **rightPanelWidth**   | Number (pixels) | The size of the addon panel when in the right position  | `200`                               |
-| **panelPosition**     | String          | Where to show the addon panel                           | `'bottom'` or `'right'`             |
-| **enableShortcuts**   | Boolean         | Enable/disable shortcuts                                | `true`                              |
-| **showToolbar**       | Boolean         | Show/hide toolbar                                       | `true`                              |
-| **theme**             | Object          | Storybook Theme, see next section                       | `undefined`                         |
-| **selectedPanel**     | String          | Id to select an addon panel                             | `storybook/actions/panel`           |
-| **initialActive**     | String          | Select the default active tab on Mobile                 | `sidebar` or `canvas` or `addons`   |
-| **sidebar**           | Object          | Sidebar options, see below                              | `{ showRoots: false }`              |
-| **toolbar**           | Object          | Modify the tools in the toolbar using the addon id      | `{ fullscreen: { hidden: false } }` |
+| Name              | Type   | Description                                        | Example Value                       |
+| ----------------- | ------ | -------------------------------------------------- | ----------------------------------- |
+| **layout**        | Object | Layout options, see below                          | `{ navSize: 300 }`                  |
+| **ui**            | Object | UI options, see below                              | `{ enableShortcuts: true }`         |
+| **theme**         | Object | Storybook Theme, see next section                  | `undefined`                         |
+| **selectedPanel** | String | Id to select an addon panel                        | `storybook/actions/panel`           |
+| **sidebar**       | Object | Sidebar options, see below                         | `{ showRoots: false }`              |
+| **toolbar**       | Object | Modify the tools in the toolbar using the addon id | `{ fullscreen: { hidden: false } }` |
+
+The following options are configurable under the `layout` namespace:
+
+| Name                  | Type            | Description                                             | Example Value                     |
+| --------------------- | --------------- | ------------------------------------------------------- | --------------------------------- |
+| **navSize**           | Number (pixels) | The size of the sidebar that shows a list of stories    | `300`                             |
+| **bottomPanelHeight** | Number (pixels) | The size of the addon panel when in the bottom position | `200`                             |
+| **rightPanelWidth**   | Number (pixels) | The size of the addon panel when in the right position  | `200`                             |
+| **panelPosition**     | String          | Where to show the addon panel                           | `'bottom'` or `'right'`           |
+| **showNav**           | Boolean         | Show/hide the sidebar                                   | `true`                            |
+| **showPanel**         | Boolean         | Show/hide the addon panel                               | `true`                            |
+| **showToolbar**       | Boolean         | Show/hide toolbar                                       | `true`                            |
+| **initialActive**     | String          | Select the default active tab on Mobile                 | `sidebar` or `canvas` or `addons` |
+
+The following options are configurable under the `ui` namespace:
+
+| Name                | Type    | Description              | Example Value |
+| ------------------- | ------- | ------------------------ | ------------- |
+| **enableShortcuts** | Boolean | Enable/disable shortcuts | `true`        |
+
+<Callout variant="info">
+
+In Storybook 10 and earlier, the `layout` and `ui` options could also be passed at the top level of `setConfig`. That shape is removed in Storybook 11. Run `npx storybook automigrate set-config-layout` to move them into the correct namespace, and see the [migration guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#top-level-setconfig-layout-and-ui-options-removed) for details.
+
+</Callout>
 
 The following options are configurable under the `sidebar` namespace:
 

--- a/docs/configure/user-interface/features-and-behavior.mdx
+++ b/docs/configure/user-interface/features-and-behavior.mdx
@@ -10,20 +10,40 @@ To control the layout of Storybook’s UI you can use `addons.setConfig` in your
 
 The following table details how to use the API values:
 
-| Name                     | Type            | Description                                             | Example Value                                                                                  |
-| ------------------------ | --------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| **navSize**              | Number (pixels) | The size of the sidebar that shows a list of stories    | `300`                                                                                          |
-| **bottomPanelHeight**    | Number (pixels) | The size of the addon panel when in the bottom position | `200`                                                                                          |
-| **rightPanelWidth**      | Number (pixels) | The size of the addon panel when in the right position  | `200`                                                                                          |
-| **panelPosition**        | String          | Where to show the addon panel                           | `'bottom'` or `'right'`                                                                        |
-| **enableShortcuts**      | Boolean         | Enable/disable shortcuts                                | `true`                                                                                         |
-| **showToolbar**          | Boolean         | Show/hide tool bar                                      | `true`                                                                                         |
-| **theme**                | Object          | Storybook Theme, see next section                       | `undefined`                                                                                    |
-| **selectedPanel**        | String          | Id to select an addon panel                             | `'storybook/actions/panel'`                                                                    |
-| **initialActive**        | String          | Select the default active tab on Mobile                 | `'sidebar'` or `'canvas'` or `'addons'`                                                        |
-| **layoutCustomisations** | Object          | Layout customisation options, see below                 | `{ showSidebar: ({ viewMode }, defaultValue) => viewMode === 'docs' ? false : defaultValue` }` |
-| **sidebar**              | Object          | Sidebar options, see below                              | `{ showRoots: false }`                                                                         |
-| **toolbar**              | Object          | Modify the tools in the toolbar using the addon id      | `{ fullscreen: { hidden: false } } `                                                           |
+| Name                     | Type   | Description                                        | Example Value                                                                                  |
+| ------------------------ | ------ | -------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| **layout**               | Object | Layout options, see below                          | `{ navSize: 300 }`                                                                             |
+| **ui**                   | Object | UI options, see below                              | `{ enableShortcuts: true }`                                                                    |
+| **theme**                | Object | Storybook Theme, see next section                  | `undefined`                                                                                    |
+| **selectedPanel**        | String | Id to select an addon panel                        | `'storybook/actions/panel'`                                                                    |
+| **layoutCustomisations** | Object | Layout customisation options, see below            | `{ showSidebar: ({ viewMode }, defaultValue) => viewMode === 'docs' ? false : defaultValue` }` |
+| **sidebar**              | Object | Sidebar options, see below                         | `{ showRoots: false }`                                                                         |
+| **toolbar**              | Object | Modify the tools in the toolbar using the addon id | `{ fullscreen: { hidden: false } } `                                                           |
+
+The following options are configurable under the `layout` namespace:
+
+| Name                  | Type            | Description                                             | Example Value                           |
+| --------------------- | --------------- | ------------------------------------------------------- | --------------------------------------- |
+| **navSize**           | Number (pixels) | The size of the sidebar that shows a list of stories    | `300`                                   |
+| **bottomPanelHeight** | Number (pixels) | The size of the addon panel when in the bottom position | `200`                                   |
+| **rightPanelWidth**   | Number (pixels) | The size of the addon panel when in the right position  | `200`                                   |
+| **panelPosition**     | String          | Where to show the addon panel                           | `'bottom'` or `'right'`                 |
+| **showNav**           | Boolean         | Show/hide the sidebar                                   | `true`                                  |
+| **showPanel**         | Boolean         | Show/hide the addon panel                               | `true`                                  |
+| **showToolbar**       | Boolean         | Show/hide tool bar                                      | `true`                                  |
+| **initialActive**     | String          | Select the default active tab on Mobile                 | `'sidebar'` or `'canvas'` or `'addons'` |
+
+The following options are configurable under the `ui` namespace:
+
+| Name                | Type    | Description              | Example Value |
+| ------------------- | ------- | ------------------------ | ------------- |
+| **enableShortcuts** | Boolean | Enable/disable shortcuts | `true`        |
+
+<Callout variant="info">
+
+In Storybook 10 and earlier, the `layout` and `ui` options could also be passed at the top level of `setConfig`. That shape is removed in Storybook 11. Run `npx storybook automigrate set-config-layout` to move them into the correct namespace, and see the [migration guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#top-level-setconfig-layout-and-ui-options-removed) for details.
+
+</Callout>
 
 The following options are configurable under the `sidebar` namespace:
 

--- a/docs/configure/user-interface/features-and-behavior.mdx
+++ b/docs/configure/user-interface/features-and-behavior.mdx
@@ -10,15 +10,15 @@ To control the layout of Storybook’s UI you can use `addons.setConfig` in your
 
 The following table details how to use the API values:
 
-| Name                     | Type   | Description                                        | Example Value                                                                                  |
-| ------------------------ | ------ | -------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| **layout**               | Object | Layout options, see below                          | `{ navSize: 300 }`                                                                             |
-| **ui**                   | Object | UI options, see below                              | `{ enableShortcuts: true }`                                                                    |
-| **theme**                | Object | Storybook Theme, see next section                  | `undefined`                                                                                    |
-| **selectedPanel**        | String | Id to select an addon panel                        | `'storybook/actions/panel'`                                                                    |
+| Name                     | Type   | Description                                        | Example Value                                                                                 |
+| ------------------------ | ------ | -------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| **layout**               | Object | Layout options, see below                          | `{ navSize: 300 }`                                                                            |
+| **ui**                   | Object | UI options, see below                              | `{ enableShortcuts: true }`                                                                   |
+| **theme**                | Object | Storybook Theme, see next section                  | `undefined`                                                                                   |
+| **selectedPanel**        | String | Id to select an addon panel                        | `'storybook/actions/panel'`                                                                   |
 | **layoutCustomisations** | Object | Layout customisation options, see below            | `{ showSidebar: ({ viewMode }, defaultValue) => viewMode === 'docs' ? false : defaultValue }` |
-| **sidebar**              | Object | Sidebar options, see below                         | `{ showRoots: false }`                                                                         |
-| **toolbar**              | Object | Modify the tools in the toolbar using the addon id | `{ fullscreen: { hidden: false } } `                                                           |
+| **sidebar**              | Object | Sidebar options, see below                         | `{ showRoots: false }`                                                                        |
+| **toolbar**              | Object | Modify the tools in the toolbar using the addon id | `{ fullscreen: { hidden: false } } `                                                          |
 
 The following options are configurable under the `layout` namespace:
 
@@ -150,13 +150,13 @@ Storybook can show status icons in the sidebar to highlight new and modified sto
 
 You can use URL parameters to configure some of the available features:
 
-| Config option       | Query param  | Supported values                                                                             |
-| ------------------- | ------------ | -------------------------------------------------------------------------------------------- |
-| **enableShortcuts** | `shortcuts`  | `false`                                                                                      |
-| --- (fullscreen)    | `full`       | `true`, `false`                                                                              |
-| --- (show sidebar)  | `nav`        | `true`, `false`                                                                              |
-| --- (show panel)    | `panel`      | `false`, `'right'`, `'bottom'`                                                               |
-| **selectedPanel**   | `addonPanel` | Any panel ID                                                                                 |
-| **showTabs**        | `tabs`       | `true`                                                                                       |
-| ---                 | `instrument` | `false`, `true`                                                                              |
-| ---                 | `statuses`   | Semicolon-separated status values: `new`, `modified`, `related` (prefix with `!` to exclude) |
+| Config option          | Query param  | Supported values                                                                             |
+| ---------------------- | ------------ | -------------------------------------------------------------------------------------------- |
+| **ui.enableShortcuts** | `shortcuts`  | `false`                                                                                      |
+| --- (fullscreen)       | `full`       | `true`, `false`                                                                              |
+| --- (show sidebar)     | `nav`        | `true`, `false`                                                                              |
+| --- (show panel)       | `panel`      | `false`, `'right'`, `'bottom'`                                                               |
+| **selectedPanel**      | `addonPanel` | Any panel ID                                                                                 |
+| **layout.showTabs**    | `tabs`       | `true`                                                                                       |
+| ---                    | `instrument` | `false`, `true`                                                                              |
+| ---                    | `statuses`   | Semicolon-separated status values: `new`, `modified`, `related` (prefix with `!` to exclude) |

--- a/docs/configure/user-interface/features-and-behavior.mdx
+++ b/docs/configure/user-interface/features-and-behavior.mdx
@@ -16,7 +16,7 @@ The following table details how to use the API values:
 | **ui**                   | Object | UI options, see below                              | `{ enableShortcuts: true }`                                                                    |
 | **theme**                | Object | Storybook Theme, see next section                  | `undefined`                                                                                    |
 | **selectedPanel**        | String | Id to select an addon panel                        | `'storybook/actions/panel'`                                                                    |
-| **layoutCustomisations** | Object | Layout customisation options, see below            | `{ showSidebar: ({ viewMode }, defaultValue) => viewMode === 'docs' ? false : defaultValue` }` |
+| **layoutCustomisations** | Object | Layout customisation options, see below            | `{ showSidebar: ({ viewMode }, defaultValue) => viewMode === 'docs' ? false : defaultValue }` |
 | **sidebar**              | Object | Sidebar options, see below                         | `{ showRoots: false }`                                                                         |
 | **toolbar**              | Object | Modify the tools in the toolbar using the addon id | `{ fullscreen: { hidden: false } } `                                                           |
 


### PR DESCRIPTION
## What I did

The `setConfig` documentation still shows layout and UI options at the top level of the config object. Storybook 11 removes that shape ([#36128](https://github.com/storybookjs/storybook/pull/36128)), so every reader copying the current example writes config that Storybook silently ignores. This moves the shared snippet and the two option tables that describe it into the `layout` and `ui` namespaces.

Which key goes where is taken from the removal PR's own key map, not guessed:

```text
setConfig({ ... })
  navSize, bottomPanelHeight, rightPanelWidth,   ──► layout: { ... }
  panelPosition, showNav, showPanel, showToolbar,
  initialActive
  enableShortcuts                                ──► ui: { ... }
  theme, selectedPanel, layoutCustomisations,    ──► unchanged, still top level
  sidebar, toolbar
```

The shared snippet after the change (`docs/_snippets/storybook-config-layout.md`, JS variant trimmed):

```js
addons.setConfig({
  layout: {
    navSize: 300,
    bottomPanelHeight: 300,
    rightPanelWidth: 300,
    panelPosition: 'bottom',
    showToolbar: true,
    initialActive: 'sidebar',
  },
  ui: {
    enableShortcuts: true,
  },
  theme: undefined,
  selectedPanel: undefined,
  layoutCustomisations: {
    /* unchanged */
  },
  sidebar: {
    /* unchanged */
  },
  toolbar: {
    /* unchanged */
  },
});
```

This matches what the `set-config-layout` automigration emits, per its inline snapshot in #36128:

```js
addons.setConfig({
  layout: {
    showNav: false,
    panelPosition: 'right'
  },
  ui: {
    enableShortcuts: false
  },
  theme
});
```

Both option tables (`docs/addons/addons-api.mdx` and `docs/configure/user-interface/features-and-behavior.mdx`) are split into a top-level table plus `layout` and `ui` namespace tables, and each page gets one callout pointing at the automigration and the migration note. `showNav` and `showPanel` are added to the `layout` table: the migration guide tells people to move them, so they need a place to land.

The "Configuring through URL parameters" table named the same two options by their old flat keys, so it now qualifies them with the namespace a reader has to write:

```diff
  | Config option          | Query param  |
- | **enableShortcuts**    | `shortcuts`  |
+ | **ui.enableShortcuts** | `shortcuts`  |
- | **showTabs**           | `tabs`       |
+ | **layout.showTabs**    | `tabs`       |
```

> [!NOTE]
> Merge this after #36128. The nested shape documented here already works in 10.x, but the `storybook automigrate set-config-layout` command named in the callouts only exists once that PR lands.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Documentation-only change. Verified with the repo's docs gate:

| Command | Run from | Result on this branch |
| --- | --- | --- |
| `oxfmt --check docs/` | branch checkout root | `All matched files use the correct format.` |
| `yarn docs:check` | branch checkout root | `✅ Docs check: no errors found.` |

#### Manual testing

1. Check out this branch and run `yarn docs:check` from the repo root. It should report `✅ Docs check: no errors found.`
2. Open `docs/configure/user-interface/features-and-behavior.mdx` and `docs/addons/addons-api.mdx`. Confirm every option listed under `layout` and `ui` appears in the corresponding namespace of the code snippet above each table, and that no option is listed twice.
3. In a Storybook 10 project, replace `.storybook/manager.ts` with the JS or TS snippet from `docs/_snippets/storybook-config-layout.md` and start Storybook. Confirm the sidebar is 300px, the addon panel sits at the bottom, the toolbar is visible, and keyboard shortcuts still work - i.e. the documented shape is honored, with no deprecation warnings in the browser console.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

The MIGRATION.md entry for this change is part of #36128.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading/downgrading deps
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version
  - `other`: Changes that don't fit in the above categories

   </details>

