### PR TITLE
Telemetry: Never wait for the endpoint, hand unfinished events to a detached process

### DIFF
--- a/code/core/build-config.ts
+++ b/code/core/build-config.ts
@@ -59,6 +59,12 @@ const config: BuildEntries = {
         dts: false,
       },
       {
+        // Spawned detached on process exit to finish delivering pending telemetry events.
+        exportEntries: ['./internal/telemetry/detached-flush'],
+        entryPoint: './src/telemetry/detached-flush.ts',
+        dts: false,
+      },
+      {
         exportEntries: ['./internal/telemetry'],
         entryPoint: './src/telemetry/index.ts',
       },

--- a/code/core/package.json
+++ b/code/core/package.json
@@ -288,6 +288,7 @@
     "open": "^10.2.0",
     "oxc-parser": "^0.127.0",
     "oxc-resolver": "11.21.2",
+    "process-ancestry": "^0.0.2",
     "recast": "^0.23.5",
     "semver": "^7.7.3",
     "use-sync-external-store": "^1.5.0",

--- a/code/core/package.json
+++ b/code/core/package.json
@@ -208,6 +208,7 @@
       "code": "./src/telemetry/index.ts",
       "default": "./dist/telemetry/index.js"
     },
+    "./internal/telemetry/detached-flush": "./dist/telemetry/detached-flush.js",
     "./internal/tools": {
       "types": "./dist/cli/tools/sdk/index.d.ts",
       "code": "./src/cli/tools/sdk/index.ts",
@@ -287,7 +288,6 @@
     "open": "^10.2.0",
     "oxc-parser": "^0.127.0",
     "oxc-resolver": "11.21.2",
-    "process-ancestry": "^0.0.2",
     "recast": "^0.23.5",
     "semver": "^7.7.3",
     "use-sync-external-store": "^1.5.0",
@@ -372,7 +372,6 @@
     "execa": "^9.6.1",
     "exsolve": "^1.0.7",
     "extend-to-be-announced": "^2.0.0",
-    "fetch-retry": "^6.0.0",
     "flush-promises": "^1.0.2",
     "fuse.js": "^3.6.1",
     "get-npm-tarball-url": "^2.1.0",

--- a/code/core/src/core-server/dev-server.ts
+++ b/code/core/src/core-server/dev-server.ts
@@ -215,7 +215,7 @@ export async function storybookDevServer(
           });
         }
       } catch {}
-      await telemetry('canceled', payload, { immediate: true });
+      await telemetry('canceled', payload);
     } finally {
       await disposeChangeDetectionRuntime();
       // Always terminate on signal, even when telemetry is disabled.

--- a/code/core/src/core-server/withTelemetry.test.ts
+++ b/code/core/src/core-server/withTelemetry.test.ts
@@ -127,7 +127,7 @@ describe('withTelemetry', () => {
       2,
       'canceled',
       { eventType: 'init' },
-      { stripMetadata: true, immediate: true }
+      { stripMetadata: true }
     );
     expect(exitSpy).toHaveBeenCalledWith(0);
 
@@ -154,7 +154,7 @@ describe('withTelemetry', () => {
       2,
       'canceled',
       { eventType: 'init' },
-      { stripMetadata: true, immediate: true }
+      { stripMetadata: true }
     );
     expect(exitSpy).toHaveBeenCalledWith(0);
 
@@ -175,7 +175,7 @@ describe('withTelemetry', () => {
       2,
       'canceled',
       { eventType: 'ai-command' },
-      { stripMetadata: true, immediate: true }
+      { stripMetadata: true }
     );
     expect(exitSpy).toHaveBeenCalledWith(0);
 
@@ -219,7 +219,7 @@ describe('withTelemetry', () => {
       2,
       'canceled',
       { eventType: 'init' },
-      { stripMetadata: true, immediate: true }
+      { stripMetadata: true }
     );
     expect(exitSpy).toHaveBeenCalledWith(0);
 
@@ -589,7 +589,6 @@ describe('sendTelemetryError', () => {
       }),
       expect.objectContaining({
         enableCrashReports: false,
-        immediate: true,
       })
     );
   });
@@ -614,7 +613,6 @@ describe('sendTelemetryError', () => {
       }),
       expect.objectContaining({
         enableCrashReports: false,
-        immediate: true,
       })
     );
   });
@@ -640,7 +638,6 @@ describe('sendTelemetryError', () => {
       }),
       expect.objectContaining({
         enableCrashReports: false,
-        immediate: true,
       })
     );
   });
@@ -674,7 +671,6 @@ describe('sendTelemetryError', () => {
       }),
       expect.objectContaining({
         enableCrashReports: false,
-        immediate: true,
       })
     );
   });
@@ -701,7 +697,6 @@ describe('sendTelemetryError', () => {
       }),
       expect.objectContaining({
         enableCrashReports: true,
-        immediate: true,
       })
     );
   });

