### PR TITLE
Core: Migrate first-party addon state to module stores

### DIFF
--- a/code/addons/a11y/src/components/A11yContext.test.tsx
+++ b/code/addons/a11y/src/components/A11yContext.test.tsx
@@ -14,11 +14,15 @@ import type { AxeResults } from 'axe-core';
 import * as api from 'storybook/manager-api';
 
 import { EVENTS, UI_STATE_ID } from '../constants.ts';
+import * as store from '../store.ts';
 import { RuleType } from '../types.ts';
 import { A11yContextProvider, useA11yContext } from './A11yContext.tsx';
 
 vi.mock('storybook/manager-api');
+vi.mock('../store.ts');
 const mockedApi = vi.mocked(api);
+const mockedStore = vi.mocked(store);
+const mockedSetA11yState = vi.mocked(mockedStore.a11yStore.set);
 
 const storyId = 'button--primary';
 const axeResult: Partial<AxeResults> = {
@@ -82,7 +86,11 @@ describe('A11yContext', () => {
       onSelect,
       unset,
     } as any);
-    mockedApi.useAddonState.mockImplementation((_, defaultState) => React.useState(defaultState));
+    mockedStore.useA11yState.mockImplementation(() => {
+      const [state, setState] = React.useState(store.initialA11yState);
+      mockedSetA11yState.mockImplementation(setState);
+      return state;
+    });
     mockedApi.useChannel.mockReturnValue(vi.fn());
     getCurrentStoryData.mockReturnValue({ id: storyId, type: 'story' });
     getParameters.mockReturnValue({});
@@ -97,7 +105,8 @@ describe('A11yContext', () => {
 
     mockedApi.useChannel.mockClear();
     mockedApi.useStorybookApi.mockClear();
-    mockedApi.useAddonState.mockClear();
+    mockedStore.useA11yState.mockClear();
+    mockedSetA11yState.mockClear();
     mockedApi.useParameter.mockClear();
     mockedApi.useStorybookState.mockClear();
     mockedApi.useGlobals.mockClear();

--- a/code/addons/a11y/src/components/A11yContext.tsx
+++ b/code/addons/a11y/src/components/A11yContext.tsx
@@ -22,7 +22,6 @@ import { HIGHLIGHT, REMOVE_HIGHLIGHT, SCROLL_INTO_VIEW } from 'storybook/highlig
 import {
   experimental_getStatusStore,
   experimental_useStatusStore,
-  useAddonState,
   useChannel,
   useGlobals,
   useParameter,
@@ -40,6 +39,7 @@ import {
   STATUS_TYPE_ID_COMPONENT_TEST,
 } from '../constants.ts';
 import type { A11yParameters } from '../params.ts';
+import { a11yStore, useA11yState } from '../store.ts';
 import type { A11yReport, EnhancedResult, EnhancedResults, Status } from '../types.ts';
 import { RuleType } from '../types.ts';
 import type { TestDiscrepancy } from './TestDiscrepancyMessage.tsx';
@@ -117,20 +117,8 @@ export const A11yContextProvider: FC<PropsWithChildren> = (props) => {
     return value;
   }, [api]);
 
-  const [state, setState] = useAddonState<{
-    ui: { highlighted: boolean; tab: RuleType };
-    results: EnhancedResults | undefined;
-    error: unknown;
-    status: Status;
-  }>(ADDON_ID, {
-    ui: {
-      highlighted: false,
-      tab: RuleType.VIOLATION,
-    },
-    results: undefined,
-    error: undefined,
-    status: getInitialStatus(manual),
-  });
+  const state = useA11yState();
+  const setState = a11yStore.set;
 
   const { ui, results, error, status } = state;
 

--- a/code/addons/a11y/src/manager.test.tsx
+++ b/code/addons/a11y/src/manager.test.tsx
@@ -6,12 +6,14 @@ import type { Addon_BaseType } from 'storybook/internal/types';
 import * as api from 'storybook/manager-api';
 
 import { PANEL_ID } from './constants.ts';
+import * as store from './store.ts';
 import './manager.tsx';
 
 vi.mock('storybook/manager-api');
+vi.mock('./store.ts');
 const mockedApi = vi.mocked<api.API>(api as any);
 mockedApi.useStorybookApi = vi.fn(() => ({ getSelectedPanel: vi.fn() }));
-mockedApi.useAddonState = vi.fn();
+const mockedStore = vi.mocked(store);
 const mockedAddons = vi.mocked(api.addons);
 const registrationImpl = mockedAddons.register.mock.calls[0][1];
 
@@ -38,7 +40,7 @@ describe('A11yManager', () => {
 
   it('should compute title with no issues', () => {
     // given
-    mockedApi.useAddonState.mockImplementation(() => [{ results: undefined }]);
+    mockedStore.useA11yState.mockReturnValue({ results: undefined } as store.A11yState);
     registrationImpl(api as unknown as api.API);
     const title = mockedAddons.add.mock.calls.map(([_, def]) => def).find(isPanel)
       ?.title as () => void;
@@ -63,14 +65,12 @@ describe('A11yManager', () => {
 
   it('should compute title with issues', () => {
     // given
-    mockedApi.useAddonState.mockImplementation(() => [
-      {
-        results: {
-          violations: [{}],
-          incomplete: [{}, {}],
-        },
+    mockedStore.useA11yState.mockReturnValue({
+      results: {
+        violations: [{}],
+        incomplete: [{}, {}],
       },
-    ]);
+    } as store.A11yState);
     registrationImpl(mockedApi);
     const title = mockedAddons.add.mock.calls.map(([_, def]) => def).find(isPanel)
       ?.title as () => void;

--- a/code/addons/a11y/src/manager.tsx
+++ b/code/addons/a11y/src/manager.tsx
@@ -2,32 +2,18 @@ import React from 'react';
 
 import { Badge } from 'storybook/internal/components';
 
-import { addons, types, useAddonState, useStorybookApi } from 'storybook/manager-api';
+import { addons, types, useStorybookApi } from 'storybook/manager-api';
 
 import { A11YPanel } from './components/A11YPanel.tsx';
 import { A11yContextProvider } from './components/A11yContext.tsx';
 import { VisionSimulator } from './components/VisionSimulator.tsx';
 import { ADDON_ID, PANEL_ID, PARAM_KEY } from './constants.ts';
-import type { EnhancedResults, Status } from './types.ts';
-import { RuleType } from './types.ts';
+import { useA11yState } from './store.ts';
 
 const Title = () => {
   const api = useStorybookApi();
   const selectedPanel = api.getSelectedPanel();
-  const [{ results }] = useAddonState<{
-    ui: { highlighted: boolean; tab: RuleType };
-    results: EnhancedResults | undefined;
-    error: unknown;
-    status: Status;
-  }>(ADDON_ID, {
-    ui: {
-      highlighted: false,
-      tab: RuleType.VIOLATION,
-    },
-    results: undefined,
-    error: undefined,
-    status: 'initial',
-  });
+  const { results } = useA11yState();
   const violationsNb = results?.violations?.length ?? 0;
   const incompleteNb = results?.incomplete?.length ?? 0;
   const count = violationsNb + incompleteNb;

--- a/code/addons/a11y/src/store.ts
+++ b/code/addons/a11y/src/store.ts
@@ -1,0 +1,39 @@
+import type { SetStateAction } from 'react';
+import { useSyncExternalStore } from 'react';
+
+import type { EnhancedResults, Status } from './types.ts';
+import { RuleType } from './types.ts';
+
+export interface A11yState {
+  ui: { highlighted: boolean; tab: RuleType };
+  results: EnhancedResults | undefined;
+  error: unknown;
+  status: Status;
+}
+
+export const initialA11yState: A11yState = {
+  ui: {
+    highlighted: false,
+    tab: RuleType.VIOLATION,
+  },
+  results: undefined,
+  error: undefined,
+  status: 'initial',
+};
+
+let state = initialA11yState;
+const listeners = new Set<() => void>();
+
+export const a11yStore = {
+  get: () => state,
+  set: (next: SetStateAction<A11yState>) => {
+    state = typeof next === 'function' ? next(state) : next;
+    listeners.forEach((listener) => listener());
+  },
+  subscribe: (listener: () => void) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+};
+
+export const useA11yState = () => useSyncExternalStore(a11yStore.subscribe, a11yStore.get);

--- a/code/addons/themes/src/theme-switcher.tsx
+++ b/code/addons/themes/src/theme-switcher.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Button, Select } from 'storybook/internal/components';
 
 import { PaintBrushIcon } from '@storybook/icons';
 
-import { addons, useAddonState, useChannel, useGlobals, useParameter } from 'storybook/manager-api';
+import { addons, useChannel, useGlobals, useParameter } from 'storybook/manager-api';
 
 import {
   DEFAULT_ADDON_STATE,
@@ -29,16 +29,14 @@ export const ThemeSwitcher = React.memo(function ThemeSwitcher() {
   const [{ theme: selected }, updateGlobals, storyGlobals] = useGlobals();
 
   const channel = addons.getChannel();
-  const fromLast = channel.last(THEMING_EVENTS.REGISTER_THEMES);
-  const initializeThemeState = Object.assign({}, DEFAULT_ADDON_STATE, {
-    themesList: fromLast?.[0]?.themes || [],
-    themeDefault: fromLast?.[0]?.defaultTheme || '',
+  const [{ themesList, themeDefault }, updateState] = useState<ThemeAddonState>(() => {
+    const fromLast = channel.last(THEMING_EVENTS.REGISTER_THEMES);
+    return {
+      ...DEFAULT_ADDON_STATE,
+      themesList: fromLast?.[0]?.themes || [],
+      themeDefault: fromLast?.[0]?.defaultTheme || '',
+    };
   });
-
-  const [{ themesList, themeDefault }, updateState] = useAddonState<ThemeAddonState>(
-    THEME_SWITCHER_ID,
-    initializeThemeState
-  );
 
   const isLocked = KEY in storyGlobals || !!themeOverride;
 

--- a/code/core/src/actions/components/Title.tsx
+++ b/code/core/src/actions/components/Title.tsx
@@ -3,14 +3,16 @@ import React from 'react';
 import { Badge } from 'storybook/internal/components';
 import { STORY_CHANGED } from 'storybook/internal/core-events';
 
-import { useAddonState, useChannel, useStorybookApi } from 'storybook/manager-api';
+import { useChannel, useStorybookApi } from 'storybook/manager-api';
 
-import { ADDON_ID, CLEAR_ID, EVENT_ID, PANEL_ID } from '../constants.ts';
+import { CLEAR_ID, EVENT_ID, PANEL_ID } from '../constants.ts';
+import { actionsStore, useActionsState } from './store.ts';
 
 export function Title() {
   const api = useStorybookApi();
   const selectedPanel = api.getSelectedPanel();
-  const [{ count }, setCount] = useAddonState(ADDON_ID, { count: 0 });
+  const { count } = useActionsState();
+  const setCount = actionsStore.set;
 
   useChannel({
     [EVENT_ID]: () => {

--- a/code/core/src/actions/components/store.ts
+++ b/code/core/src/actions/components/store.ts
@@ -1,0 +1,25 @@
+import type { SetStateAction } from 'react';
+import { useSyncExternalStore } from 'react';
+
+interface ActionsState {
+  count: number;
+}
+
+export const initialActionsState: ActionsState = { count: 0 };
+
+let state = initialActionsState;
+const listeners = new Set<() => void>();
+
+export const actionsStore = {
+  get: () => state,
+  set: (next: SetStateAction<ActionsState>) => {
+    state = typeof next === 'function' ? next(state) : next;
+    listeners.forEach((listener) => listener());
+  },
+  subscribe: (listener: () => void) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+};
+
+export const useActionsState = () => useSyncExternalStore(actionsStore.subscribe, actionsStore.get);

--- a/code/core/src/component-testing/components/Panel.tsx
+++ b/code/core/src/component-testing/components/Panel.tsx
@@ -14,7 +14,6 @@ import { global } from '@storybook/global';
 
 import {
   experimental_useStatusStore,
-  useAddonState,
   useChannel,
   useParameter,
   useStorybookApi,
@@ -33,9 +32,10 @@ import {
   type LogItem,
   type RenderPhase,
 } from '../../instrumenter/types.ts';
-import { ADDON_ID, INTERNAL_RENDER_CALL_ID } from '../constants.ts';
+import { INTERNAL_RENDER_CALL_ID } from '../constants.ts';
 import { InteractionsPanel, type SerializedError } from './InteractionsPanel.tsx';
 import type { PlayStatus } from './StatusBadge.tsx';
+import { INITIAL_CONTROL_STATES, panelStore, usePanelState } from './store.ts';
 
 export interface PanelState {
   status: PlayStatus;
@@ -47,15 +47,6 @@ export interface PanelState {
   caughtException?: Error;
   unhandledErrors?: SerializedError[];
 }
-
-const INITIAL_CONTROL_STATES = {
-  detached: false,
-  start: false,
-  back: false,
-  goto: false,
-  next: false,
-  end: false,
-};
 
 const playStatusMap: Record<
   Extract<RenderPhase, 'rendering' | 'playing' | 'completed' | 'errored' | 'aborted'>,
@@ -201,16 +192,8 @@ export const Panel = memo<{ refId?: string; storyId: string; storyUrl: string }>
     const importPath = data?.importPath as string | undefined;
     const canOpenInEditor = global.CONFIG_TYPE === 'DEVELOPMENT' && !state.refId;
 
-    const [panelState, set] = useAddonState<PanelState>(ADDON_ID, {
-      status: 'rendering' as PlayStatus,
-      controlStates: INITIAL_CONTROL_STATES,
-      interactions: [] as ReturnType<typeof getInteractions>,
-      interactionsCount: 0,
-      hasException: false,
-      pausedAt: undefined,
-      caughtException: undefined,
-      unhandledErrors: undefined,
-    });
+    const panelState = usePanelState();
+    const set = panelStore.set;
 
     // local state
     const [scrollTarget, setScrollTarget] = useState<HTMLElement | undefined>(undefined);

--- a/code/core/src/component-testing/components/PanelTitle.tsx
+++ b/code/core/src/component-testing/components/PanelTitle.tsx
@@ -2,18 +2,17 @@ import React from 'react';
 
 import { Badge } from 'storybook/internal/components';
 
-import { useAddonState, useStorybookApi } from 'storybook/manager-api';
+import { useStorybookApi } from 'storybook/manager-api';
 
 import { CallStates } from '../../instrumenter/types.ts';
-import { ADDON_ID, PANEL_ID } from '../constants.ts';
-import type { PanelState } from './Panel.tsx';
+import { PANEL_ID } from '../constants.ts';
 import { StatusIcon } from './StatusIcon.tsx';
+import { usePanelState } from './store.ts';
 
 export function PanelTitle() {
   const api = useStorybookApi();
   const selectedPanel = api.getSelectedPanel();
-  const [addonState = {}] = useAddonState<PanelState>(ADDON_ID);
-  const { status, hasException, interactionsCount } = addonState as PanelState;
+  const { status, hasException, interactionsCount } = usePanelState();
 
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>

--- a/code/core/src/component-testing/components/store.ts
+++ b/code/core/src/component-testing/components/store.ts
@@ -1,0 +1,41 @@
+import type { SetStateAction } from 'react';
+import { useSyncExternalStore } from 'react';
+
+import type { PanelState } from './Panel.tsx';
+
+export const INITIAL_CONTROL_STATES = {
+  detached: false,
+  start: false,
+  back: false,
+  goto: false,
+  next: false,
+  end: false,
+};
+
+export const initialPanelState: PanelState = {
+  status: 'rendering',
+  controlStates: INITIAL_CONTROL_STATES,
+  interactions: [],
+  interactionsCount: 0,
+  hasException: false,
+  pausedAt: undefined,
+  caughtException: undefined,
+  unhandledErrors: undefined,
+};
+
+let state = initialPanelState;
+const listeners = new Set<() => void>();
+
+export const panelStore = {
+  get: () => state,
+  set: (next: SetStateAction<PanelState>) => {
+    state = typeof next === 'function' ? next(state) : next;
+    listeners.forEach((listener) => listener());
+  },
+  subscribe: (listener: () => void) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+};
+
+export const usePanelState = () => useSyncExternalStore(panelStore.subscribe, panelStore.get);


### PR DESCRIPTION

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

- replaced Storybook's a11y, component-testing, and actions `useAddonState` call sites with addon-owned module stores
- switched the single-consumer themes state to lazy local React state
- rewrote the a11y tests to mock the addon's store instead of the manager API

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

1. Run `cd code && yarn storybook:ui`.
2. Open `?path=/story/addons-accessibility-tests--violations`, select Accessibility, then select Controls. Confirm the Accessibility tab keeps its `5` badge while its panel body is inactive.
3. Open `?path=/story/component-testing-test-fn--play-function:should-be-clicked-by-play-function`, select Interactions, then select Controls. Confirm the Interactions tab keeps its `2` badge while its panel body is inactive.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-36141-sha-6ddbeb4a`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-36141-sha-6ddbeb4a sandbox` or in an existing project with `npx storybook@0.0.0-pr-36141-sha-6ddbeb4a upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-36141-sha-6ddbeb4a`](https://npmjs.com/package/storybook/v/0.0.0-pr-36141-sha-6ddbeb4a) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`agent/sto-156-addon-module-stores`](https://github.com/storybookjs/storybook/tree/agent/sto-156-addon-module-stores) |
| **Commit** | [`6ddbeb4a`](https://github.com/storybookjs/storybook/commit/6ddbeb4ab734f17970517ac011d937aeba73bf9e) |
| **Datetime** | Thu Sep  3 11:50:52 UTC 2026 (`1788436252`) |
| **Workflow run** | [33751905401](https://github.com/storybookjs/storybook/actions/runs/33751905401) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=36141`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

