### PR TITLE
CLI: Add object AST helpers for automigrations

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/helpers/config-object.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/helpers/config-object.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import { parser, types as t } from 'storybook/internal/babel';
+
+import {
+  findIndirectProperty,
+  getStaticProperties,
+  getStaticPropertyName,
+} from './config-object.ts';
+
+const parseObject = (source: string) => {
+  const expression = parser.parseExpression(source, { plugins: ['typescript'] });
+  if (!t.isObjectExpression(expression)) {
+    throw new Error(`expected an object expression, got ${expression.type}`);
+  }
+  return expression;
+};
+
+const firstMember = (source: string) => parseObject(source).properties[0];
+
+describe('getStaticPropertyName', () => {
+  it.each([
+    ['identifier key', `{ storySort: 1 }`, 'storySort'],
+    ['string literal key', `{ 'storySort': 1 }`, 'storySort'],
+    ['shorthand', `{ storySort }`, 'storySort'],
+    ['object method', `{ storySort(a, b) { return 0 } }`, 'storySort'],
+    ['getter', `{ get storySort() { return 0 } }`, 'storySort'],
+    ['reserved word key', `{ default: 1 }`, 'default'],
+    ['key needing quotes', `{ 'story-sort': 1 }`, 'story-sort'],
+  ])('reads a %s', (_name, source, expected) => {
+    expect(getStaticPropertyName(firstMember(source))).toBe(expected);
+  });
+
+  it.each([
+    ['spread element', `{ ...rest }`],
+    ['computed identifier key', `{ [key]: 1 }`],
+    ['computed string literal key', `{ ['storySort']: 1 }`],
+    ['computed template key', `{ [\`storySort\`]: 1 }`],
+    ['computed method key', `{ [key]() { return 0 } }`],
+    ['numeric key', `{ 0: 1 }`],
+    ['bigint key', `{ 0n: 1 }`],
+  ])('returns undefined for a %s', (_name, source) => {
+    expect(getStaticPropertyName(firstMember(source))).toBeUndefined();
+  });
+
+  it('does not confuse a computed key with the identifier it references', () => {
+    expect(getStaticPropertyName(firstMember(`{ [storySort]: 1 }`))).toBeUndefined();
+  });
+});
+
+describe('findIndirectProperty', () => {
+  it('returns undefined when every key is statically readable', () => {
+    expect(
+      findIndirectProperty(parseObject(`{ a: 1, 'b': 2, c() {}, get d() { return 3 } }`))
+    ).toBeUndefined();
+  });
+
+  it.each([
+    ['spread', `{ a: 1, ...rest }`],
+    ['computed key', `{ a: 1, [key]: 2 }`],
+    ['computed string literal key', `{ a: 1, ['b']: 2 }`],
+    ['numeric key', `{ a: 1, 0: 2 }`],
+  ])('returns the offending member for a %s', (_name, source) => {
+    const object = parseObject(source);
+    expect(findIndirectProperty(object)).toBe(object.properties[1]);
+  });
+
+  it('returns the first offender so callers report the earliest source location', () => {
+    const object = parseObject(`{ a: 1, [key]: 2, ...rest }`);
+    expect(findIndirectProperty(object)).toBe(object.properties[1]);
+  });
+
+  it('returns undefined for an empty object', () => {
+    expect(findIndirectProperty(parseObject(`{}`))).toBeUndefined();
+  });
+});
+
+describe('getStaticProperties', () => {
+  it('returns every member whose static key matches', () => {
+    const object = parseObject(`{ a: 1, b: 2, a: 3 }`);
+    expect(getStaticProperties(object, 'a')).toEqual([object.properties[0], object.properties[2]]);
+  });
+
+  it('matches identifier and string literal spellings of the same key', () => {
+    expect(getStaticProperties(parseObject(`{ a: 1, 'a': 2 }`), 'a')).toHaveLength(2);
+  });
+
+  it('does not match a computed key that spells the name', () => {
+    expect(getStaticProperties(parseObject(`{ ['a']: 1 }`), 'a')).toHaveLength(0);
+  });
+
+  it('does not match a spread that might contribute the name', () => {
+    expect(getStaticProperties(parseObject(`{ ...rest }`), 'a')).toHaveLength(0);
+  });
+
+  it('returns an empty array when the key is absent', () => {
+    expect(getStaticProperties(parseObject(`{ b: 1 }`), 'a')).toEqual([]);
+  });
+});

