### PR TITLE
Core: Fix build crash when ref reachability check fails mid-request

### DIFF
--- a/code/core/src/common/utils/get-storybook-refs.test.ts
+++ b/code/core/src/common/utils/get-storybook-refs.test.ts
@@ -32,4 +32,11 @@ describe('checkRef', () => {
     vi.spyOn(global, 'fetch').mockRejectedValue(new Error('Network error'));
     expect(await checkRef('https://chromatic.com')).toBe(false);
   });
+
+  it('returns false when the JSON follow-up fetch fails after a 200 response', async () => {
+    vi.spyOn(global, 'fetch')
+      .mockResolvedValueOnce({ ok: true, status: 200 } as Response)
+      .mockRejectedValueOnce(new TypeError('fetch failed'));
+    expect(await checkRef('https://chromatic.com')).toBe(false);
+  });
 });

--- a/code/core/src/common/utils/get-storybook-refs.ts
+++ b/code/core/src/common/utils/get-storybook-refs.ts
@@ -44,27 +44,27 @@ export const getAutoRefs = async (options: Options): Promise<Record<string, Ref>
   );
 };
 
-export const checkRef = (url: string) =>
-  fetch(`${url}/iframe.html`).then(
-    async ({ ok, status }) => {
-      if (ok) {
-        if (status !== 200) {
-          return false;
-        }
+export const checkRef = async (url: string) => {
+  try {
+    const { ok, status } = await fetch(`${url}/iframe.html`);
+    if (!ok || status !== 200) {
+      return false;
+    }
 
-        // so the status is ok, but if we'd ask for JSON we might get a response saying we need to authenticate.
-        const data = await fetch(`${url}/iframe.html`, {
-          headers: { Accept: 'application/json' },
-        });
-        // we might receive non-JSON as a response, because the service ignored our request for JSON response type.
-        if (data.ok && (await (data as any).json().catch(() => ({}))).loginUrl) {
-          return false;
-        }
-      }
-      return ok;
-    },
-    () => false
-  );
+    // so the status is ok, but if we'd ask for JSON we might get a response saying we need to authenticate.
+    const data = await fetch(`${url}/iframe.html`, {
+      headers: { Accept: 'application/json' },
+    });
+    if (!data.ok) {
+      return true;
+    }
+    // we might receive non-JSON as a response, because the service ignored our request for JSON response type.
+    const json = await data.json().catch(() => ({}));
+    return !json.loginUrl;
+  } catch {
+    return false;
+  }
+};
 
 const stripTrailingSlash = (url: string) => url.replace(/\/$/, '');
 


### PR DESCRIPTION
Closes #31925

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

`checkRef` verifies that each composed Storybook ref is publicly reachable. It makes two requests: a plain fetch of `iframe.html`, then a follow-up fetch with `Accept: application/json` to detect auth-gated hosts. Only the first fetch had a rejection handler, so when the second one failed (e.g. behind a CI firewall) the rejection escaped and crashed `storybook build` with `TypeError: fetch failed`.

This rewrites `checkRef` as a single `async` function with one `try/catch`, so any network failure in either request marks the ref as `unknown` (runtime fallback) instead of failing the build. Behavior for all existing cases (non-ok, non-200, `loginUrl`, non-JSON body) is unchanged, and the `as any` cast is gone.

Adds a unit test for the previously uncovered case: first fetch returns 200, second fetch rejects.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Run the unit tests:
   ```bash
   cd code && yarn vitest run --config core/vitest.config.ts core/src/common/utils/get-storybook-refs.test.ts
   ```
   Expected: all 5 tests pass. Checking out `next` for `get-storybook-refs.ts` only and re-running should fail the new test with `TypeError: fetch failed`.
2. Reproduce the issue end to end: in a sandbox (`yarn task sandbox --template react-vite/default-ts --start-from auto`), add a ref to `.storybook/main.ts` pointing at a host that accepts the first request but drops the second, or simply block outbound network after the first request (e.g. a ref to `https://example.com` while offline mid-build is hard to time, so the unit test is the reliable check). Run `yarn storybook build`.
   Expected: the build completes and the ref is emitted with `type: 'unknown'` rather than the build crashing.
3. Regression check: run `yarn storybook build` with a ref to a publicly reachable Storybook (e.g. `https://next--635781f3500dd2c49e189caf.chromatic.com`). Expected: the ref is emitted with `type: 'server-checked'` as before.

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
