### PR TITLE
Core: Sync the story index to attached tools callers through an open service

### DIFF
--- a/code/core/src/core-server/presets/common-preset.ts
+++ b/code/core/src/core-server/presets/common-preset.ts
@@ -1,6 +1,8 @@
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 
+import invariant from 'tiny-invariant';
+
 import type { Channel } from 'storybook/internal/channels';
 import {
   JsPackageManagerFactory,
@@ -37,6 +39,8 @@ import { createDocgenWorkerClient } from '../../shared/open-service/services/doc
 import { registerModuleGraphService } from '../../shared/open-service/services/module-graph/server.ts';
 import { registerReviewService } from '../../shared/open-service/services/review/server.ts';
 import { registerStoryDocsService } from '../../shared/open-service/services/story-docs/server.ts';
+import { registerStoryIndexService } from '../../shared/open-service/services/story-index/server.ts';
+import { isDelegatedMode } from '../../shared/open-service/service-registry.ts';
 import { createLocalDocsAccess } from '../../shared/open-service/toolsets/docs/access-local.ts';
 import { registerToolset } from '../../shared/open-service/toolset-registry.ts';
 import { createDocsToolset } from '../../shared/open-service/toolsets/docs/definition.ts';
@@ -372,10 +376,19 @@ export const services = async (_value: void, options: Options): Promise<void> =>
   }
   globalThis.STORYBOOK_SERVICES_LOADED = true;
 
