### PR TITLE
Telemetry: Collect project metadata steps concurrently

### DIFF
--- a/code/core/src/telemetry/storybook-metadata.ts
+++ b/code/core/src/telemetry/storybook-metadata.ts
@@ -120,7 +120,21 @@ export const computeStorybookMetadata = async ({
   mainConfig?: StorybookConfig & Record<string, any>;
   configDir: string;
 }): Promise<StorybookMetadata> => {
-  const settings = isCI() && !detectAgent() ? undefined : await globalSettings();
+  const allDependencies = {
+    ...packageJson?.dependencies,
+    ...packageJson?.devDependencies,
+    ...packageJson?.peerDependencies,
+  };
+
+  const metaFramework = Object.keys(allDependencies).find((dep) => !!metaFrameworks[dep]);
+
+  const [settings, metaFrameworkVersion, knownPackages, packageManager] = await Promise.all([
+    isCI() && !detectAgent() ? undefined : globalSettings(),
+    metaFramework ? getActualPackageVersion(metaFramework) : undefined,
+    analyzeEcosystemPackages(packageJson),
+    getPackageManagerInfo(),
+  ]);
+
   const metadata: Partial<StorybookMetadata> = {
     generatedAt: new Date().getTime(),
     userSince: settings?.value.userSince,
@@ -132,23 +146,15 @@ export const computeStorybookMetadata = async ({
     refCount: 0,
   };
 
-  const allDependencies = {
-    ...packageJson?.dependencies,
-    ...packageJson?.devDependencies,
-    ...packageJson?.peerDependencies,
-  };
-
-  const metaFramework = Object.keys(allDependencies).find((dep) => !!metaFrameworks[dep]);
   if (metaFramework) {
-    const { version } = await getActualPackageVersion(metaFramework);
     metadata.metaFramework = {
       name: metaFrameworks[metaFramework],
       packageName: metaFramework,
-      version: version || 'unknown',
+      version: metaFrameworkVersion?.version || 'unknown',
     };
   }
 
-  metadata.knownPackages = await analyzeEcosystemPackages(packageJson);
+  metadata.knownPackages = knownPackages;
   metadata.hasRouterPackage = getHasRouterPackage(packageJson);
   metadata.hasTurbopack = getHasTurbopack(packageJson);
   metadata.hasModuleFederation = getHasModuleFederation(packageJson);
@@ -158,7 +164,7 @@ export const computeStorybookMetadata = async ({
     metadata.monorepo = monorepoType;
   }
 
-  metadata.packageManager = await getPackageManagerInfo();
+  metadata.packageManager = packageManager;
 
   const language = allDependencies.typescript ? 'typescript' : 'javascript';
 
@@ -180,68 +186,7 @@ export const computeStorybookMetadata = async ({
     metadata.typescriptOptions = mainConfig.typescript;
   }
 
-  const frameworkInfo = await getFrameworkInfo(mainConfig, configDir);
-
-  const rendererPackages = Object.fromEntries(
-    await Promise.all(
-      getRendererPackages(frameworkInfo.renderer).map(async (packageName) => {
-        const { version } = await getActualPackageVersion(packageName);
-        return [packageName, version || 'unknown'];
-      })
-    )
-  );
-  if (Object.keys(rendererPackages).length > 0) {
-    metadata.knownPackages = { ...metadata.knownPackages, rendererPackages };
-  }
-
-  if (typeof mainConfig.refs === 'object') {
-    metadata.refCount = Object.keys(mainConfig.refs).length;
-  }
-
-  if (typeof mainConfig.features === 'object') {
-    metadata.features = mainConfig.features;
-  }
-
-  const addons: Record<string, StorybookAddon> = {};
-  if (mainConfig.addons) {
-    mainConfig.addons.forEach((addon) => {
-      let addonName;
-      let options;
-
-      if (typeof addon === 'string') {
-        addonName = sanitizeAddonName(addon);
-      } else {
-        if (addon.name.includes('addon-essentials')) {
-          options = addon.options;
-        }
-        addonName = sanitizeAddonName(addon.name);
-      }
-
-      addons[addonName] = {
-        options,
-        version: undefined,
-      };
-    });
-  }
-
-  const chromaticVersionSpecifier = getChromaticVersionSpecifier(packageJson);
-  if (chromaticVersionSpecifier) {
-    addons.chromatic = {
-      version: undefined,
-      versionSpecifier: chromaticVersionSpecifier,
-      options: undefined,
-    };
-  }
-
-  const addonVersions = await getActualPackageVersions(addons);
-  addonVersions.forEach(({ name, version }) => {
-    addons[name] = addons[name] || {
-      name,
-      version,
-    };
-    addons[name].version = version || undefined;
-  });
-
+  const addons = collectAddons(mainConfig, packageJson);
   const addonNames = Object.keys(addons);
 
   // all Storybook deps minus the addons
@@ -254,7 +199,48 @@ export const computeStorybookMetadata = async ({
       };
     }, {}) as Record<string, Dependency>;
 
-  const storybookPackageVersions = await getActualPackageVersions(storybookPackages);
+  const [
+    { frameworkInfo, rendererPackages },
+    addonVersions,
+    storybookPackageVersions,
+    { storybookInfo, usesGlobals },
+    portableStoriesFileCount,
+    applicationFileCount,
+  ] = await Promise.all([
+    getFrameworkInfo(mainConfig, configDir).then(async (info) => ({
+      frameworkInfo: info,
+      rendererPackages: await resolveRendererPackages(info.renderer),
+    })),
+    getActualPackageVersions(addons),
+    getActualPackageVersions(storybookPackages),
+    getStorybookInfo(configDir).then(async (info) => ({
+      storybookInfo: info,
+      usesGlobals: await previewUsesGlobals(info.previewConfigPath),
+    })),
+    getPortableStoriesFileCount(),
+    getApplicationFileCount(dirname(packageJsonPath)),
+  ]);
+
+  if (Object.keys(rendererPackages).length > 0) {
+    metadata.knownPackages = { ...metadata.knownPackages, rendererPackages };
+  }
+
+  if (typeof mainConfig.refs === 'object') {
+    metadata.refCount = Object.keys(mainConfig.refs).length;
+  }
+
+  if (typeof mainConfig.features === 'object') {
+    metadata.features = mainConfig.features;
+  }
+
+  addonVersions.forEach(({ name, version }) => {
+    addons[name] = addons[name] || {
+      name,
+      version,
+    };
+    addons[name].version = version || undefined;
+  });
+
   storybookPackageVersions.forEach(({ name, version }) => {
     storybookPackages[name] = storybookPackages[name] || {
       name,
@@ -266,23 +252,9 @@ export const computeStorybookMetadata = async ({
 
   const hasStorybookEslint = !!allDependencies['eslint-plugin-storybook'];
 
-  const storybookInfo = await getStorybookInfo(configDir);
-
-  try {
-    const { previewConfigPath: previewConfig } = storybookInfo;
-    if (previewConfig) {
-      const config = await readConfig(previewConfig);
-      const usesGlobals = !!(
-        config.getFieldNode(['globals']) || config.getFieldNode(['globalTypes'])
-      );
-      metadata.preview = { ...metadata.preview, usesGlobals };
-    }
-  } catch (e) {
-    // gracefully handle error, as it's not critical information and AST parsing can cause trouble
+  if (usesGlobals !== undefined) {
+    metadata.preview = { ...metadata.preview, usesGlobals };
   }
-
-  const portableStoriesFileCount = await getPortableStoriesFileCount();
-  const applicationFileCount = await getApplicationFileCount(dirname(packageJsonPath));
 
   return {
     ...metadata,
@@ -298,6 +270,57 @@ export const computeStorybookMetadata = async ({
     packageJsonType: packageJson.type ?? 'unknown',
   };
 };
+
+function collectAddons(
+  mainConfig: StorybookConfig,
+  packageJson: PackageJson
+): Record<string, StorybookAddon> {
+  const addons: Record<string, StorybookAddon> = {};
+  for (const addon of mainConfig.addons ?? []) {
+    if (typeof addon === 'string') {
+      addons[sanitizeAddonName(addon)] = { options: undefined, version: undefined };
+    } else {
+      addons[sanitizeAddonName(addon.name)] = {
+        options: addon.name.includes('addon-essentials') ? addon.options : undefined,
+        version: undefined,
+      };
+    }
+  }
+
+  const chromaticVersionSpecifier = getChromaticVersionSpecifier(packageJson);
+  if (chromaticVersionSpecifier) {
+    addons.chromatic = {
+      version: undefined,
+      versionSpecifier: chromaticVersionSpecifier,
+      options: undefined,
+    };
+  }
+  return addons;
+}
+
+async function resolveRendererPackages(renderer: string | undefined) {
+  return Object.fromEntries(
+    await Promise.all(
+      getRendererPackages(renderer).map(async (packageName) => {
+        const { version } = await getActualPackageVersion(packageName);
+        return [packageName, version || 'unknown'];
+      })
+    )
+  );
+}
+
+// Not critical information, and AST parsing of user code can fail, so a parse error yields nothing.
+async function previewUsesGlobals(previewConfigPath: string | undefined) {
+  if (!previewConfigPath) {
+    return undefined;
+  }
+  try {
+    const config = await readConfig(previewConfigPath);
+    return !!(config.getFieldNode(['globals']) || config.getFieldNode(['globalTypes']));
+  } catch {
+    return undefined;
+  }
+}
 
 async function getPackageJsonDetails() {
   const packageJsonPath = pkg.up();


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Every telemetry event includes a description of the project: framework, addons and their versions, package manager, number of story files, and so on. Storybook collects this once per process in `computeStorybookMetadata`.

### The problem

The function did ten independent lookups, one after the other:

```ts
const settings = await globalSettings();
const framework = await getActualPackageVersion(metaFramework);
const known = await analyzeEcosystemPackages(packageJson);
const packageManager = await getPackageManagerInfo();
const frameworkInfo = await getFrameworkInfo(mainConfig, configDir);
// ... five more, each waiting for the previous one
```

None of them needs the result of another. So the total time was all of them added together.

### The fix

Run them at the same time with `Promise.all`. The total is now the slowest single lookup instead of the sum.

Two lookups do depend on each other and stay in order: the framework info is needed before the renderer packages, and the Storybook info is needed before the preview file check. Three pieces of logic moved into small named functions so the groups read as a plain list.

### How much faster

Together with #36158 and #36159, which make individual lookups cheaper, collecting the metadata went from about **700 ms** to about **100 ms** on a 154-component project. This PR is the part that stops the lookups from waiting on each other.

The output is the same object with the same fields. Only the order in which the inputs are fetched changed.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

1. Run `STORYBOOK_TELEMETRY_DEBUG=1 npx storybook dev --ci --smoke-test` in any project, once on `next` and once on this branch.
2. Compare the printed `metadata` blocks. Apart from `generatedAt` they are identical.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
