### PR TITLE
A11y: Fix SummaryScreen region nesting

### DIFF
--- a/code/core/src/manager/components/review/screens/SummaryScreen.tsx
+++ b/code/core/src/manager/components/review/screens/SummaryScreen.tsx
@@ -35,12 +35,12 @@ import { CollectionGrid } from '../components/CollectionGrid.tsx';
 import { CopyButton } from '../components/CopyButton.tsx';
 import { Markdown } from '../components/Markdown.tsx';
 import { ReviewHeader } from '../components/ReviewHeader.tsx';
+import type { ReviewBanner } from '../review-context.ts';
 import {
   REVIEW_SUMMARY_BACK_ATTR,
   buildReviewStoryHref,
   buildSummaryBackHref,
 } from '../review-navigation.ts';
-import type { ReviewBanner } from '../review-context.ts';
 import type { ReviewState } from '../review-state.ts';
 import type { StoryInfo } from '../review-types.ts';
 
@@ -218,7 +218,16 @@ const CardRationale = styled(MarkdownWrapper)(({ theme }) => ({
   margin: '0 12px',
 }));
 
-const Footer = styled.div(({ theme }) => ({
+const Footer = styled.footer(({ theme }) => ({
+  color: theme.textMutedColor,
+  padding: '10px 22px 42px',
+  fontSize: theme.typography.size.s2,
+  textAlign: 'center',
+  textWrap: 'balance',
+}));
+
+const EmptyMessage = styled.p(({ theme }) => ({
+  margin: 0,
   color: theme.textMutedColor,
   padding: '10px 10px 30px',
   fontSize: theme.typography.size.s2,
@@ -239,18 +248,14 @@ const CollectionLandmark: FC<{ titleId: string; children: ReactNode }> = ({
   );
 };
 
-// A `contentinfo` landmark must stay top-level, but this footer sits inside the
-// `main` landmark, so it is exposed as a named `region` instead. It renders as a
-// `section` because `region` is not an allowed role on `footer` (aria-allowed-role),
-// and a `<footer>` nested in `<main>` has no implicit `contentinfo` role anyway.
 const FooterLandmark: FC<{ children: ReactNode }> = ({ children }) => {
-  const regionRef = useRef<HTMLDivElement>(null);
+  const footerRef = useRef<HTMLElement>(null);
   const { landmarkProps } = useLandmark(
     { role: 'contentinfo', 'aria-label': 'About this review' },
-    regionRef
+    footerRef
   );
   return (
-    <Footer as="section" ref={regionRef} {...landmarkProps}>
+    <Footer ref={footerRef} {...landmarkProps}>
       {children}
     </Footer>
   );
@@ -444,7 +449,9 @@ export const SummaryScreen: FC<SummaryScreenProps> = ({
               </SummaryCard>
             </SummaryLandmark>
             {visibleCollections.length === 0 ? (
-              <Footer>{showNewOnly ? 'No new stories found.' : 'No collections found.'}</Footer>
+              <EmptyMessage>
+                {showNewOnly ? 'No new stories found.' : 'No collections found.'}
+              </EmptyMessage>
             ) : (
               visibleCollections.map(({ collection, index, storyIds }) => {
                 const isExpanded = expandedCollections.has(index);
@@ -508,12 +515,12 @@ export const SummaryScreen: FC<SummaryScreenProps> = ({
                 );
               })
             )}
-            <FooterLandmark>
-              This review shows the {pluralize(storyCount, 'story', 'stories')} most relevant for
-              you to spot-check right now. Because this is AI-curated, results may be inaccurate or
-              incomplete.
-            </FooterLandmark>
           </Main>
+          <FooterLandmark>
+            This review shows the {pluralize(storyCount, 'story', 'stories')} most relevant for you
+            to spot-check right now. Because this is AI-curated, results may be inaccurate or
+            incomplete.
+          </FooterLandmark>
         </ScrollArea>
       </ListScroll>
     </Page>


### PR DESCRIPTION
## What I did

Fixes two minor discrepancies in SummaryScreen:
* The footer was embedded inside main for layout purposes, but should ideally be outside of it to match expected role semantics
* The footer was reused for an empty preview message though that message should've been in a main

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

* Check SummaryScreen stories in Chromatic to ensure the roles look correct
* Check Chromatic for visual regressions

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
