### PR TITLE
CLI: Install ajv@8 on Webpack 5 init to fix ajv-keywords resolution

### DIFF
--- a/code/lib/create-storybook/src/generators/baseGenerator.ts
+++ b/code/lib/create-storybook/src/generators/baseGenerator.ts
@@ -16,7 +16,11 @@ import {
   optionalEnvToBoolean,
 } from 'storybook/internal/common';
 import { prompt } from 'storybook/internal/node-logger';
-import { SupportedFramework, SupportedLanguage } from 'storybook/internal/types';
+import {
+  SupportedBuilder,
+  SupportedFramework,
+  SupportedLanguage,
+} from 'storybook/internal/types';
 
 import invariant from 'tiny-invariant';
 import { dedent } from 'ts-dedent';
@@ -203,6 +207,11 @@ export async function baseGenerator(
     ...(installFrameworkPackages ? [frameworkPackage] : []),
     ...addonPackages,
     ...(extraPackagesToInstall || []),
+    // npm may hoist ESLint's ajv@6 to the project root while webpack's
+    // schema-utils → ajv-keywords needs ajv@8 (`ajv/dist/compile/codegen`).
+    // Installing ajv@8 as a direct dependency keeps resolution compatible.
+    // See: https://github.com/storybookjs/storybook/issues/36176
+    ...(builder === SupportedBuilder.WEBPACK5 ? ['ajv@^8.17.1'] : []),
   ].filter(Boolean);
 
   const packagesToInstall = [...new Set(allPackages)].filter(

--- a/code/lib/create-storybook/src/generators/baseGenerator.ts
+++ b/code/lib/create-storybook/src/generators/baseGenerator.ts
@@ -16,11 +16,7 @@ import {
   optionalEnvToBoolean,
 } from 'storybook/internal/common';
 import { prompt } from 'storybook/internal/node-logger';
-import {
-  SupportedBuilder,
-  SupportedFramework,
-  SupportedLanguage,
-} from 'storybook/internal/types';
+import { SupportedFramework, SupportedLanguage } from 'storybook/internal/types';
 
 import invariant from 'tiny-invariant';
 import { dedent } from 'ts-dedent';
@@ -28,6 +24,7 @@ import { dedent } from 'ts-dedent';
 import { AddonService } from '../services/index.ts';
 import { configureMain, configurePreview } from './configure.ts';
 import type { FrameworkOptions, GeneratorOptions } from './types.ts';
+import { resolveWebpack5AjvPackageToInstall } from './webpack5Ajv.ts';
 
 const defaultOptions = {
   extraPackages: [],
@@ -202,16 +199,20 @@ export async function baseGenerator(
         })
       : extraPackages;
 
+  // Hoisted ESLint ajv@6 breaks webpack's schema-utils → ajv-keywords (needs ajv@8).
+  // Install ajv@8 when missing; never overwrite a user-owned incompatible direct range.
+  // See: https://github.com/storybookjs/storybook/issues/36176
+  const webpack5AjvPackage = resolveWebpack5AjvPackageToInstall({
+    builder,
+    declaredAjvRange: packageJson.dependencies?.ajv ?? packageJson.devDependencies?.ajv,
+  });
+
   const allPackages = [
     'storybook',
     ...(installFrameworkPackages ? [frameworkPackage] : []),
     ...addonPackages,
     ...(extraPackagesToInstall || []),
-    // npm may hoist ESLint's ajv@6 to the project root while webpack's
-    // schema-utils → ajv-keywords needs ajv@8 (`ajv/dist/compile/codegen`).
-    // Installing ajv@8 as a direct dependency keeps resolution compatible.
-    // See: https://github.com/storybookjs/storybook/issues/36176
-    ...(builder === SupportedBuilder.WEBPACK5 ? ['ajv@^8.17.1'] : []),
+    ...(webpack5AjvPackage ? [webpack5AjvPackage] : []),
   ].filter(Boolean);
 
   const packagesToInstall = [...new Set(allPackages)].filter(

--- a/code/lib/create-storybook/src/generators/webpack5Ajv.test.ts
+++ b/code/lib/create-storybook/src/generators/webpack5Ajv.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { SupportedBuilder } from 'storybook/internal/types';
+
+import { WEBPACK5_AJV_PACKAGE, resolveWebpack5AjvPackageToInstall } from './webpack5Ajv.ts';
+
+describe('resolveWebpack5AjvPackageToInstall', () => {
+  it('does not install ajv for Vite projects', () => {
+    expect(
+      resolveWebpack5AjvPackageToInstall({
+        builder: SupportedBuilder.VITE,
+        declaredAjvRange: undefined,
+      })
+    ).toBeNull();
+  });
+
+  it('installs ajv@8 for a fresh Webpack 5 project', () => {
+    expect(
+      resolveWebpack5AjvPackageToInstall({
+        builder: SupportedBuilder.WEBPACK5,
+        declaredAjvRange: undefined,
+      })
+    ).toBe(WEBPACK5_AJV_PACKAGE);
+  });
+
+  it('leaves an existing compatible direct ajv@8 range alone', () => {
+    expect(
+      resolveWebpack5AjvPackageToInstall({
+        builder: SupportedBuilder.WEBPACK5,
+        declaredAjvRange: '^8.12.0',
+      })
+    ).toBeNull();
+  });
+
+  it('stops with an actionable error when a direct ajv@6 range is present', () => {
+    expect(() =>
+      resolveWebpack5AjvPackageToInstall({
+        builder: SupportedBuilder.WEBPACK5,
+        declaredAjvRange: '^6.12.6',
+      })
+    ).toThrow(/ajv@\^6\.12\.6/);
+
+    expect(() =>
+      resolveWebpack5AjvPackageToInstall({
+        builder: SupportedBuilder.WEBPACK5,
+        declaredAjvRange: '^6.12.6',
+      })
+    ).toThrow(/will not overwrite/);
+  });
+});

--- a/code/lib/create-storybook/src/generators/webpack5Ajv.ts
+++ b/code/lib/create-storybook/src/generators/webpack5Ajv.ts
@@ -1,0 +1,50 @@
+import { SupportedBuilder } from 'storybook/internal/types';
+
+import semver from 'semver';
+import { dedent } from 'ts-dedent';
+
+/** Range required by webpack's schema-utils → ajv-keywords@5 (`ajv/dist/compile/codegen`). */
+export const WEBPACK5_AJV_RANGE = '^8.17.1';
+export const WEBPACK5_AJV_PACKAGE = `ajv@${WEBPACK5_AJV_RANGE}`;
+
+/**
+ * Decide whether Webpack 5 Storybook init should install ajv@8.
+ *
+ * - No direct `ajv`: install a compatible range.
+ * - Direct `ajv` already compatible with ^8: leave the user's range alone.
+ * - Direct `ajv` incompatible (e.g. ^6): fail with an actionable message — never overwrite.
+ *
+ * @see https://github.com/storybookjs/storybook/issues/36176
+ */
+export function resolveWebpack5AjvPackageToInstall({
+  builder,
+  declaredAjvRange,
+}: {
+  builder: SupportedBuilder;
+  declaredAjvRange: string | undefined;
+}): string | null {
+  if (builder !== SupportedBuilder.WEBPACK5) {
+    return null;
+  }
+
+  if (!declaredAjvRange) {
+    return WEBPACK5_AJV_PACKAGE;
+  }
+
+  const range = declaredAjvRange.trim();
+  if (semver.validRange(range) && semver.intersects(range, WEBPACK5_AJV_RANGE)) {
+    return null;
+  }
+
+  throw new Error(dedent`
+    Webpack 5 Storybook requires ajv@${WEBPACK5_AJV_RANGE} because webpack's schema-utils →
+    ajv-keywords needs \`ajv/dist/compile/codegen\`, but this project already declares a direct
+    dependency on ajv@${declaredAjvRange}.
+
+    Storybook will not overwrite that range. Please upgrade the direct \`ajv\` dependency to
+    ${WEBPACK5_AJV_RANGE} (or remove it so Storybook can install a compatible version), then
+    re-run the initializer.
+
+    See: https://github.com/storybookjs/storybook/issues/36176
+  `);
+}


### PR DESCRIPTION
## What I did

- Fresh `@storybook/nextjs` (Webpack) projects that also install ESLint can fail preview compilation with `Cannot find module 'ajv/dist/compile/codegen'`.
- npm may hoist ESLint's `ajv@6` to the project root while webpack's `schema-utils` → `ajv-keywords@5` needs `ajv@8`. When `ajv-keywords@5` is also hoisted to the root, it resolves the incompatible `ajv@6`.
- During Webpack 5 Storybook init, install `ajv@^8.17.1` as a direct dependency so root resolution stays compatible. If a project already declares an incompatible direct `ajv` range (e.g. `ajv@6`), init stops with an actionable error instead of silently dropping the compatible `ajv@8`.
- Vite-based init (`@storybook/nextjs-vite`) is unchanged (no extra `ajv`).

Fixes #36176

## Reproduction confirmed

On macOS + npm, with `ajv-keywords@5` hoisted to the project root and `ajv@6` from ESLint:

```
Error: Cannot find module 'ajv/dist/compile/codegen'
Require stack:
- ./node_modules/ajv-keywords/dist/definitions/typeof.js
```

`npm install --save-dev ajv@8` makes `storybook dev` start successfully.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] unit tests
- [ ] stories
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run `npx create-next-app@latest test-app --eslint` so the app installs ESLint (and its `ajv@6`).
2. `cd test-app && npx storybook@latest init` (resolves to `@storybook/nextjs` / Webpack 5 builder).
3. Confirm `package.json` now includes `ajv` with a `^8` range.
4. Run `npm run storybook` and confirm the preview compiles without `Cannot find module 'ajv/dist/compile/codegen'`.
5. Regression: run the same init on a project that already declares a direct `ajv@6` dependency and confirm init stops with the actionable error message.
6. Regression: Vite-based init (`@storybook/nextjs-vite`) is unchanged — no extra `ajv` is added.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)