--- a/code/core/src/core-server/withTelemetry.ts
+++ b/code/core/src/core-server/withTelemetry.ts
@@ -146,7 +146,6 @@ export async function sendTelemetryError(
           ...(parent ? { parent: parent.fullErrorCode } : {}),
         },
         {
-          immediate: true,
           configDir: options.cliOptions.configDir || options.presetOptions?.configDir,
           enableCrashReports: errorLevel === 'full',
           force: true,
@@ -231,7 +230,7 @@ export async function withTelemetry<T>(
 
   async function cancelTelemetry() {
     canceled = true;
-    await telemetry('canceled', { eventType }, { stripMetadata: true, immediate: true });
+    await telemetry('canceled', { eventType }, { stripMetadata: true });
 
     process.exit(0);
   }

--- a/code/core/src/telemetry/detached-flush.ts
+++ b/code/core/src/telemetry/detached-flush.ts
@@ -1,0 +1,3 @@
+import { flushEventsFile } from './flush-events-file.ts';
+
+await flushEventsFile(process.argv[2]);

--- a/code/core/src/telemetry/detached-flush.ts
+++ b/code/core/src/telemetry/detached-flush.ts
@@ -1,8 +1,3 @@
 import { flushEventsFile } from './flush-events-file.ts';
 
-const file = process.argv[2];
-if (!file) {
-  throw new Error('detached-flush expects the path of the events file as its only argument');
-}
-
-await flushEventsFile(file);
+await flushEventsFile(process.argv[2]);

--- a/code/core/src/telemetry/detached-flush.ts
+++ b/code/core/src/telemetry/detached-flush.ts
@@ -1,3 +1,8 @@
 import { flushEventsFile } from './flush-events-file.ts';
 
-await flushEventsFile(process.argv[2]);
+const file = process.argv[2];
+if (!file) {
+  throw new Error('detached-flush expects the path of the events file as its only argument');
+}
+
+await flushEventsFile(file);

--- a/code/core/src/telemetry/fetch.ts
+++ b/code/core/src/telemetry/fetch.ts
@@ -1,1 +1,0 @@
-export const fetch = global.fetch;

--- a/code/core/src/telemetry/flush-events-file.test.ts
+++ b/code/core/src/telemetry/flush-events-file.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+
+import * as memfs from 'memfs';
+import { vol } from 'memfs';
+
+import { flushEventsFile } from './flush-events-file.ts';
+import { postEvent } from './post-event.ts';
+
+vi.mock('node:fs/promises', { spy: true });
+vi.mock('./post-event.ts', () => ({ postEvent: vi.fn(async () => ({ status: 200 })) }));
+
+beforeEach(async () => {
+  vol.reset();
+  const fs = await import('node:fs/promises');
+  vi.mocked(fs.readFile).mockImplementation(memfs.fs.promises.readFile as any);
+  vi.mocked(fs.rm).mockImplementation(memfs.fs.promises.rm as any);
+  vi.mocked(postEvent).mockClear();
+});
+
+it('posts every event in the file and removes the file', async () => {
+  const events = [{ body: { eventId: 'a' } }, { body: { eventId: 'b' }, retryDelay: 5 }];
+  vol.fromJSON({ '/project/events.json': JSON.stringify(events) });
+
+  await flushEventsFile('/project/events.json');
+
+  expect(vi.mocked(postEvent).mock.calls.map(([event]) => event)).toEqual(events);
+  expect(vi.mocked(postEvent).mock.calls[0][1]).toMatchObject({ keepProcessAlive: true });
+  expect(vol.toJSON()).toEqual({ '/project': null });
+});
+
+it('keeps delivering the others when one post fails', async () => {
+  vi.mocked(postEvent).mockRejectedValueOnce(new Error('network'));
+  vol.fromJSON({
+    '/project/events.json': JSON.stringify([
+      { body: { eventId: 'a' } },
+      { body: { eventId: 'b' } },
+    ]),
+  });
+
+  await expect(flushEventsFile('/project/events.json')).resolves.toBeUndefined();
+
+  expect(postEvent).toHaveBeenCalledTimes(2);
+});

--- a/code/core/src/telemetry/flush-events-file.test.ts
+++ b/code/core/src/telemetry/flush-events-file.test.ts
@@ -7,7 +7,7 @@ import { flushEventsFile } from './flush-events-file.ts';
 import { postEvent } from './post-event.ts';
 
 vi.mock('node:fs/promises', { spy: true });
-vi.mock('./post-event.ts', () => ({ postEvent: vi.fn(async () => ({ status: 200 })) }));
+vi.mock('./post-event.ts', () => ({ postEvent: vi.fn(async () => {}) }));
 
 beforeEach(async () => {
   vol.reset();
@@ -40,4 +40,13 @@ it('keeps delivering the others when one post fails', async () => {
   await expect(flushEventsFile('/project/events.json')).resolves.toBeUndefined();
 
   expect(postEvent).toHaveBeenCalledTimes(2);
+});
+
+it('removes a file it cannot parse', async () => {
+  vol.fromJSON({ '/project/events.json': '[{"body":' });
+
+  await expect(flushEventsFile('/project/events.json')).rejects.toThrow();
+
+  expect(vol.toJSON()).toEqual({ '/project': null });
+  expect(postEvent).not.toHaveBeenCalled();
 });

--- a/code/core/src/telemetry/flush-events-file.ts
+++ b/code/core/src/telemetry/flush-events-file.ts
@@ -1,0 +1,15 @@
+import { readFile, rm } from 'node:fs/promises';
+
+import { type PendingEvent, postEvent } from './post-event.ts';
+
+export async function flushEventsFile(file: string): Promise<void> {
+  const events: PendingEvent[] = JSON.parse(await readFile(file, 'utf8'));
+  await rm(file, { force: true });
+  await Promise.all(
+    events.map((event) =>
+      postEvent(event, { signal: AbortSignal.timeout(30_000), keepProcessAlive: true }).catch(
+        () => {}
+      )
+    )
+  );
+}

--- a/code/core/src/telemetry/flush-events-file.ts
+++ b/code/core/src/telemetry/flush-events-file.ts
@@ -3,13 +3,10 @@ import { readFile, rm } from 'node:fs/promises';
 import { type PendingEvent, postEvent } from './post-event.ts';
 
 export async function flushEventsFile(file: string): Promise<void> {
-  const events: PendingEvent[] = JSON.parse(await readFile(file, 'utf8'));
+  const contents = await readFile(file, 'utf8');
   await rm(file, { force: true });
+  const events: PendingEvent[] = JSON.parse(contents);
   await Promise.all(
-    events.map((event) =>
-      postEvent(event, { signal: AbortSignal.timeout(30_000), keepProcessAlive: true }).catch(
-        () => {}
-      )
-    )
+    events.map((event) => postEvent(event, { keepProcessAlive: true }).catch(() => {}))
   );
 }

--- a/code/core/src/telemetry/post-event.test.ts
+++ b/code/core/src/telemetry/post-event.test.ts
@@ -1,7 +1,9 @@
 import { afterAll, afterEach, beforeAll, expect, it, vi } from 'vitest';
 
+import { spawn } from 'node:child_process';
 import { type Server, createServer } from 'node:http';
 import { Socket } from 'node:net';
+import { fileURLToPath } from 'node:url';
 
 import type { postEvent as PostEvent } from './post-event.ts';
 
@@ -91,4 +93,35 @@ it('unrefs the socket while the request is in flight, unless it may keep the pro
 
   expect(await inFlight(false)).toBeGreaterThan(0);
   expect(await inFlight(true)).toBe(0);
+});
+
+const postFromChildProcess = (keepProcessAlive: boolean, retryDelay: number) => {
+  const script = fileURLToPath(new URL('./post-event.ts', import.meta.url));
+  const child = spawn(
+    process.execPath,
+    [
+      '--input-type=module',
+      '-e',
+      `import { postEvent } from ${JSON.stringify(script)};
+       postEvent(${JSON.stringify({ ...event, retryDelay })}, { keepProcessAlive: ${keepProcessAlive} });`,
+    ],
+    { env: process.env, stdio: 'ignore' }
+  );
+  return new Promise<number | null>((resolve) => child.on('exit', resolve));
+};
+
+it('keeps the process alive through the retry back-off when asked to', async () => {
+  responses = [503, 200];
+
+  expect(await postFromChildProcess(true, 50)).toBe(0);
+
+  expect(received).toBe(2);
+});
+
+it('lets the process exit during the retry back-off otherwise', async () => {
+  responses = [503, 200];
+
+  expect(await postFromChildProcess(false, 5000)).toBe(0);
+
+  expect(received).toBe(1);
 });

--- a/code/core/src/telemetry/post-event.test.ts
+++ b/code/core/src/telemetry/post-event.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, afterEach, beforeAll, expect, it, vi } from 'vitest';
+
+import { type Server, createServer } from 'node:http';
+import { Socket } from 'node:net';
+
+import type { postEvent as PostEvent } from './post-event.ts';
+
+let server: Server;
+let postEvent: typeof PostEvent;
+let responses: Array<number | 'hang'> = [];
+let received = 0;
+
+beforeAll(async () => {
+  server = createServer((request, response) => {
+    received += 1;
+    request.resume();
+    const next = responses.shift() ?? 200;
+    if (next === 'hang') {
+      return;
+    }
+    request.on('end', () => {
+      response.writeHead(next);
+      response.end();
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as { port: number };
+  vi.stubEnv('STORYBOOK_TELEMETRY_URL', `http://127.0.0.1:${port}/event-log`);
+  ({ postEvent } = await import('./post-event.ts'));
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+  server.closeAllConnections();
+  server.close();
+});
+
+afterEach(() => {
+  responses = [];
+  received = 0;
+  vi.restoreAllMocks();
+});
+
+const event = { body: { eventType: 'dev', eventId: 'e1' } as any, retryDelay: 0 };
+
+it('posts the event once when the server accepts it', async () => {
+  await postEvent(event, { signal: AbortSignal.timeout(1000), keepProcessAlive: true });
+
+  expect(received).toBe(1);
+});
+
+it('retries a 503 response', async () => {
+  responses = [503, 200];
+
+  await postEvent(event, { signal: AbortSignal.timeout(1000), keepProcessAlive: true });
+
+  expect(received).toBe(2);
+});
+
+it('gives up after three retries', async () => {
+  responses = [503, 503, 503, 503, 503];
+
+  await postEvent(event, { signal: AbortSignal.timeout(1000), keepProcessAlive: true });
+
+  expect(received).toBe(4);
+});
+
+it('abandons a request that never responds once the signal aborts', async () => {
+  responses = ['hang'];
+
+  await expect(
+    postEvent(event, { signal: AbortSignal.timeout(50), keepProcessAlive: true })
+  ).rejects.toThrow();
+  expect(received).toBe(1);
+});
+
+it('unrefs the socket while the request is in flight, unless it may keep the process alive', async () => {
+  const unref = vi.spyOn(Socket.prototype, 'unref');
+  const inFlight = async (keepProcessAlive: boolean) => {
+    responses = ['hang'];
+    const controller = new AbortController();
+    const request = postEvent(event, { signal: controller.signal, keepProcessAlive });
+    await vi.waitFor(() => expect(received).toBe(1));
+    const unrefCalls = unref.mock.calls.length;
+    controller.abort();
+    await request.catch(() => {});
+    received = 0;
+    unref.mockClear();
+    return unrefCalls;
+  };
+
+  expect(await inFlight(false)).toBeGreaterThan(0);
+  expect(await inFlight(true)).toBe(0);
+});

--- a/code/core/src/telemetry/post-event.ts
+++ b/code/core/src/telemetry/post-event.ts
@@ -18,6 +18,7 @@ export type PostOptions = {
 };
 
 const TELEMETRY_URL = process.env.STORYBOOK_TELEMETRY_URL || 'https://storybook.js.org/event-log';
+const request = TELEMETRY_URL.startsWith('https:') ? httpsRequest : httpRequest;
 
 const TIMEOUT = 30_000;
 const MAX_ATTEMPTS = 4;
@@ -45,7 +46,6 @@ export async function postEvent(
 }
 
 function post(payload: string, signal: AbortSignal, keepProcessAlive: boolean): Promise<number> {
-  const request = TELEMETRY_URL.startsWith('https:') ? httpsRequest : httpRequest;
   return new Promise((resolve, reject) => {
     const outgoing = request(
       TELEMETRY_URL,

--- a/code/core/src/telemetry/post-event.ts
+++ b/code/core/src/telemetry/post-event.ts
@@ -9,42 +9,41 @@ export type PendingEvent = {
 };
 
 export type PostOptions = {
-  signal: AbortSignal;
-  /**
-   * Whether the request may keep the process alive until its response arrives. A process that
-   * exits with unfinished requests hands them to a detached child, so only that child, and an
-   * `immediate` send, hold on to it.
-   */
+  // Whether the request and its retry back-off may keep the process alive until the response
+  // arrives. The detached child and `immediate` sends do; everything else is handed to the
+  // child on exit instead.
   keepProcessAlive: boolean;
+  signal?: AbortSignal;
 };
 
 const TELEMETRY_URL = process.env.STORYBOOK_TELEMETRY_URL || 'https://storybook.js.org/event-log';
 
+const TIMEOUT = 30_000;
 const MAX_ATTEMPTS = 4;
 const RETRYABLE_STATUSES = new Set([503, 504]);
 
 export async function postEvent(
   { body, retryDelay = 1000 }: PendingEvent,
-  options: PostOptions
+  { keepProcessAlive, signal = AbortSignal.timeout(TIMEOUT) }: PostOptions
 ): Promise<void> {
   const payload = JSON.stringify(body);
   for (let attempt = 0; ; attempt += 1) {
     const lastAttempt = attempt === MAX_ATTEMPTS - 1;
     try {
-      const status = await post(payload, options);
+      const status = await post(payload, signal, keepProcessAlive);
       if (!RETRYABLE_STATUSES.has(status) || lastAttempt) {
         return;
       }
     } catch (error) {
-      if (options.signal.aborted || lastAttempt) {
+      if (signal.aborted || lastAttempt) {
         throw error;
       }
     }
-    await sleep(2 ** attempt * retryDelay, options.signal);
+    await sleep(2 ** attempt * retryDelay, signal, keepProcessAlive);
   }
 }
 
-function post(payload: string, { signal, keepProcessAlive }: PostOptions): Promise<number> {
+function post(payload: string, signal: AbortSignal, keepProcessAlive: boolean): Promise<number> {
   const request = TELEMETRY_URL.startsWith('https:') ? httpsRequest : httpRequest;
   return new Promise((resolve, reject) => {
     const outgoing = request(
@@ -71,17 +70,19 @@ function post(payload: string, { signal, keepProcessAlive }: PostOptions): Promi
   });
 }
 
-function sleep(ms: number, signal: AbortSignal): Promise<void> {
+function sleep(ms: number, signal: AbortSignal, keepProcessAlive: boolean): Promise<void> {
   return new Promise((resolve, reject) => {
-    const timer = setTimeout(resolve, ms);
-    timer.unref();
-    signal.addEventListener(
-      'abort',
-      () => {
-        clearTimeout(timer);
-        reject(signal.reason);
-      },
-      { once: true }
-    );
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal.reason);
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    if (!keepProcessAlive) {
+      timer.unref();
+    }
+    signal.addEventListener('abort', onAbort, { once: true });
   });
 }

--- a/code/core/src/telemetry/post-event.ts
+++ b/code/core/src/telemetry/post-event.ts
@@ -1,5 +1,6 @@
 import { request as httpRequest } from 'node:http';
 import { request as httpsRequest } from 'node:https';
+import { setTimeout as sleep } from 'node:timers/promises';
 
 import type { TelemetryEvent } from './types.ts';
 
@@ -39,7 +40,7 @@ export async function postEvent(
         throw error;
       }
     }
-    await sleep(2 ** attempt * retryDelay, signal, keepProcessAlive);
+    await sleep(2 ** attempt * retryDelay, undefined, { signal, ref: keepProcessAlive });
   }
 }
 
@@ -67,22 +68,5 @@ function post(payload: string, signal: AbortSignal, keepProcessAlive: boolean): 
     }
     outgoing.on('error', reject);
     outgoing.end(payload);
-  });
-}
-
-function sleep(ms: number, signal: AbortSignal, keepProcessAlive: boolean): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const onAbort = () => {
-      clearTimeout(timer);
-      reject(signal.reason);
-    };
-    const timer = setTimeout(() => {
-      signal.removeEventListener('abort', onAbort);
-      resolve();
-    }, ms);
-    if (!keepProcessAlive) {
-      timer.unref();
-    }
-    signal.addEventListener('abort', onAbort, { once: true });
   });
 }

--- a/code/core/src/telemetry/post-event.ts
+++ b/code/core/src/telemetry/post-event.ts
@@ -1,0 +1,87 @@
+import { request as httpRequest } from 'node:http';
+import { request as httpsRequest } from 'node:https';
+
+import type { TelemetryEvent } from './types.ts';
+
+export type PendingEvent = {
+  body: TelemetryEvent;
+  retryDelay?: number;
+};
+
+export type PostOptions = {
+  signal: AbortSignal;
+  /**
+   * Whether the request may keep the process alive until its response arrives. A process that
+   * exits with unfinished requests hands them to a detached child, so only that child, and an
+   * `immediate` send, hold on to it.
+   */
+  keepProcessAlive: boolean;
+};
+
+const TELEMETRY_URL = process.env.STORYBOOK_TELEMETRY_URL || 'https://storybook.js.org/event-log';
+
+const MAX_ATTEMPTS = 4;
+const RETRYABLE_STATUSES = new Set([503, 504]);
+
+export async function postEvent(
+  { body, retryDelay = 1000 }: PendingEvent,
+  options: PostOptions
+): Promise<void> {
+  const payload = JSON.stringify(body);
+  for (let attempt = 0; ; attempt += 1) {
+    const lastAttempt = attempt === MAX_ATTEMPTS - 1;
+    try {
+      const status = await post(payload, options);
+      if (!RETRYABLE_STATUSES.has(status) || lastAttempt) {
+        return;
+      }
+    } catch (error) {
+      if (options.signal.aborted || lastAttempt) {
+        throw error;
+      }
+    }
+    await sleep(2 ** attempt * retryDelay, options.signal);
+  }
+}
+
+function post(payload: string, { signal, keepProcessAlive }: PostOptions): Promise<number> {
+  const request = TELEMETRY_URL.startsWith('https:') ? httpsRequest : httpRequest;
+  return new Promise((resolve, reject) => {
+    const outgoing = request(
+      TELEMETRY_URL,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(payload),
+        },
+        signal,
+      },
+      (response) => {
+        response.resume();
+        response.on('end', () => resolve(response.statusCode ?? 0));
+        response.on('error', reject);
+      }
+    );
+    if (!keepProcessAlive) {
+      outgoing.on('socket', (socket) => socket.unref());
+    }
+    outgoing.on('error', reject);
+    outgoing.end(payload);
+  });
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref();
+    signal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        reject(signal.reason);
+      },
+      { once: true }
+    );
+  });
+}

