### PR TITLE
Preview: Respect prefers-reduced-motion when scrolling to an anchor

### DIFF
--- a/code/core/src/backgrounds/decorator.ts
+++ b/code/core/src/backgrounds/decorator.ts
@@ -17,8 +17,6 @@ const defaultGrid: GridConfig = {
 const BG_SELECTOR_BASE = `addon-backgrounds`;
 const GRID_SELECTOR_BASE = 'addon-backgrounds-grid';
 
-const transitionStyle = isReduceMotionEnabled() ? '' : 'transition: background-color 0.3s;';
-
 export const withBackgroundAndGrid: DecoratorFunction = (StoryFn, context) => {
   const { globals = {}, parameters = {}, viewMode, id } = context;
   const {
@@ -53,6 +51,7 @@ export const withBackgroundAndGrid: DecoratorFunction = (StoryFn, context) => {
   const backgroundTarget = viewMode === 'docs' ? id : null;
 
   useEffect(() => {
+    const transitionStyle = isReduceMotionEnabled() ? '' : 'transition: background-color 0.3s;';
     const backgroundStyles = `
     ${backgroundSelector} {
       background: ${value} !important;

--- a/code/core/src/backgrounds/decorator.ts
+++ b/code/core/src/backgrounds/decorator.ts
@@ -5,7 +5,8 @@ import { useEffect } from 'storybook/preview-api';
 import { PARAM_KEY } from './constants.ts';
 import { DEFAULT_BACKGROUNDS } from './defaults.ts';
 import type { BackgroundsParameters, GridConfig } from './types.ts';
-import { addBackgroundStyle, addGridStyle, clearStyles, isReduceMotionEnabled } from './utils.ts';
+import { isReduceMotionEnabled } from '../shared/utils/is-reduced-motion-enabled.ts';
+import { addBackgroundStyle, addGridStyle, clearStyles } from './utils.ts';
 
 const defaultGrid: GridConfig = {
   cellSize: 100,

--- a/code/core/src/backgrounds/utils.ts
+++ b/code/core/src/backgrounds/utils.ts
@@ -1,13 +1,5 @@
 const { document } = globalThis;
 
-export const isReduceMotionEnabled = () => {
-  if (!globalThis?.matchMedia) {
-    return false;
-  }
-  const prefersReduceMotion = globalThis.matchMedia('(prefers-reduced-motion: reduce)');
-  return !!prefersReduceMotion?.matches;
-};
-
 export const clearStyles = (selector: string | string[]) => {
   const selectors = Array.isArray(selector) ? selector : [selector];
   selectors.forEach(clearStyle);

--- a/code/core/src/preview-api/modules/preview-web/PreviewWeb.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/PreviewWeb.test.ts
@@ -10,6 +10,7 @@ import {
   FORCE_REMOUNT,
   FORCE_RE_RENDER,
   GLOBALS_UPDATED,
+  NAVIGATE_URL,
   PLAY_FUNCTION_THREW_EXCEPTION,
   PREVIEW_KEYDOWN,
   RESET_STORY_ARGS,
@@ -3714,6 +3715,35 @@ describe('PreviewWeb', () => {
         }),
         'story-element'
       );
+    });
+  });
+
+  describe('onNavigateUrl', () => {
+    it('scrolls the view to the anchor when NAVIGATE_URL is emitted on the channel', async () => {
+      document.location.search = '?id=component-one--docs&viewMode=docs';
+      const preview = await createAndRenderPreview();
+
+      emitter.emit(NAVIGATE_URL, '#a-heading');
+
+      expect(preview.view.scrollToAnchor).toHaveBeenCalledWith('#a-heading');
+    });
+
+    it('does not scroll for a url that is not an in-page anchor', async () => {
+      document.location.search = '?id=component-one--docs&viewMode=docs';
+      const preview = await createAndRenderPreview();
+
+      emitter.emit(NAVIGATE_URL, '/?path=/story/component-one--a');
+
+      expect(preview.view.scrollToAnchor).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when the view does not implement scrollToAnchor', async () => {
+      document.location.search = '?id=component-one--docs&viewMode=docs';
+      const preview = await createAndRenderPreview();
+      // @ts-expect-error scrollToAnchor is optional on the View interface
+      preview.view.scrollToAnchor = undefined;
+
+      expect(() => preview.onNavigateUrl('#a-heading')).not.toThrow();
     });
   });
 

--- a/code/core/src/preview-api/modules/preview-web/PreviewWeb.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/PreviewWeb.test.ts
@@ -3740,7 +3740,6 @@ describe('PreviewWeb', () => {
     it('does not throw when the view does not implement scrollToAnchor', async () => {
       document.location.search = '?id=component-one--docs&viewMode=docs';
       const preview = await createAndRenderPreview();
-      // @ts-expect-error scrollToAnchor is optional on the View interface
       preview.view.scrollToAnchor = undefined;
 
       expect(() => preview.onNavigateUrl('#a-heading')).not.toThrow();

--- a/code/core/src/preview-api/modules/preview-web/WebView.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/WebView.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { WebView } from './WebView.ts';
 
@@ -35,5 +35,88 @@ describe('WebView htmlLang', () => {
     const view = new WebView();
     view.prepareForDocs();
     expect(document.documentElement.lang).toBe('en');
+  });
+});
+
+describe('WebView scrollToAnchor', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="storybook-root"></div>
+      <div id="storybook-docs">
+        <h2 id="a-heading"></h2>
+        <h2 id="2-column--basic"></h2>
+        <h2 id="a heading"></h2>
+      </div>
+    `;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('scrolls to the element named by the hash', () => {
+    const heading = document.getElementById('a-heading')!;
+    const scrollIntoView = vi.spyOn(heading, 'scrollIntoView');
+
+    new WebView().scrollToAnchor('#a-heading');
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+  });
+
+  it('decodes a percent-encoded hash before looking the element up', () => {
+    const heading = document.getElementById('a heading')!;
+    const scrollIntoView = vi.spyOn(heading, 'scrollIntoView');
+
+    new WebView().scrollToAnchor('#a%20heading');
+
+    expect(scrollIntoView).toHaveBeenCalledOnce();
+  });
+
+  it('resolves an id that is not a valid CSS selector', () => {
+    const heading = document.getElementById('2-column--basic')!;
+    const scrollIntoView = vi.spyOn(heading, 'scrollIntoView');
+
+    new WebView().scrollToAnchor('#2-column--basic');
+
+    expect(scrollIntoView).toHaveBeenCalledOnce();
+  });
+
+  it('does nothing when no element matches the hash', () => {
+    const scrollIntoView = vi.spyOn(Element.prototype, 'scrollIntoView');
+
+    expect(() => new WebView().scrollToAnchor('#no-such-heading')).not.toThrow();
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it('scrolls instantly when the user prefers reduced motion', () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: true }));
+    const heading = document.getElementById('a-heading')!;
+    const scrollIntoView = vi.spyOn(heading, 'scrollIntoView');
+
+    new WebView().scrollToAnchor('#a-heading');
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'instant' });
+  });
+
+  it('scrolls smoothly when the user expresses no motion preference', () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: false }));
+    const heading = document.getElementById('a-heading')!;
+    const scrollIntoView = vi.spyOn(heading, 'scrollIntoView');
+
+    new WebView().scrollToAnchor('#a-heading');
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+  });
+
+  it('scrolls smoothly when matchMedia is unavailable', () => {
+    vi.stubGlobal('matchMedia', undefined);
+    const heading = document.getElementById('a-heading')!;
+    const scrollIntoView = vi.spyOn(heading, 'scrollIntoView');
+
+    new WebView().scrollToAnchor('#a-heading');
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
   });
 });