-  const getIndex = () =>
-    options.presets
-      .apply<StoryIndexGenerator>('storyIndexGenerator')
-      .then((generator) => generator.getIndex());
+  const getGenerator = () => options.presets.apply<StoryIndexGenerator>('storyIndexGenerator');
+  const storyIndexService = registerStoryIndexService({ getSource: getGenerator });
+
+  // An attached caller delegates commands, so its service holds the index the dev server built;
+  // resolving the generator there would index the whole project on every CLI call.
+  const getIndex = async () => {
+    if (!isDelegatedMode()) {
+      return (await getGenerator()).getIndex();
+    }
+    const index = await storyIndexService.queries.index.loaded();
+    invariant(index !== undefined, 'The attached Storybook did not provide a story index');
+    return index;
+  };
 
   registerModuleGraphService({
     channel: options.channel,

--- a/code/core/src/shared/open-service/core-service-types.ts
+++ b/code/core/src/shared/open-service/core-service-types.ts
@@ -3,6 +3,7 @@ import { moduleGraphServiceDef } from './services/module-graph/definition.ts';
 import { moduleGraphIndexServiceDef } from './services/module-graph-index/definition.ts';
 import { reviewServiceDef } from './services/review/definition.ts';
 import { storyDocsServiceDef } from './services/story-docs/definition.ts';
+import { storyIndexServiceDef } from './services/story-index/definition.ts';
 import type {
   AnyServiceDefinition,
   GetServiceOptions,
@@ -35,6 +36,7 @@ export const serverCoreServiceDefs = [
   moduleGraphIndexServiceDef,
   moduleGraphServiceDef,
   reviewServiceDef,
+  storyIndexServiceDef,
 ];
 /** Maps a list of service definitions to `{ [id]: instance }`, keyed by each definition's id. */
 type CoreServices<TDefs extends readonly AnyServiceDefinition[]> = {

--- a/code/core/src/shared/open-service/services/story-index/definition.ts
+++ b/code/core/src/shared/open-service/services/story-index/definition.ts
@@ -1,0 +1,62 @@
+import * as v from 'valibot';
+
+import { defineService } from 'storybook/open-service';
+import type { StoryIndex } from '../../../../types/modules/indexer.ts';
+import type { ServiceInstanceOf } from '../../types.ts';
+
+type StoryIndexServiceState = {
+  index: StoryIndex | undefined;
+};
+
+// Shape-checked only: the full `IndexEntry` union is typed, and validating thousands of entries on
+// every read would cost more than reading the index.
+const storyIndexSchema = v.custom<StoryIndex>(
+  (value) => typeof value === 'object' && value !== null && 'entries' in value
+);
+
+/**
+ * Definition for the `core/story-index` open service.
+ *
+ * The dev server owns the index through its `StoryIndexGenerator`; this service carries that index
+ * as state so other runtimes read it synced instead of indexing the project themselves. The load is
+ * a no-op while an index is stored: `_invalidate` drops it when the generator invalidates, so a
+ * stored index is always the generator's current one.
+ */
+export const storyIndexServiceDef = defineService({
+  id: 'core/story-index',
+  internal: true,
+  description: 'The story index of the running Storybook, as its dev server computed it.',
+  initialState: { index: undefined } as StoryIndexServiceState,
+  queries: {
+    index: {
+      description: 'Returns the current story index, or undefined when none has been loaded.',
+      input: v.void(),
+      output: v.optional(storyIndexSchema),
+      handler: (_input, ctx) => ctx.self.state.index,
+      load: async (_input, ctx) => {
+        if (ctx.self.state.index !== undefined) {
+          return;
+        }
+        await ctx.self.commands._refresh(undefined);
+      },
+    },
+  },
+  commands: {
+    _refresh: {
+      internal: true,
+      description:
+        'Reads the index from the generator and stores it. Handler supplied at server registration.',
+      input: v.undefined(),
+      output: v.void(),
+    },
+    _invalidate: {
+      internal: true,
+      description:
+        'Drops the stored index after the generator invalidated it, so the next load reads a fresh one.',
+      input: v.undefined(),
+      output: v.void(),
+    },
+  },
+});
+
+export type StoryIndexService = ServiceInstanceOf<typeof storyIndexServiceDef>;

--- a/code/core/src/shared/open-service/services/story-index/server.test.ts
+++ b/code/core/src/shared/open-service/services/story-index/server.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { StoryIndex } from '../../../../types/modules/indexer.ts';
+import { clearRegistry } from '../../server.ts';
+import { registerStoryIndexService, type StoryIndexSource } from './server.ts';
+
+afterEach(() => {
+  clearRegistry();
+});
+
+function makeIndex(ids: string[]): StoryIndex {
+  return {
+    v: 5,
+    entries: Object.fromEntries(
+      ids.map((id) => [
+        id,
+        {
+          id,
+          name: id,
+          title: 'Comp',
+          type: 'story',
+          subtype: 'story',
+          importPath: './comp.stories.tsx',
+        },
+      ])
+    ),
+  };
+}
+
+function makeSource(initial: StoryIndex) {
+  let current = initial;
+  const listeners = new Set<() => void>();
+  const source: StoryIndexSource = {
+    getIndex: vi.fn(async () => current),
+    onInvalidated: vi.fn((listener: () => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    }),
+  };
+  return {
+    source,
+    getSource: vi.fn(async () => source),
+    invalidate(next: StoryIndex) {
+      current = next;
+      listeners.forEach((listener) => listener());
+    },
+  };
+}
+
+describe('story-index open service', () => {
+  it('reads the index from the source on the first load and stores it', async () => {
+    const index = makeIndex(['button--primary']);
+    const { getSource, source } = makeSource(index);
+    const service = registerStoryIndexService({ getSource });
+
+    expect(service.queries.index.get()).toBeUndefined();
+    expect(getSource).not.toHaveBeenCalled();
+
+    await expect(service.queries.index.loaded()).resolves.toEqual(index);
+    expect(service.queries.index.get()).toEqual(index);
+    expect(source.getIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves the stored index without touching the source again', async () => {
+    const { getSource, source } = makeSource(makeIndex(['button--primary']));
+    const service = registerStoryIndexService({ getSource });
+
+    await service.queries.index.loaded();
+    await service.queries.index.loaded();
+
+    expect(source.getIndex).toHaveBeenCalledTimes(1);
+    expect(source.onInvalidated).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops the stored index when the source invalidates and reads the next one on load', async () => {
+    const { getSource, source, invalidate } = makeSource(makeIndex(['button--primary']));
+    const service = registerStoryIndexService({ getSource });
+    await service.queries.index.loaded();
+
+    const next = makeIndex(['button--primary', 'button--secondary']);
+    invalidate(next);
+
+    await vi.waitFor(() => expect(service.queries.index.get()).toBeUndefined());
+    await expect(service.queries.index.loaded()).resolves.toEqual(next);
+    expect(source.getIndex).toHaveBeenCalledTimes(2);
+    expect(source.onInvalidated).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-reads when the source invalidates while a read is in flight', async () => {
+    const stale = makeIndex(['button--primary']);
+    const fresh = makeIndex(['button--primary', 'button--secondary']);
+    const { getSource, source, invalidate } = makeSource(stale);
+    let releaseFirstRead = () => {};
+    vi.mocked(source.getIndex).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseFirstRead = () => resolve(stale);
+        })
+    );
+    const service = registerStoryIndexService({ getSource });
+
+    const loading = service.queries.index.loaded();
+    await vi.waitFor(() => expect(source.onInvalidated).toHaveBeenCalledTimes(1));
+    invalidate(fresh);
+    releaseFirstRead();
+
+    await expect(loading).resolves.toEqual(fresh);
+    expect(source.getIndex).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces a failing source through loaded() and stores nothing', async () => {
+    const { getSource, source } = makeSource(makeIndex([]));
+    vi.mocked(source.getIndex).mockRejectedValueOnce(new Error('Duplicate stories'));
+    const service = registerStoryIndexService({ getSource });
+
+    await expect(service.queries.index.loaded()).rejects.toThrow('Duplicate stories');
+    expect(service.queries.index.get()).toBeUndefined();
+  });
+});

--- a/code/core/src/shared/open-service/services/story-index/server.ts
+++ b/code/core/src/shared/open-service/services/story-index/server.ts
@@ -1,0 +1,69 @@
+import type { StoryIndex } from '../../../../types/modules/indexer.ts';
+import { registerService } from '../../server.ts';
+import { storyIndexServiceDef, type StoryIndexService } from './definition.ts';
+
+/** What the service needs from `StoryIndexGenerator`, which satisfies it as-is. */
+export interface StoryIndexSource {
+  getIndex: () => Promise<StoryIndex>;
+  onInvalidated: (listener: () => void) => () => void;
+}
+
+export interface RegisterStoryIndexServiceOptions {
+  /**
+   * Resolved on the first `_refresh`, never at registration: an attached caller registers this
+   * service too, and resolving the generator there would index the project in the caller.
+   */
+  getSource: () => Promise<StoryIndexSource>;
+}
+
+/** Registers the `core/story-index` service in the server realm. */
+export function registerStoryIndexService({
+  getSource,
+}: RegisterStoryIndexServiceOptions): StoryIndexService {
+  // Counted in the listener itself, not in `_invalidate`: command handlers run after async input
+  // validation, and a refresh finishing in that gap must still see the invalidation.
+  let invalidations = 0;
+  let storedFor = -1;
+  let subscribed = false;
+
+  const service = registerService(storyIndexServiceDef, {
+    commands: {
+      _refresh: {
+        handler: async (_input, ctx) => {
+          const source = await getSource();
+          if (!subscribed) {
+            subscribed = true;
+            source.onInvalidated(() => {
+              invalidations += 1;
+              void service.commands._invalidate(undefined);
+            });
+          }
+
+          let seen: number;
+          let index: StoryIndex;
+          do {
+            seen = invalidations;
+            index = await source.getIndex();
+          } while (seen !== invalidations);
+
+          storedFor = seen;
+          ctx.self.setState((state) => {
+            state.index = index;
+          });
+        },
+      },
+      _invalidate: {
+        handler: async (_input, ctx) => {
+          if (storedFor === invalidations) {
+            return;
+          }
+          ctx.self.setState((state) => {
+            state.index = undefined;
+          });
+        },
+      },
+    },
+  });
+
+  return service;
+}


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

An attached `storybook tools` call re-indexes the whole project inside the CLI process. The `services` preset hands every service a `getIndex` closure that applies the `storyIndexGenerator` preset, and in attached mode that hook runs in the caller exactly as it runs on the server. The first `getIndex()` call from a toolset handler (`docs list` calls it before anything else, to classify the index into component ids, story-based ids and MDX docs) constructs a `StoryIndexGenerator` and parses every story file with Babel. On Astryx (155 story files) that is 1.9s of the 6s a warm `docs list` takes, measured with `--cpu-prof` (context: https://chromaticqa.slack.com/archives/C0BESJJM34M/p1788364914852829). Delegated mode only reroutes commands, and the index was not service state, so the leaf had nothing synced to read.

This PR adds `core/story-index`, an internal open service the dev server owns:

- State is the generator's `StoryIndex`. Nothing else is derived server-side: consumers already treat the index as their input, so every reader (`classifyIndex`, `stories changed`, `stories find-by-component`, the extraction refresh subscription) keeps working unchanged through the same `getIndex` closure.
- The `index` query's load is a no-op while an index is stored and otherwise triggers `_refresh`, whose handler is supplied at server registration and reads the generator. A delegated leaf therefore reads the synced snapshot when it has arrived and pays one round trip when it has not.
- Freshness stays with the generator: its `onInvalidated` listener runs `_invalidate`, which drops the stored index, so the next load reads a fresh one. The server never pushes the index on a file save; an invalidation broadcasts an empty state. A refresh that overlaps an invalidation re-reads until the two agree, and a late `_invalidate` does not clear an index that already reflects it.
- In the `services` preset, `getIndex` reads the service only in delegated mode. The server keeps calling the generator directly, whose memoized `lastIndex` is already its cache, so the 155 `getIndex()` calls an `extractAll` makes on the server stay a plain memo read.
- No manager or preview registrar and no static files: the manager keeps fetching `index.json`, static builds keep writing it. That is a separate, larger step.

### Results

Attached, warm, telemetry off, this repo's own `code/.storybook` with `STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER=true` (1740 index entries, 299 components):

| | before | after |
| --- | --- | --- |
| CLI CPU per `docs list` | index build plus boot | 1.3s, no `createIndex` / `StoryIndexGenerator.initialize` frames in the profile |
| Story files parsed in the CLI | every one | none |

Measured on Astryx with the published 11.0.0-alpha.0 before this change: `createIndex` was 1.9s of 3.3s CLI CPU per warm call (`createIndex` window 1.08s to 2.97s in the profile). The remaining wall time of a warm call is the server re-running docgen and story-docs extraction for every component on every `loaded()`, which this PR does not touch.

With `experimentalDocgenServer` off the docs toolset takes the manifest path, and `loadManifests` applies the `storyIndexGenerator` preset directly, so an attached caller still indexes locally there. Also untouched here.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`core/src/shared/open-service/services/story-index/server.test.ts` covers first load, the no-op load while stored, invalidation followed by a fresh read, an invalidation landing while a read is in flight, and a throwing generator. `core-service-types.test.ts` picks up the new registrar. The existing tools, presets, manifests and open-service suites pass (1143 tests).

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. `yarn nx compile core`, then from `code/`: `STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER=true node core/dist/bin/dispatcher.js dev --port 6006 --config-dir ./.storybook --ci`
2. In another terminal, from `code/`: `STORYBOOK_EXPERIMENTAL_DOCGEN_SERVER=true node --cpu-prof --cpu-prof-dir=/tmp/prof core/dist/bin/dispatcher.js tools --attach docs list`, twice.
3. Open the second `.cpuprofile` in Chrome DevTools. No `createIndex`, `initialize` or `extractStories` frames appear, and the CLI's own CPU time is about a second.
4. Add a story to any story file, run the command again: the new story is listed (the generator invalidated, the service dropped its index, the next load re-read it).

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
