### PR TITLE
React: Fix meta args inference for required literal props

### DIFF
--- a/code/renderers/react/src/csf-factories.test.tsx
+++ b/code/renderers/react/src/csf-factories.test.tsx
@@ -105,6 +105,46 @@ describe('Args can be provided in multiple ways', () => {
       render: (args) => <div>Hello world</div>,
     });
   });
+
+  describe('Literal-typed args (#36125)', () => {
+    type LiteralButtonProps = { variant: 'primary' | 'secondary'; disabled: boolean };
+    const LiteralButton: (props: LiteralButtonProps) => ReactElement = () => <></>;
+
+    it('✅ A literal arg provided in meta does not have to be repeated in the story', () => {
+      const meta = preview.meta({
+        component: LiteralButton,
+        args: { variant: 'primary', disabled: false },
+      });
+
+      const Basic = meta.story();
+      const WithArgs = meta.story({ args: { variant: 'secondary' } });
+    });
+
+    it('✅ A literal arg provided in meta is still inferred when types are added via .type()', () => {
+      const meta = preview
+        .type<{ args: { extra?: boolean } }>()
+        .meta({ component: LiteralButton, args: { variant: 'primary', disabled: false } });
+
+      const Basic = meta.story();
+    });
+
+    it('❌ A required arg missing from both meta and the story is still required', () => {
+      const meta = preview.meta({
+        component: LiteralButton,
+        args: { variant: 'primary' },
+      });
+      // @ts-expect-error disabled not provided ❌
+      const Basic = meta.story();
+    });
+
+    it('❌ An invalid literal value is still rejected', () => {
+      const meta = preview.meta({
+        component: LiteralButton,
+        // @ts-expect-error 'tertiary' is not part of the union ❌
+        args: { variant: 'tertiary', disabled: false },
+      });
+    });
+  });
 });
 
 it('✅ Void functions are not changed', () => {

--- a/code/renderers/react/src/preview.tsx
+++ b/code/renderers/react/src/preview.tsx
@@ -117,8 +117,10 @@ export interface ReactPreview<T extends AddonTypes> extends Preview<ReactTypes &
   meta<
     TArgs extends Args,
     Decorators extends DecoratorFunction<ReactTypes & T, any>,
-    // Try to make Exact<Partial<TArgs>, TMetaArgs> work
-    TMetaArgs extends Partial<TArgs & T['args']>,
+    // `const` so TS infers the exact args passed. Without it, inference falls back to
+    // the (all-optional) constraint for literal-typed props, which collapses the
+    // captured meta args to `{}` and makes stories re-require them (#36125).
+    const TMetaArgs extends Partial<TArgs & T['args']>,
   >(
     meta: {
       render?: ArgsStoryFn<ReactTypes & T, TArgs & T['args']>;


### PR DESCRIPTION
Mirrors #36134 (Vue 3) for the React renderer. Same root cause, same one-line fix.

## What I did

When a component has a required prop of a literal type, such as `'A' | 'B'`, and it is set in `meta.args`, `meta.story()` still asks for it again. A plain `string` prop works fine.

The cause is in `code/renderers/react/src/preview.tsx`. `meta()` records the args you pass in a type parameter `TMetaArgs`, and stories use it to make those args optional. But its constraint is `Partial<TArgs & T['args']>`, which references `TArgs` — itself still being inferred from `component`. For a literal-typed prop, TypeScript cannot satisfy that constraint without widening, so it abandons inference for `TMetaArgs` and substitutes the constraint. Since the constraint is all-optional, `Partial<TArgs> extends TMetaArgs` becomes trivially true and the guard

```ts
args: Partial<TArgs> extends TMetaArgs ? {} : TMetaArgs;
```

collapses the captured args to `{}`. `story()` then no longer knows the prop was ever provided.

The fix is to add `const` to the `TMetaArgs` type parameter so TypeScript keeps the exact args passed instead of falling back to the constraint. Wrong literal values are still rejected, and a genuinely missing required arg is still required.

React has one `meta()` overload, so only one `const` is needed (Vue 3 has two).

## Why this matters beyond the type error

The reported error points at the `meta.story()` calls, not at the `meta({ args })` object that actually caused it — in a real story file those can be hundreds of lines apart. The message claims a prop like `children` is missing when `meta.args` visibly supplies it. In practice this leads people to loosen the component's own prop types to satisfy Storybook, which is a production API regression caused by a tooling bug.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Four type tests in `code/renderers/react/src/csf-factories.test.tsx`, added to the existing `Args can be provided in multiple ways` suite: the literal arg can be omitted in the story, the same with `.type()`, a genuinely missing required arg is still required, and an invalid literal value is still rejected. No runtime assertions — checked by `tsc --noEmit`.

Without the fix the two positive tests fail with `TS2554: Expected 1 arguments, but got 0` and `TS2769`. With it, the file reports `Tests 24 passed (24)` / `Type Errors no errors`.

#### Manual testing

1. In `code/renderers/react`, run `yarn tsc --noEmit -p .` → no `csf-factories` errors
2. Revert the change in `src/preview.tsx` and run it again → the new tests fail:

```
src/csf-factories.test.tsx(119,26): error TS2554: Expected 1 arguments, but got 0.
src/csf-factories.test.tsx(120,29): error TS2769: No overload matches this call.
src/csf-factories.test.tsx(128,26): error TS2554: Expected 1 arguments, but got 0.
```

3. Optional, standalone React repro: clone https://github.com/cyberuni/storybook-csf-meta-args-repro, `npm install`, `npm run typecheck`. `src/stepper.stories.tsx` fails; `src/stepper_workaround.stories.tsx` (`as const`) and `src/box_control.stories.tsx` (no literal-union prop) both pass, isolating the trigger to literal-type widening in `meta({ args })`.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

This is a type-inference fix only; no documentation changes needed.

## Notes for maintainers

- `const` type parameters require TypeScript >= 5.0, while `@storybook/react` declares a `typescript >= 4.9.x` peer range. This is the same version consideration that put #32829 on the 11 milestone, so this PR likely belongs to the same release as #36134.
- `renderers/web-components` and `frameworks/angular` still have the same unmodified `TMetaArgs` and are presumably affected too. Happy to extend this PR to cover them, or leave them for separate ones — let me know which you prefer.

Made with [Cursor](https://cursor.com)