--- a/code/core/src/preview-api/modules/preview-web/WebView.ts
+++ b/code/core/src/preview-api/modules/preview-web/WebView.ts
@@ -9,7 +9,7 @@ import { dedent } from 'ts-dedent';
 
 import type { View } from './View.ts';
 
-const { document } = global;
+const { document, window: globalWindow } = global;
 
 const PREPARING_DELAY = 100;
 
@@ -38,6 +38,9 @@ type Layout = keyof typeof layoutClassMap | 'none';
 const ansiConverter = new AnsiToHtml({
   escapeXML: true,
 });
+
+const prefersReducedMotion = () =>
+  !!globalWindow?.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
 
 export class WebView implements View<HTMLElement> {
   private currentLayoutClass?: (typeof layoutClassMap)[keyof typeof layoutClassMap] | null;
@@ -109,7 +112,7 @@ export class WebView implements View<HTMLElement> {
     // getElementById instead of querySelector: anchor ids (e.g. story ids) may contain
     // characters that are invalid in CSS selectors.
     const element = document.getElementById(decodeURIComponent(hash.substring(1)));
-    element?.scrollIntoView({ behavior: 'smooth' });
+    element?.scrollIntoView({ behavior: prefersReducedMotion() ? 'instant' : 'smooth' });
   }
 
   applyLayout(layout: Layout = 'padded') {

--- a/code/core/src/preview-api/modules/preview-web/WebView.ts
+++ b/code/core/src/preview-api/modules/preview-web/WebView.ts
@@ -7,9 +7,10 @@ import AnsiToHtml from 'ansi-to-html';
 import { parse } from 'picoquery';
 import { dedent } from 'ts-dedent';
 
+import { isReduceMotionEnabled } from '../../../shared/utils/is-reduced-motion-enabled.ts';
 import type { View } from './View.ts';
 
-const { document, window: globalWindow } = global;
+const { document } = global;
 
 const PREPARING_DELAY = 100;
 
@@ -38,9 +39,6 @@ type Layout = keyof typeof layoutClassMap | 'none';
 const ansiConverter = new AnsiToHtml({
   escapeXML: true,
 });
-
-const prefersReducedMotion = () =>
-  !!globalWindow?.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
 
 export class WebView implements View<HTMLElement> {
   private currentLayoutClass?: (typeof layoutClassMap)[keyof typeof layoutClassMap] | null;
@@ -112,7 +110,7 @@ export class WebView implements View<HTMLElement> {
     // getElementById instead of querySelector: anchor ids (e.g. story ids) may contain
     // characters that are invalid in CSS selectors.
     const element = document.getElementById(decodeURIComponent(hash.substring(1)));
-    element?.scrollIntoView({ behavior: prefersReducedMotion() ? 'instant' : 'smooth' });
+    element?.scrollIntoView({ behavior: isReduceMotionEnabled() ? 'instant' : 'smooth' });
   }
 
   applyLayout(layout: Layout = 'padded') {

--- a/code/core/src/shared/utils/is-reduced-motion-enabled.test.ts
+++ b/code/core/src/shared/utils/is-reduced-motion-enabled.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { isReduceMotionEnabled } from './is-reduced-motion-enabled.ts';
+
+describe('isReduceMotionEnabled', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('queries the reduced-motion media feature', () => {
+    const matchMedia = vi.fn().mockReturnValue({ matches: false });
+    vi.stubGlobal('matchMedia', matchMedia);
+
+    isReduceMotionEnabled();
+
+    expect(matchMedia).toHaveBeenCalledWith('(prefers-reduced-motion: reduce)');
+  });
+
+  it('is true when the user prefers reduced motion', () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: true }));
+
+    expect(isReduceMotionEnabled()).toBe(true);
+  });
+
+  it('is false when the user expresses no preference', () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: false }));
+
+    expect(isReduceMotionEnabled()).toBe(false);
+  });
+
+  it('is false where matchMedia does not exist', () => {
+    vi.stubGlobal('matchMedia', undefined);
+
+    expect(isReduceMotionEnabled()).toBe(false);
+  });
+});