--- a/code/core/src/telemetry/post-event.ts
+++ b/code/core/src/telemetry/post-event.ts
@@ -10,9 +10,8 @@ export type PendingEvent = {
 };
 
 export type PostOptions = {
-  // Whether the request and its retry back-off may keep the process alive until the response
-  // arrives. The detached child and `immediate` sends do; everything else is handed to the
-  // child on exit instead.
+  // Only the detached child holds the process open for a response; the parent hands its
+  // unfinished requests to that child on exit.
   keepProcessAlive: boolean;
   signal?: AbortSignal;
 };

--- a/code/core/src/telemetry/session-id.test.ts
+++ b/code/core/src/telemetry/session-id.test.ts
@@ -10,8 +10,8 @@ import { SESSION_TIMEOUT, getSessionId, resetSessionIdForTest } from './session-
 vi.mock('storybook/internal/common', async (importOriginal) => ({
   ...(await importOriginal<typeof import('storybook/internal/common')>()),
   cache: {
-    get: vi.fn(),
-    set: vi.fn(),
+    getSync: vi.fn(),
+    setSync: vi.fn(),
   },
 }));
 vi.mock('nanoid');
@@ -28,11 +28,11 @@ describe('getSessionId', () => {
     const existingSessionId = 'memory-session-id';
     resetSessionIdForTest(existingSessionId);
 
-    const sessionId = await getSessionId();
+    const sessionId = getSessionId();
 
-    expect(cache.get).not.toHaveBeenCalled();
-    expect(cache.set).toHaveBeenCalledTimes(1);
-    expect(cache.set).toHaveBeenCalledWith(
+    expect(cache.getSync).not.toHaveBeenCalled();
+    expect(cache.setSync).toHaveBeenCalledTimes(1);
+    expect(cache.setSync).toHaveBeenCalledWith(
       'session',
       expect.objectContaining({ id: existingSessionId })
     );
@@ -46,14 +46,14 @@ describe('getSessionId', () => {
       lastUsed: Date.now() - SESSION_TIMEOUT + 1000,
     };
 
-    spy(cache.get).mockResolvedValueOnce(existingSession);
+    spy(cache.getSync).mockReturnValueOnce(existingSession);
 
-    const sessionId = await getSessionId();
+    const sessionId = getSessionId();
 
-    expect(cache.get).toHaveBeenCalledTimes(1);
-    expect(cache.get).toHaveBeenCalledWith('session');
-    expect(cache.set).toHaveBeenCalledTimes(1);
-    expect(cache.set).toHaveBeenCalledWith(
+    expect(cache.getSync).toHaveBeenCalledTimes(1);
+    expect(cache.getSync).toHaveBeenCalledWith('session');
+    expect(cache.setSync).toHaveBeenCalledTimes(1);
+    expect(cache.setSync).toHaveBeenCalledWith(
       'session',
       expect.objectContaining({ id: existingSessionId })
     );
@@ -64,15 +64,15 @@ describe('getSessionId', () => {
     const newSessionId = 'new-session-id';
     (nanoid as unknown as MockInstance).mockReturnValueOnce(newSessionId);
 
-    spy(cache.get).mockResolvedValueOnce(undefined);
+    spy(cache.getSync).mockReturnValueOnce(undefined);
 
-    const sessionId = await getSessionId();
+    const sessionId = getSessionId();
 
-    expect(cache.get).toHaveBeenCalledTimes(1);
-    expect(cache.get).toHaveBeenCalledWith('session');
+    expect(cache.getSync).toHaveBeenCalledTimes(1);
+    expect(cache.getSync).toHaveBeenCalledWith('session');
     expect(nanoid).toHaveBeenCalledTimes(1);
-    expect(cache.set).toHaveBeenCalledTimes(1);
-    expect(cache.set).toHaveBeenCalledWith(
+    expect(cache.setSync).toHaveBeenCalledTimes(1);
+    expect(cache.setSync).toHaveBeenCalledWith(
       'session',
       expect.objectContaining({ id: newSessionId })
     );
@@ -85,18 +85,29 @@ describe('getSessionId', () => {
     const newSessionId = 'new-session-id';
     spy(nanoid).mockReturnValueOnce(newSessionId);
 
-    spy(cache.get).mockResolvedValueOnce(expiredSession);
+    spy(cache.getSync).mockReturnValueOnce(expiredSession);
 
-    const sessionId = await getSessionId();
+    const sessionId = getSessionId();
 
-    expect(cache.get).toHaveBeenCalledTimes(1);
-    expect(cache.get).toHaveBeenCalledWith('session');
+    expect(cache.getSync).toHaveBeenCalledTimes(1);
+    expect(cache.getSync).toHaveBeenCalledWith('session');
     expect(nanoid).toHaveBeenCalledTimes(1);
-    expect(cache.set).toHaveBeenCalledTimes(1);
-    expect(cache.set).toHaveBeenCalledWith(
+    expect(cache.setSync).toHaveBeenCalledTimes(1);
+    expect(cache.setSync).toHaveBeenCalledWith(
       'session',
       expect.objectContaining({ id: newSessionId })
     );
     expect(sessionId).toBe(newSessionId);
+  });
+});
+
+describe('getSessionId when the cache cannot be written', () => {
+  it('still returns the session id', () => {
+    resetSessionIdForTest('memory-session-id');
+    spy(cache.setSync).mockImplementationOnce(() => {
+      throw new Error('read-only');
+    });
+
+    expect(getSessionId()).toBe('memory-session-id');
   });
 });

--- a/code/core/src/telemetry/session-id.ts
+++ b/code/core/src/telemetry/session-id.ts
@@ -15,16 +15,17 @@ export const resetSessionIdForTest = (val: string | undefined = undefined) => {
   sessionId = val;
 };
 
-export const getSessionId = async () => {
+// Synchronous so an event is fully built, and can be handed off on exit, without an await in between.
+export const getSessionId = () => {
   const now = Date.now();
   if (!sessionId) {
-    const session: Session | undefined = await cache.get('session');
-    if (session && session.lastUsed >= now - SESSION_TIMEOUT) {
-      sessionId = session.id;
-    } else {
-      sessionId = nanoid();
-    }
+    const session = cache.getSync<Session | undefined>('session');
+    sessionId = session && session.lastUsed >= now - SESSION_TIMEOUT ? session.id : nanoid();
   }
-  await cache.set('session', { id: sessionId, lastUsed: now });
+  try {
+    cache.setSync('session', { id: sessionId, lastUsed: now });
+  } catch {
+    // An unwritable cache must not cost the event; the session just restarts next time.
+  }
   return sessionId;
 };

--- a/code/core/src/telemetry/telemetry.test.ts
+++ b/code/core/src/telemetry/telemetry.test.ts
@@ -11,8 +11,8 @@ import { postEvent } from './post-event.ts';
 import { handOffPendingEvents, sendTelemetry } from './telemetry.ts';
 
 vi.mock('./post-event.ts', () => ({ postEvent: vi.fn(async () => {}) }));
-vi.mock('./event-cache', () => ({ set: vi.fn() }));
-vi.mock('./session-id', () => ({ getSessionId: vi.fn(() => 'session-id') }));
+vi.mock('./event-cache.ts', () => ({ set: vi.fn() }));
+vi.mock('./session-id.ts', () => ({ getSessionId: vi.fn(() => 'session-id') }));
 vi.mock('node:fs', { spy: true });
 vi.mock('node:child_process', async (importOriginal) => ({
   ...(await importOriginal<typeof import('node:child_process')>()),
@@ -75,6 +75,32 @@ it('waits for the response and holds the process when immediate', async () => {
 
   expect(responded).toBe(true);
   expect(postMock.mock.calls[0][1]).toMatchObject({ keepProcessAlive: true });
+});
+
+it('waits for the responses of earlier events too when immediate', async () => {
+  let earlierResponded = false;
+  postMock.mockImplementationOnce(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    earlierResponded = true;
+  });
+  await sendTelemetry({ eventType: 'dev', payload: {} });
+  expect(earlierResponded).toBe(false);
+
+  await sendTelemetry({ eventType: 'error', payload: {} }, { immediate: true });
+
+  expect(earlierResponded).toBe(true);
+});
+
+it('registers the exit hook once, with the first event', async () => {
+  vi.resetModules();
+  const once = vi.spyOn(process, 'once');
+  const { sendTelemetry: send } = await import('./telemetry.ts');
+
+  await send({ eventType: 'dev', payload: {} });
+  await send({ eventType: 'build', payload: {} });
+
+  expect(once.mock.calls.filter(([name]) => name === 'exit')).toHaveLength(1);
+  once.mockRestore();
 });
 
 it('hands events without a response to a detached process on exit, once', async () => {

--- a/code/core/src/telemetry/telemetry.test.ts
+++ b/code/core/src/telemetry/telemetry.test.ts
@@ -77,20 +77,6 @@ it('waits for the response and holds the process when immediate', async () => {
   expect(postMock.mock.calls[0][1]).toMatchObject({ keepProcessAlive: true });
 });
 
-it('waits for the responses of earlier events too when immediate', async () => {
-  let earlierResponded = false;
-  postMock.mockImplementationOnce(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    earlierResponded = true;
-  });
-  await sendTelemetry({ eventType: 'dev', payload: {} });
-  expect(earlierResponded).toBe(false);
-
-  await sendTelemetry({ eventType: 'error', payload: {} }, { immediate: true });
-
-  expect(earlierResponded).toBe(true);
-});
-
 it('registers the exit hook once, with the first event', async () => {
   vi.resetModules();
   const once = vi.spyOn(process, 'once');

--- a/code/core/src/telemetry/telemetry.test.ts
+++ b/code/core/src/telemetry/telemetry.test.ts
@@ -77,15 +77,13 @@ it('waits for the response and holds the process when immediate', async () => {
   expect(postMock.mock.calls[0][1]).toMatchObject({ keepProcessAlive: true });
 });
 
-it('registers the exit hook once, with the first event', async () => {
+it('registers the exit hook when loaded', async () => {
   vi.resetModules();
   const once = vi.spyOn(process, 'once');
-  const { sendTelemetry: send } = await import('./telemetry.ts');
 
-  await send({ eventType: 'dev', payload: {} });
-  await send({ eventType: 'build', payload: {} });
+  await import('./telemetry.ts');
 
-  expect(once.mock.calls.filter(([name]) => name === 'exit')).toHaveLength(1);
+  expect(once).toHaveBeenCalledWith('exit', expect.any(Function));
   once.mockRestore();
 });
 

--- a/code/core/src/telemetry/telemetry.test.ts
+++ b/code/core/src/telemetry/telemetry.test.ts
@@ -64,19 +64,6 @@ it('returns as soon as the request is started, without waiting for the response'
   expect(postMock).toHaveBeenCalledTimes(1);
 });
 
-it('waits for the response and holds the process when immediate', async () => {
-  let responded = false;
-  postMock.mockImplementation(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    responded = true;
-  });
-
-  await sendTelemetry({ eventType: 'error', payload: {} }, { immediate: true });
-
-  expect(responded).toBe(true);
-  expect(postMock.mock.calls[0][1]).toMatchObject({ keepProcessAlive: true });
-});
-
 it('registers the exit hook when loaded', async () => {
   vi.resetModules();
   const once = vi.spyOn(process, 'once');

--- a/code/core/src/telemetry/telemetry.test.ts
+++ b/code/core/src/telemetry/telemetry.test.ts
@@ -1,150 +1,135 @@
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 
-import { fetch } from './fetch.ts';
-import { sendTelemetry } from './telemetry.ts';
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
 
-vi.mock('./fetch');
-vi.mock('./event-cache', () => {
-  return { set: vi.fn() };
-});
+import * as memfs from 'memfs';
+import { vol } from 'memfs';
 
-vi.mock('./session-id', () => {
-  return {
-    getSessionId: async () => {
-      return 'session-id';
-    },
-  };
-});
+import { postEvent } from './post-event.ts';
+import { handOffPendingEvents, sendTelemetry } from './telemetry.ts';
 
-const fetchMock = vi.mocked(fetch);
+vi.mock('./post-event.ts', () => ({ postEvent: vi.fn(async () => {}) }));
+vi.mock('./event-cache', () => ({ set: vi.fn() }));
+vi.mock('./session-id', () => ({ getSessionId: vi.fn(() => 'session-id') }));
+vi.mock('node:fs', { spy: true });
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:child_process')>()),
+  spawn: vi.fn(() => ({ unref: vi.fn() })),
+}));
+
+const postMock = vi.mocked(postEvent);
+
+const neverResponds = () => new Promise<void>(() => {});
 
 beforeEach(() => {
-  fetchMock.mockResolvedValue({ status: 200 } as any);
+  vol.reset();
+  vol.mkdirSync(os.tmpdir(), { recursive: true });
+  vi.mocked(fs.writeFileSync).mockImplementation(memfs.fs.writeFileSync as any);
+  vi.mocked(fs.rmSync).mockImplementation(memfs.fs.rmSync as any);
+  postMock.mockImplementation(async () => {});
 });
 
 afterEach(() => {
-  vi.restoreAllMocks();
+  handOffPendingEvents();
+  vi.clearAllMocks();
 });
 
-it('makes a fetch request with name and data', async () => {
+const writtenEvents = () =>
+  Object.entries(vol.toJSON())
+    .filter(([file]) => file.includes('storybook-telemetry-'))
+    .map(([file, contents]) => [file, JSON.parse(contents as string)] as const);
+
+it('posts the event with its data and context, without holding the process', async () => {
   await sendTelemetry({ eventType: 'dev', payload: { foo: 'bar' } });
 
-  expect(fetchMock).toHaveBeenCalledTimes(1);
-  const body = JSON.parse(fetchMock?.mock?.calls?.[0]?.[1]?.body as any);
-  expect(body).toMatchObject({
+  expect(postMock).toHaveBeenCalledTimes(1);
+  const [event, options] = postMock.mock.calls[0];
+  expect(event.body).toMatchObject({
     eventType: 'dev',
     payload: { foo: 'bar' },
+    sessionId: 'session-id',
+    eventId: expect.any(String),
+    context: { storybookVersion: expect.any(String) },
   });
+  expect(options).toMatchObject({ keepProcessAlive: false });
 });
 
-it('abandons a request that never responds, instead of hanging the process', async () => {
-  const controller = new AbortController();
-  const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(controller.signal);
+it('returns as soon as the request is started, without waiting for the response', async () => {
+  postMock.mockImplementation(neverResponds);
 
-  // fetch that never settles on its own - it only rejects once its signal aborts, which we control via the timeoutSpy above.
-  fetchMock.mockImplementation(
-    (_url, init) =>
-      new Promise((_resolve, reject) => {
-        const signal = (init as RequestInit | undefined)?.signal;
-        if (signal?.aborted) {
-          reject(signal.reason);
-        } else {
-          signal?.addEventListener('abort', () => reject(signal.reason));
-        }
-      })
-  );
+  await sendTelemetry({ eventType: 'dev', payload: {} });
 
-  let settled = false;
-  const promise = sendTelemetry({ eventType: 'dev', payload: { foo: 'bar' } }).finally(() => {
-    settled = true;
-  });
-
-  // Let the request reach its in-flight state.
-  await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
-  expect(timeoutSpy).toHaveBeenCalledWith(30_000);
-  expect(settled).toBe(false);
-
-  // Abort the request, simulating the timeout expiring. This should cause the promise to reject and the sendTelemetry
-  // call to settle, instead of hanging indefinitely.
-  controller.abort();
-
-  await promise;
-
-  expect(settled).toBe(true);
-
-  // Ensure the aborted request is not retried
-  expect(fetchMock).toHaveBeenCalledTimes(1);
+  expect(postMock).toHaveBeenCalledTimes(1);
 });
 
-it('retries if fetch fails with a 503', async () => {
-  fetchMock.mockResolvedValueOnce({ status: 503 } as any);
-  await sendTelemetry(
-    {
-      eventType: 'dev',
-      payload: { foo: 'bar' },
-    },
-    { retryDelay: 0 }
-  );
+it('waits for the response and holds the process when immediate', async () => {
+  let responded = false;
+  postMock.mockImplementation(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    responded = true;
+  });
 
-  expect(fetchMock).toHaveBeenCalledTimes(2);
+  await sendTelemetry({ eventType: 'error', payload: {} }, { immediate: true });
+
+  expect(responded).toBe(true);
+  expect(postMock.mock.calls[0][1]).toMatchObject({ keepProcessAlive: true });
 });
 
-it('gives up if fetch repeatedly fails', async () => {
-  fetchMock.mockResolvedValue({ status: 503 } as any);
-  await sendTelemetry(
-    {
-      eventType: 'dev',
-      payload: { foo: 'bar' },
-    },
-    { retryDelay: 0 }
-  );
+it('hands events without a response to a detached process on exit, once', async () => {
+  postMock.mockImplementation(neverResponds);
+  await sendTelemetry({ eventType: 'dev', payload: {} });
+  await sendTelemetry({ eventType: 'build', payload: {} }, { retryDelay: 5 });
 
-  expect(fetchMock).toHaveBeenCalledTimes(4);
+  handOffPendingEvents();
+  handOffPendingEvents();
+
+  expect(writtenEvents()).toEqual([
+    [
+      expect.stringMatching(/storybook-telemetry-.*\.json$/),
+      [
+        { body: expect.objectContaining({ eventType: 'dev' }) },
+        { body: expect.objectContaining({ eventType: 'build' }), retryDelay: 5 },
+      ],
+    ],
+  ]);
+
+  expect(spawn).toHaveBeenCalledTimes(1);
+  const [command, args, options] = vi.mocked(spawn).mock.calls[0];
+  expect(command).toBe(process.execPath);
+  expect(args).toEqual([expect.stringMatching(/detached-flush/), writtenEvents()[0][0]]);
+  expect(options).toMatchObject({ detached: true, stdio: 'ignore' });
 });
 
-it('await all pending telemetry when passing in immediate = true', async () => {
-  let numberOfResolvedTasks = 0;
+it('hands off nothing when every response has arrived', async () => {
+  await sendTelemetry({ eventType: 'dev', payload: {} });
+  await new Promise((resolve) => setTimeout(resolve, 0));
 
-  fetchMock.mockImplementation(async () => {
-    // wait 10ms so that the "fetch" is still running while
-    // getSessionId resolves immediately below. tricky!
-    await new Promise((resolve) => {
-      setTimeout(resolve, 10);
-    });
-    numberOfResolvedTasks += 1;
-    return { status: 200 } as any;
+  handOffPendingEvents();
+
+  expect(writtenEvents()).toEqual([]);
+  expect(spawn).not.toHaveBeenCalled();
+});
+
+it('removes the file again when the detached process cannot be started', async () => {
+  postMock.mockImplementation(neverResponds);
+  vi.mocked(spawn).mockImplementationOnce(() => {
+    throw new Error('EACCES');
+  });
+  await sendTelemetry({ eventType: 'dev', payload: {} });
+
+  handOffPendingEvents();
+
+  expect(writtenEvents()).toEqual([]);
+});
+
+it('still resolves when the session id cannot be read', async () => {
+  const { getSessionId } = await import('./session-id.ts');
+  vi.mocked(getSessionId).mockImplementationOnce(() => {
+    throw new Error('disk');
   });
 
-  // when we call sendTelemetry with immediate = true
-  // all pending tasks will be awaited
-  // to test this we add a few telemetry tasks that will be in the 'queue'
-  // we do NOT await these tasks!
-  sendTelemetry({
-    eventType: 'init',
-    payload: { foo: 'bar' },
-  });
-  sendTelemetry({
-    eventType: 'dev',
-    payload: { foo: 'bar' },
-  });
-
-  // wait for getSessionId to finish, but not for fetches
-  await new Promise((resolve) => {
-    setTimeout(resolve, 0);
-  });
-
-  expect(fetchMock).toHaveBeenCalledTimes(2);
-  expect(numberOfResolvedTasks).toBe(0);
-
-  // here we await
-  await sendTelemetry(
-    {
-      eventType: 'error',
-      payload: { foo: 'bar' },
-    },
-    { retryDelay: 0, immediate: true }
-  );
-
-  expect(fetchMock).toHaveBeenCalledTimes(3);
-  expect(numberOfResolvedTasks).toBe(3);
+  await expect(sendTelemetry({ eventType: 'dev', payload: {} })).resolves.toBeUndefined();
+  expect(postMock).not.toHaveBeenCalled();
 });

--- a/code/core/src/telemetry/telemetry.ts
+++ b/code/core/src/telemetry/telemetry.ts
@@ -92,13 +92,13 @@ export async function sendTelemetry(data: TelemetryData, options: Partial<Option
       context,
     };
     const event: PendingEvent = { body, retryDelay: options.retryDelay };
-    const request = postEvent(event, { keepProcessAlive: options.immediate === true })
+    const request = postEvent(event, { keepProcessAlive: false })
       .catch(() => {})
       .finally(() => inFlight.delete(body.eventId));
 
     inFlight.set(body.eventId, event);
 
-    await Promise.all([options.immediate ? request : undefined, saveToCache(eventType, body)]);
+    await saveToCache(eventType, body);
   } catch (err) {
     //
   }

--- a/code/core/src/telemetry/telemetry.ts
+++ b/code/core/src/telemetry/telemetry.ts
@@ -94,17 +94,17 @@ export async function sendTelemetry(data: TelemetryData, options: Partial<Option
       context,
     };
     const event: PendingEvent = { body, retryDelay: options.retryDelay };
-    const request = postEvent(event, {
-      signal: AbortSignal.timeout(30_000),
-      keepProcessAlive: options.immediate === true,
-    })
+    const request = postEvent(event, { keepProcessAlive: options.immediate === true })
       .catch(() => {})
       .finally(() => inFlight.delete(body.eventId));
 
     inFlight.set(body.eventId, { event, request });
     registerExitHook();
 
-    await Promise.all([options.immediate ? request : undefined, saveToCache(eventType, body)]);
+    // An immediate send usually precedes a process.exit(), so it also waits for the responses
+    // that earlier sends are still expecting.
+    const responses = options.immediate ? [...inFlight.values()].map((i) => i.request) : [];
+    await Promise.all([...responses, saveToCache(eventType, body)]);
   } catch (err) {
     //
   }

--- a/code/core/src/telemetry/telemetry.ts
+++ b/code/core/src/telemetry/telemetry.ts
@@ -18,9 +18,7 @@ import { type PendingEvent, postEvent } from './post-event.ts';
 import { getSessionId } from './session-id.ts';
 import type { Options, TelemetryData, TelemetryEvent } from './types.ts';
 
-type InFlight = { event: PendingEvent; request: Promise<void> };
-
-const inFlight = new Map<string, InFlight>();
+const inFlight = new Map<string, PendingEvent>();
 let exitHookRegistered = false;
 
 export const addToGlobalContext = (key: string, value: any) => {
@@ -98,13 +96,10 @@ export async function sendTelemetry(data: TelemetryData, options: Partial<Option
       .catch(() => {})
       .finally(() => inFlight.delete(body.eventId));
 
-    inFlight.set(body.eventId, { event, request });
+    inFlight.set(body.eventId, event);
     registerExitHook();
 
-    // An immediate send usually precedes a process.exit(), so it also waits for the responses
-    // that earlier sends are still expecting.
-    const responses = options.immediate ? [...inFlight.values()].map((i) => i.request) : [];
-    await Promise.all([...responses, saveToCache(eventType, body)]);
+    await Promise.all([options.immediate ? request : undefined, saveToCache(eventType, body)]);
   } catch (err) {
     //
   }
@@ -123,7 +118,7 @@ export function handOffPendingEvents() {
   if (inFlight.size === 0) {
     return;
   }
-  const events = [...inFlight.values()].map(({ event }) => event);
+  const events = [...inFlight.values()];
   inFlight.clear();
   const file = join(os.tmpdir(), `storybook-telemetry-${nanoid()}.json`);
   try {

--- a/code/core/src/telemetry/telemetry.ts
+++ b/code/core/src/telemetry/telemetry.ts
@@ -1,27 +1,27 @@
 /// <reference types="node" />
-import { readFileSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { readFileSync, rmSync, writeFileSync } from 'node:fs';
 import * as os from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { isCI } from 'storybook/internal/common';
 
-import retry from 'fetch-retry';
 import { nanoid } from 'nanoid';
 
 import { version } from '../../package.json';
-import { resolvePackageDir } from '../shared/utils/module.ts';
+import { importMetaResolve, resolvePackageDir } from '../shared/utils/module.ts';
 import { getAnonymousProjectId, getProjectSince } from './anonymous-id.ts';
 import { detectAgent } from './detect-agent.ts';
 import { set as saveToCache } from './event-cache.ts';
-import { fetch } from './fetch.ts';
+import { type PendingEvent, postEvent } from './post-event.ts';
 import { getSessionId } from './session-id.ts';
-import type { Options, TelemetryData } from './types.ts';
+import type { Options, TelemetryData, TelemetryEvent } from './types.ts';
 
-const retryingFetch = retry(fetch);
+type InFlight = { event: PendingEvent; request: Promise<void> };
 
-const URL = process.env.STORYBOOK_TELEMETRY_URL || 'https://storybook.js.org/event-log';
-
-let tasks: Promise<any>[] = [];
+const inFlight = new Map<string, InFlight>();
+let exitHookRegistered = false;
 
 export const addToGlobalContext = (key: string, value: any) => {
   globalContext[key] = value;
@@ -61,36 +61,6 @@ const globalContext = {
   storybookVersion: getVersionNumber(),
 } as Record<string, any>;
 
-const prepareRequest = async (data: TelemetryData, context: Record<string, any>, options: any) => {
-  const { eventType, payload, metadata, ...rest } = data;
-  const sessionId = await getSessionId();
-  const eventId = nanoid();
-  const body = { ...rest, eventType, eventId, sessionId, metadata, payload, context };
-  const signal = AbortSignal.timeout(30_000);
-  const maxRetries = 3;
-
-  return retryingFetch(URL, {
-    method: 'post',
-    body: JSON.stringify(body),
-    headers: { 'Content-Type': 'application/json' },
-    retryDelay: (attempt: number) =>
-      2 ** attempt *
-      (typeof options?.retryDelay === 'number' && !Number.isNaN(options?.retryDelay)
-        ? options.retryDelay
-        : 1000),
-    retryOn: (attempt, error, response) => {
-      // If explicitly aborted (e.g. by the timeout above), or if we've exhausted our retries, give up.
-      if (signal.aborted || attempt >= maxRetries) {
-        return false;
-      }
-
-      // Retry transient network errors and server-overload responses.
-      return Boolean(error) || response?.status === 503 || response?.status === 504;
-    },
-    signal,
-  });
-};
-
 function getVersionNumber() {
   try {
     return JSON.parse(readFileSync(join(resolvePackageDir('storybook'), 'package.json'), 'utf8'))
@@ -100,17 +70,8 @@ function getVersionNumber() {
   }
 }
 
-export async function sendTelemetry(
-  data: TelemetryData,
-  options: Partial<Options> = { retryDelay: 1000, immediate: false }
-) {
+export async function sendTelemetry(data: TelemetryData, options: Partial<Options> = {}) {
   const { eventType, payload, metadata, ...rest } = data;
-
-  // We use this id so we can de-dupe events that arrive at the index multiple times due to the
-  // use of retries. There are situations in which the request "5xx"s (or times-out), but
-  // the server actually gets the request and stores it anyway.
-
-  // flatten the data before we send it
 
   const context = options.stripMetadata
     ? globalContext
@@ -120,20 +81,60 @@ export async function sendTelemetry(
         projectSince: getProjectSince()?.getTime(),
       };
 
-  let request: any;
   try {
-    request = prepareRequest(data, context, options);
-    tasks.push(request);
+    // The eventId lets the server de-duplicate an event that arrives more than once: a retry
+    // after a timed-out response, or the detached process re-sending what this one had started.
+    const body: TelemetryEvent = {
+      ...rest,
+      eventType,
+      eventId: nanoid(),
+      sessionId: getSessionId(),
+      metadata,
+      payload,
+      context,
+    };
+    const event: PendingEvent = { body, retryDelay: options.retryDelay };
+    const request = postEvent(event, {
+      signal: AbortSignal.timeout(30_000),
+      keepProcessAlive: options.immediate === true,
+    })
+      .catch(() => {})
+      .finally(() => inFlight.delete(body.eventId));
 
-    const sessionId = await getSessionId();
-    const eventId = nanoid();
-    const body = { ...rest, eventType, eventId, sessionId, metadata, payload, context };
+    inFlight.set(body.eventId, { event, request });
+    registerExitHook();
 
-    const waitFor = options.immediate ? tasks : [request];
-    await Promise.all([...waitFor, saveToCache(eventType, body)]);
+    await Promise.all([options.immediate ? request : undefined, saveToCache(eventType, body)]);
   } catch (err) {
     //
-  } finally {
-    tasks = tasks.filter((task) => task !== request);
+  }
+}
+
+function registerExitHook() {
+  if (!exitHookRegistered) {
+    exitHookRegistered = true;
+    process.once('exit', handOffPendingEvents);
+  }
+}
+
+// Runs on process exit, where only synchronous work is possible: the events without a response
+// go to a detached child that outlives this process and posts them.
+export function handOffPendingEvents() {
+  if (inFlight.size === 0) {
+    return;
+  }
+  const events = [...inFlight.values()].map(({ event }) => event);
+  inFlight.clear();
+  const file = join(os.tmpdir(), `storybook-telemetry-${nanoid()}.json`);
+  try {
+    writeFileSync(file, JSON.stringify(events));
+    const script = fileURLToPath(importMetaResolve('storybook/internal/telemetry/detached-flush'));
+    spawn(process.execPath, [script, file], {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+    }).unref();
+  } catch {
+    rmSync(file, { force: true });
   }
 }

--- a/code/core/src/telemetry/telemetry.ts
+++ b/code/core/src/telemetry/telemetry.ts
@@ -19,7 +19,7 @@ import { getSessionId } from './session-id.ts';
 import type { Options, TelemetryData, TelemetryEvent } from './types.ts';
 
 const inFlight = new Map<string, PendingEvent>();
-let exitHookRegistered = false;
+process.once('exit', handOffPendingEvents);
 
 export const addToGlobalContext = (key: string, value: any) => {
   globalContext[key] = value;
@@ -97,18 +97,10 @@ export async function sendTelemetry(data: TelemetryData, options: Partial<Option
       .finally(() => inFlight.delete(body.eventId));
 
     inFlight.set(body.eventId, event);
-    registerExitHook();
 
     await Promise.all([options.immediate ? request : undefined, saveToCache(eventType, body)]);
   } catch (err) {
     //
-  }
-}
-
-function registerExitHook() {
-  if (!exitHookRegistered) {
-    exitHookRegistered = true;
-    process.once('exit', handOffPendingEvents);
   }
 }
 

--- a/code/core/src/telemetry/types.ts
+++ b/code/core/src/telemetry/types.ts
@@ -141,7 +141,6 @@ export interface Context {
 
 export interface Options {
   retryDelay: number;
-  immediate: boolean;
   configDir?: string;
   enableCrashReports?: boolean;
   stripMetadata?: boolean;

--- a/code/lib/create-storybook/src/commands/ProjectDetectionCommand.ts
+++ b/code/lib/create-storybook/src/commands/ProjectDetectionCommand.ts
@@ -120,7 +120,7 @@ We assume that Storybook is already instantiated for your project. Do you still 
         await telemetry(
           'exit',
           { eventType: 'init', reason: 'existing-installation' },
-          { stripMetadata: true, immediate: true }
+          { stripMetadata: true }
         );
         process.exit(0);
       }

--- a/code/lib/create-storybook/src/prompt-cancel.ts
+++ b/code/lib/create-storybook/src/prompt-cancel.ts
@@ -1,28 +1,11 @@
 import type { TelemetryService } from './services/TelemetryService.ts';
 
-const PROMPT_CANCEL_TIMEOUT_MS = 2_000;
-
 export const createPromptCancelOptions = (
   telemetryService: Pick<TelemetryService, 'trackPromptCancel'>,
   promptName: string
 ) => ({
   async onCancel() {
-    let timeout: ReturnType<typeof setTimeout> | undefined;
-    const timeoutPromise = new Promise<void>((resolve) => {
-      timeout = setTimeout(resolve, PROMPT_CANCEL_TIMEOUT_MS);
-      timeout.unref?.();
-    });
-
-    try {
-      await Promise.race([
-        telemetryService.trackPromptCancel(promptName).catch(() => {}),
-        timeoutPromise,
-      ]);
-    } finally {
-      if (timeout !== undefined) {
-        clearTimeout(timeout);
-      }
-    }
+    await telemetryService.trackPromptCancel(promptName).catch(() => {});
     process.exit(0);
   },
 });

--- a/code/lib/create-storybook/src/scaffold-new-project.ts
+++ b/code/lib/create-storybook/src/scaffold-new-project.ts
@@ -142,7 +142,7 @@ export const scaffoldNewProject = async (
     await telemetry(
       'exit',
       { eventType: 'init', reason: 'scaffold-other' },
-      { stripMetadata: true, immediate: true }
+      { stripMetadata: true }
     );
     logger.warn(
       'To install Storybook on another framework, first generate a project with that framework and then rerun this command.'

--- a/code/lib/create-storybook/src/services/TelemetryService.test.ts
+++ b/code/lib/create-storybook/src/services/TelemetryService.test.ts
@@ -99,7 +99,7 @@ describe('TelemetryService', () => {
       expect(telemetry).toHaveBeenCalledWith(
         'canceled',
         { eventType: 'init', prompt: 'new-user-check' },
-        { stripMetadata: true, immediate: true }
+        { stripMetadata: true }
       );
     });
   });

--- a/code/lib/create-storybook/src/services/TelemetryService.ts
+++ b/code/lib/create-storybook/src/services/TelemetryService.ts
@@ -116,10 +116,6 @@ export class TelemetryService {
   }
 
   async trackPromptCancel(prompt: string): Promise<void> {
-    await telemetry(
-      'canceled',
-      { eventType: 'init', prompt },
-      { stripMetadata: true, immediate: true }
-    );
+    await telemetry('canceled', { eventType: 'init', prompt }, { stripMetadata: true });
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23523,13 +23523,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fetch-retry@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "fetch-retry@npm:6.0.0"
-  checksum: 10c0/8e275b042ff98041236d30b71966f24c34ff19f957bb0f00e664754bd63d0dfb5122d091e7d5bca21f6370d88a1713d22421b33471305d7b86d6799427278802
-  languageName: node
-  linkType: hard
-
 "figures@npm:3.2.0":
   version: 3.2.0
   resolution: "figures@npm:3.2.0"
@@ -36659,7 +36652,6 @@ __metadata:
     execa: "npm:^9.6.1"
     exsolve: "npm:^1.0.7"
     extend-to-be-announced: "npm:^2.0.0"
-    fetch-retry: "npm:^6.0.0"
     flush-promises: "npm:^1.0.2"
     fuse.js: "npm:^3.6.1"
     get-npm-tarball-url: "npm:^2.1.0"
@@ -36698,7 +36690,6 @@ __metadata:
     polka: "npm:^1.0.0-next.28"
     prettier: "npm:^3.7.1"
     pretty-hrtime: "npm:^1.0.3"
-    process-ancestry: "npm:^0.0.2"
     qrcode.react: "npm:^4.2.0"
     react: "npm:^18.2.0"
     react-aria-components: "patch:react-aria-components@npm%3A1.12.2#~/.yarn/patches/react-aria-components-npm-1.12.2-6c5dcdafab.patch"

--- a/yarn.lock
+++ b/yarn.lock
@@ -36690,6 +36690,7 @@ __metadata:
     polka: "npm:^1.0.0-next.28"
     prettier: "npm:^3.7.1"
     pretty-hrtime: "npm:^1.0.3"
+    process-ancestry: "npm:^0.0.2"
     qrcode.react: "npm:^4.2.0"
     react: "npm:^18.2.0"
     react-aria-components: "patch:react-aria-components@npm%3A1.12.2#~/.yarn/patches/react-aria-components-npm-1.12.2-6c5dcdafab.patch"


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

No Storybook command waits for the telemetry server any more.

### The problem

Every command ended the same way: build the telemetry event, send it to `storybook.js.org`, **wait for the reply**, and only then exit. A reply takes about 250 ms. A slow server could hold the command for up to 30 s.

`storybook tools docs list` sends two events at the end, so every call paid about half a second for something the user never sees. The same was true for `build`, `index`, `skills get`, `init`, and crash reports.

On a 154-component project, a warm `docs list` with the published build took:

| Telemetry | Duration |
| --- | --- |
| on | 7.5 to 8.6 s |
| off | 6.2 to 6.7 s |

### The fix

Three parts. Together they say: send right away, never wait, and let a separate process finish whatever is still open.

**1. Send and return.**
`sendTelemetry` builds the event, starts the request, and returns. No call site had to change.

**2. Let the process exit while a reply is still pending.**
Node keeps a process alive as long as it has an open connection. `socket.unref()` tells Node to ignore this one. `fetch` never exposes its socket, so the request now goes through `node:http` directly. That replaces `fetch` and the `fetch-retry` package with a small helper that keeps the same retry rules: 3 retries on 503, 504, or a network error, 30 s in total.

**3. Finish the open replies in a detached child process.**
On exit, a hook writes the events that have no reply yet to a temp file and spawns `dist/telemetry/detached-flush.js`, detached from the parent. The child reads the file, deletes it, sends the events, waits for the replies, and exits. Nobody waits for it, and no event is lost because a command finished.

The child process is the same idea Next.js uses when `next dev` shuts down. Storybook goes further, because most of its commands are short: every command gets the hand-off, and none of them waits.

### What changed for callers

- **`immediate: true` is gone.** Every use of it sat right before a `process.exit()`: Ctrl+C in `dev` and `init`, crash reports, and `init` bail-outs. It waited for the reply so the event would not die with the process. The exit hook covers that now. Ctrl+C in `storybook dev` exits at once, and the `canceled` event arrives from the child. The prompt-cancel handler in `create-storybook` no longer needs to race that wait against a timeout.
- **The session id lookup is synchronous.** An event is fully built before the first `await`, so an early `process.exit()` cannot lose it.
- **Event names and payloads are unchanged.**
- `fetch-retry` is no longer a dependency. `./internal/telemetry/detached-flush` is a new internal export: the child's entry point.

### What a `docs list` call looks like now

| When | What happens |
| --- | --- |
| 0.5 s | `boot` is sent; its reply arrives while the tool runs |
| 6 s | the two `tools-command` events are sent |
| exit | the hook hands those two to the child; the parent is gone |
| exit + 6 ms | the child re-sends them, waits for the replies, cleans up, exits |

Checked against a test server that answers after 10 s: `storybook index` exited 2.3 s after sending `boot`, without waiting, and the child re-sent the same event 6 ms later. The exit hook itself costs 2 ms.

### How much faster

`storybook index` on the same 154-component project. Both builds were installed into the project one after the other and measured within the same half hour, with telemetry on and off alternating, five pairs each after a warm-up pair. Load average was about 6. Telemetry's share is the median difference within a pair.

| Build | With telemetry | Without | Telemetry's share |
| --- | --- | --- | --- |
| Published 11.0.0-alpha.0 | 2.16 to 2.40 s | 1.65 to 1.80 s | 0.42 s |
| This branch | 1.64 to 2.11 s | 1.61 to 1.76 s | 0.03 s |
| Published 11.0.0-alpha.0, measured again afterwards | 2.05 to 2.30 s | 1.61 to 1.70 s | 0.49 s |

The "without" column is the same for all three rows, as it should be: this change only touches what happens when telemetry is on. With it on, the published build pays close to half a second per call for the reply it waits for. This branch pays nothing measurable.

### Trade-offs

- **The last events of a short command are usually sent twice**: once by the parent, cut off at exit, and once by the child. The server de-duplicates on `eventId`. The retry logic already relied on that.
- **The child is spawned in CI too**, as Next.js does. A CI container killed within a few hundred milliseconds of the command finishing loses that last event.
- **SIGTERM or SIGKILL without a handler skips the exit hook**, so those events are lost. That was already the case.
- **The temp file lives in the OS temp directory.** It contains only anonymised project metadata.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

1. Start a test server that answers after 10 seconds:
   ```bash
   node -e "require('http').createServer((req,res)=>{req.resume();req.on('end',()=>{console.log(new Date().toISOString(),'received');setTimeout(()=>{res.writeHead(200);res.end()},10000)})}).listen(6100)"
   ```
2. In any sandbox, run:
   ```bash
   STORYBOOK_TELEMETRY_URL=http://127.0.0.1:6100/event-log yarn storybook index -o /tmp/index.json
   ```
   Expected:
   - The command exits without waiting for the server.
   - The server logs `received` once from the parent, and once more right after the parent exits. That is the child re-sending.
   - `ps | grep detached-flush` shows the child until the server answers, then nothing.
   - No `storybook-telemetry-*.json` is left in the temp directory.
3. Run `storybook dev --ci --smoke-test` against the same server. The command still exits promptly.
4. Run `storybook dev` against the same server and press Ctrl+C. The process exits at once. The server logs `received` for the `canceled` event right after, sent by the child.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->