--- a/code/lib/cli-storybook/src/automigrate/helpers/config-object.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/helpers/config-object.test.ts
@@ -4,6 +4,11 @@ import { parser, types as t } from 'storybook/internal/babel';
 
 import {
   findIndirectProperty,
+  findSpreadProperty,
+  findUnresolvedComputedProperty,
+  getDirectProperties,
+  getDirectPropertyName,
+  getObjectPropertyValue,
   getStaticProperties,
   getStaticPropertyName,
 } from './config-object.ts';
@@ -27,6 +32,8 @@ describe('getStaticPropertyName', () => {
     ['getter', `{ get storySort() { return 0 } }`, 'storySort'],
     ['reserved word key', `{ default: 1 }`, 'default'],
     ['key needing quotes', `{ 'story-sort': 1 }`, 'story-sort'],
+    ['computed string literal key', `{ ['storySort']: 1 }`, 'storySort'],
+    ['computed template key', `{ [\`storySort\`]: 1 }`, 'storySort'],
   ])('reads a %s', (_name, source, expected) => {
     expect(getStaticPropertyName(firstMember(source))).toBe(expected);
   });
@@ -34,8 +41,7 @@ describe('getStaticPropertyName', () => {
   it.each([
     ['spread element', `{ ...rest }`],
     ['computed identifier key', `{ [key]: 1 }`],
-    ['computed string literal key', `{ ['storySort']: 1 }`],
-    ['computed template key', `{ [\`storySort\`]: 1 }`],
+    ['computed template expression', '{ [`story${kind}`]: 1 }'],
     ['computed method key', `{ [key]() { return 0 } }`],
     ['numeric key', `{ 0: 1 }`],
     ['bigint key', `{ 0n: 1 }`],
@@ -45,6 +51,69 @@ describe('getStaticPropertyName', () => {
 
   it('does not confuse a computed key with the identifier it references', () => {
     expect(getStaticPropertyName(firstMember(`{ [storySort]: 1 }`))).toBeUndefined();
+  });
+});
+
+describe('getDirectPropertyName', () => {
+  it.each([
+    ['identifier key', `{ storySort: 1 }`, 'storySort'],
+    ['string literal key', `{ 'storySort': 1 }`, 'storySort'],
+  ])('reads a %s', (_name, source, expected) => {
+    expect(getDirectPropertyName(firstMember(source))).toBe(expected);
+  });
+
+  it.each([
+    ['spread element', `{ ...rest }`],
+    ['computed identifier key', `{ [key]: 1 }`],
+    ['computed string literal key', `{ ['storySort']: 1 }`],
+    ['computed template key', `{ [\`storySort\`]: 1 }`],
+  ])('returns undefined for a %s', (_name, source) => {
+    expect(getDirectPropertyName(firstMember(source))).toBeUndefined();
+  });
+});
+
+describe('getObjectPropertyValue', () => {
+  it('returns an expression value', () => {
+    const property = firstMember(`{ storySort: { order: ['Intro'] } }`);
+    expect(getObjectPropertyValue(property)).toBe(
+      t.isObjectProperty(property) ? property.value : undefined
+    );
+  });
+
+  it.each([
+    ['spread element', `{ ...rest }`],
+    ['object method', `{ storySort() {} }`],
+  ])('returns undefined for a %s', (_name, source) => {
+    expect(getObjectPropertyValue(firstMember(source))).toBeUndefined();
+  });
+});
+
+describe('findSpreadProperty', () => {
+  it('returns the first spread property', () => {
+    const object = parseObject(`{ a: 1, ...first, ...second }`);
+    expect(findSpreadProperty(object)).toBe(object.properties[1]);
+  });
+
+  it('returns undefined without a spread property', () => {
+    expect(findSpreadProperty(parseObject(`{ a: 1, [key]: 2 }`))).toBeUndefined();
+  });
+});
+
+describe('findUnresolvedComputedProperty', () => {
+  it.each([
+    ['computed identifier key', `{ a: 1, [key]: 2 }`],
+    ['computed template expression', '{ a: 1, [`key${suffix}`]: 2 }'],
+  ])('returns the first %s', (_name, source) => {
+    const object = parseObject(source);
+    expect(findUnresolvedComputedProperty(object)).toBe(object.properties[1]);
+  });
+
+  it.each([
+    ['direct properties', `{ a: 1, b: 2 }`],
+    ['static computed properties', `{ ['a']: 1, [\`b\`]: 2 }`],
+    ['spread properties', `{ ...rest }`],
+  ])('returns undefined for %s', (_name, source) => {
+    expect(findUnresolvedComputedProperty(parseObject(source))).toBeUndefined();
   });
 });
 
@@ -85,8 +154,8 @@ describe('getStaticProperties', () => {
     expect(getStaticProperties(parseObject(`{ a: 1, 'a': 2 }`), 'a')).toHaveLength(2);
   });
 
-  it('does not match a computed key that spells the name', () => {
-    expect(getStaticProperties(parseObject(`{ ['a']: 1 }`), 'a')).toHaveLength(0);
+  it('matches statically computable keys', () => {
+    expect(getStaticProperties(parseObject(`{ ['a']: 1, [\`a\`]: 2 }`), 'a')).toHaveLength(2);
   });
 
   it('does not match a spread that might contribute the name', () => {
@@ -95,5 +164,16 @@ describe('getStaticProperties', () => {
 
   it('returns an empty array when the key is absent', () => {
     expect(getStaticProperties(parseObject(`{ b: 1 }`), 'a')).toEqual([]);
+  });
+});
+
+describe('getDirectProperties', () => {
+  it('returns only non-computed members whose key matches', () => {
+    const object = parseObject(`{ a: 1, 'a': 2, ['a']: 3, [\`a\`]: 4 }`);
+    expect(getDirectProperties(object, 'a')).toEqual([object.properties[0], object.properties[1]]);
+  });
+
+  it('returns an empty array when the key is absent', () => {
+    expect(getDirectProperties(parseObject(`{ b: 1 }`), 'a')).toEqual([]);
   });
 });

--- a/code/lib/cli-storybook/src/automigrate/helpers/config-object.ts
+++ b/code/lib/cli-storybook/src/automigrate/helpers/config-object.ts
@@ -1,0 +1,37 @@
+import { types as t } from 'storybook/internal/babel';
+
+type ObjectMember = t.ObjectMember | t.SpreadElement;
+
+/**
+ * The key of a non-computed identifier or string-literal property.
+ *
+ * Returns `undefined` for spread elements, computed keys, and every other shape a configuration
+ * migration cannot statically reason about. Config migrations must treat `undefined` as "bail out
+ * with an actionable error", never as "skip this property".
+ */
+export const getStaticPropertyName = (property: ObjectMember): string | undefined => {
+  if (t.isSpreadElement(property) || property.computed) {
+    return undefined;
+  }
+  if (t.isIdentifier(property.key)) {
+    return property.key.name;
+  }
+  if (t.isStringLiteral(property.key)) {
+    return property.key.value;
+  }
+  return undefined;
+};
+
+/**
+ * The first member of `object` that defeats static analysis: a spread element, or a property whose
+ * key {@link getStaticPropertyName} cannot read. The node is returned rather than a boolean so
+ * callers can point at its source location in the error they raise.
+ */
+export const findIndirectProperty = (object: t.ObjectExpression): ObjectMember | undefined =>
+  object.properties.find(
+    (property) => t.isSpreadElement(property) || getStaticPropertyName(property) === undefined
+  );
+
+/** Every member of `object` whose static key is exactly `name`. */
+export const getStaticProperties = (object: t.ObjectExpression, name: string): ObjectMember[] =>
+  object.properties.filter((property) => getStaticPropertyName(property) === name);

--- a/code/lib/cli-storybook/src/automigrate/helpers/config-object.ts
+++ b/code/lib/cli-storybook/src/automigrate/helpers/config-object.ts
@@ -28,10 +28,10 @@ export const getStaticPropertyName = (property: ObjectMember): string | undefine
  * callers can point at its source location in the error they raise.
  */
 export const findIndirectProperty = (object: t.ObjectExpression): ObjectMember | undefined =>
-  object.properties.find(
-    (property) => t.isSpreadElement(property) || getStaticPropertyName(property) === undefined
-  );
+  object.properties.find((property) => getStaticPropertyName(property) === undefined);
 
 /** Every member of `object` whose static key is exactly `name`. */
-export const getStaticProperties = (object: t.ObjectExpression, name: string): ObjectMember[] =>
-  object.properties.filter((property) => getStaticPropertyName(property) === name);
+export const getStaticProperties = (object: t.ObjectExpression, name: string): t.ObjectMember[] =>
+  object.properties.filter(
+    (property): property is t.ObjectMember => getStaticPropertyName(property) === name
+  );

--- a/code/lib/cli-storybook/src/automigrate/helpers/config-object.ts
+++ b/code/lib/cli-storybook/src/automigrate/helpers/config-object.ts
@@ -2,15 +2,17 @@ import { types as t } from 'storybook/internal/babel';
 
 type ObjectMember = t.ObjectMember | t.SpreadElement;
 
-/**
- * The key of a non-computed identifier or string-literal property.
- *
- * Returns `undefined` for spread elements, computed keys, and every other shape a configuration
- * migration cannot statically reason about. Config migrations must treat `undefined` as "bail out
- * with an actionable error", never as "skip this property".
- */
 export const getStaticPropertyName = (property: ObjectMember): string | undefined => {
-  if (t.isSpreadElement(property) || property.computed) {
+  if (t.isSpreadElement(property)) {
+    return undefined;
+  }
+  if (property.computed) {
+    if (t.isStringLiteral(property.key)) {
+      return property.key.value;
+    }
+    if (t.isTemplateLiteral(property.key) && property.key.expressions.length === 0) {
+      return property.key.quasis[0]?.value.cooked;
+    }
     return undefined;
   }
   if (t.isIdentifier(property.key)) {
@@ -22,16 +24,34 @@ export const getStaticPropertyName = (property: ObjectMember): string | undefine
   return undefined;
 };
 
-/**
- * The first member of `object` that defeats static analysis: a spread element, or a property whose
- * key {@link getStaticPropertyName} cannot read. The node is returned rather than a boolean so
- * callers can point at its source location in the error they raise.
- */
-export const findIndirectProperty = (object: t.ObjectExpression): ObjectMember | undefined =>
-  object.properties.find((property) => getStaticPropertyName(property) === undefined);
+export const getDirectPropertyName = (property: ObjectMember): string | undefined =>
+  !t.isSpreadElement(property) && !property.computed ? getStaticPropertyName(property) : undefined;
 
-/** Every member of `object` whose static key is exactly `name`. */
+export const getObjectPropertyValue = (property: ObjectMember): t.Expression | undefined =>
+  t.isObjectProperty(property) && t.isExpression(property.value) ? property.value : undefined;
+
+export const findSpreadProperty = (object: t.ObjectExpression): t.SpreadElement | undefined =>
+  object.properties.find((property): property is t.SpreadElement => t.isSpreadElement(property));
+
+export const findUnresolvedComputedProperty = (
+  object: t.ObjectExpression
+): t.ObjectMember | undefined =>
+  object.properties.find(
+    (property): property is t.ObjectMember =>
+      !t.isSpreadElement(property) &&
+      property.computed &&
+      getStaticPropertyName(property) === undefined
+  );
+
+export const findIndirectProperty = (object: t.ObjectExpression): ObjectMember | undefined =>
+  object.properties.find((property) => getDirectPropertyName(property) === undefined);
+
 export const getStaticProperties = (object: t.ObjectExpression, name: string): t.ObjectMember[] =>
   object.properties.filter(
     (property): property is t.ObjectMember => getStaticPropertyName(property) === name
+  );
+
+export const getDirectProperties = (object: t.ObjectExpression, name: string): t.ObjectMember[] =>
+  object.properties.filter(
+    (property): property is t.ObjectMember => getDirectPropertyName(property) === name
   );


### PR DESCRIPTION
Closes #

## What I did

Storybook's SB11 automigrations repeatedly inspect object literals, but they need two distinct safety contracts:

- Config relocation migrations must accept only direct identifier or string-literal keys. A computed key is indirect and must stop the transform.
- CSF migrations can safely recognize computed string and no-substitution template keys, while still rejecting dynamic computed keys.

This PR gives both contracts explicit names instead of forcing each migration to grow another subtly different reader.

| Helper | Contract | Adopting migration |
| --- | --- | --- |
| `getStaticPropertyName` | Reads direct keys and statically computable string/template keys | #36129 |
| `getDirectPropertyName` | Reads only non-computed identifier/string keys | #36128, #36137 |
| `getStaticProperties` | Collects every statically named member | #36129 |
| `getDirectProperties` | Collects only direct named members | #36128, #36137 |
| `getObjectPropertyValue` | Returns an expression value only from an object property | #36128, #36129, #36137 |
| `findSpreadProperty` | Returns the first spread for location-aware errors | #36129 |
| `findUnresolvedComputedProperty` | Returns the first dynamic computed member | #36129 |
| `findIndirectProperty` | Returns the first spread, computed, or unreadable member | #36128, #36137 |

Returning nodes instead of booleans preserves each migration's source-location-aware error reporting. Returning all matches rather than the first preserves duplicate-key checks.

The helpers deliberately do not resolve identifiers, unwrap TypeScript expressions, or decide whether a value is safe to move. Those rules differ between the three migrations: #36128 moves values within one file, #36137 copies literals across files, and #36129 resolves bindings with Babel scope. Keeping those policies in the callers avoids widening any transform.

### Landing order

1. Merge this PR.
2. Restack #36128, #36129, and #36137 and replace their local object-member primitives with these helpers.
3. Run each migration's focused success and cannot-transform-safely tests, then its seeded-v10 fixture verification.

### Verification at `2baa226520e7eeba4e99def4dc55dae5ecbb4cd8`

- `yarn test code/lib/cli-storybook/src/automigrate/helpers/config-object.test.ts` — 46 passed
- `yarn test code/lib/cli-storybook/src/automigrate` — 461 passed across 31 files
- `yarn nx run-many -t check --projects=cli` — passed
- `yarn --cwd code lint:js:cmd lib/cli-storybook/src/automigrate/helpers/config-object.ts lib/cli-storybook/src/automigrate/helpers/config-object.test.ts` — passed
- `cd code && yarn fmt:write` — completed; worktree contains only the two intended files
- `git diff --check` — passed

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No manual test is necessary. This PR only adds internal AST helper functions; the focused unit tests exercise their public contracts, including duplicate keys and unsafe object members. The adopting migration PRs own seeded-v10 fixture verification.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No product documentation or `MIGRATION.md` change is needed for this internal utility PR. Each adopting migration owns its user-facing migration entry.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=36157`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