--- a/code/core/src/shared/utils/is-reduced-motion-enabled.ts
+++ b/code/core/src/shared/utils/is-reduced-motion-enabled.ts
@@ -1,0 +1,7 @@
+export const isReduceMotionEnabled = () => {
+  if (!globalThis?.matchMedia) {
+    return false;
+  }
+  const prefersReduceMotion = globalThis.matchMedia('(prefers-reduced-motion: reduce)');
+  return !!prefersReduceMotion?.matches;
+};


### PR DESCRIPTION
Follow-up to the review on #36088, which named two gaps on `next`. This covers both.

## What I did

`WebView.scrollToAnchor` always scrolls with `behavior: 'smooth'`. That is an animation, and it runs even when the user has asked the system for less motion. This adds a check and falls back to an instant scroll.

I used `'instant'` rather than `'auto'` on purpose. `'auto'` defers to the `scroll-behavior` CSS property, so a docs page that sets `scroll-behavior: smooth` would animate again for the same user. `'instant'` cannot be overridden that way.

The guard follows `getPreferredColorScheme` in `code/core/src/theming/utils.ts`, which checks that `matchMedia` exists before calling it, because preview code also runs outside a browser.

The second half is coverage. `scrollToAnchor` and `PreviewWithSelection.onNavigateUrl` had no tests at all before this: `WebView.test.ts` covered only `htmlLang`. The `onNavigateUrl` tests go through the channel rather than calling the method, because the dispatch is the part that carries the behaviour: `Channel.emit` runs `handleEvent` on the same instance, so the preview's own listener fires for the preview's own emit.

Every test was checked by breaking the source, not only by passing:

- restoring `behavior: 'smooth'` fails only "scrolls instantly when the user prefers reduced motion"; the other 10 stay green
- removing `channel.on(NAVIGATE_URL, ...)` fails only "scrolls the view to the anchor when NAVIGATE_URL is emitted on the channel"
- removing the `url.startsWith('#')` guard fails only "does not scroll for a url that is not an in-page anchor"

## What this does not cover

The same gap exists in nine other places that scroll with `behavior: 'smooth'`, among them `A11yContext.tsx`, `component-testing/components/Panel.tsx`, `TabList.tsx`, `useHighlights.ts`, `Focus.tsx` and `TourGuide/HighlightElement.tsx`. I left them alone so this PR stays the one file the review pointed at. If you would rather have a shared helper and all call sites fixed together, say so and I will open that as a follow-up.

The tests run in happy-dom, so they assert the call and its arguments. They do not assert that the page really moved.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run a sandbox: `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open the "Configure your project" docs page in the sandbox
3. Use the sidebar search, type the name of a heading on that page, and select the heading result. The preview scrolls to it smoothly.
4. Open DevTools, go to Rendering, and set "Emulate CSS media feature prefers-reduced-motion" to `reduce`
5. Scroll the preview back to the top and repeat step 3. The preview now jumps to the heading with no animation. The heading it lands on is the same one.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)
