### PR TITLE
CSF Factories: Keep meta args typed when they contain literal values

### DIFF
--- a/code/core/src/csf/csf-factories-meta-args.md
+++ b/code/core/src/csf/csf-factories-meta-args.md
@@ -1,0 +1,120 @@
+# Meta args inference in CSF factories
+
+Why `MetaArgsConstraint` and `MetaArgsInput` exist, what they give up, and what would make them
+unnecessary. Read this before touching the `meta()` signatures in the renderers.
+
+## The problem
+
+`meta()` captures the args it is given, so a story does not have to repeat them:
+
+```ts
+const meta = preview.meta({
+  component: Button, // props: { variant: 'primary' | 'secondary'; disabled: boolean }
+  args: { variant: 'primary', disabled: false },
+});
+
+export const Default = meta.story(); // nothing left to provide
+```
+
+Until #36185, this only worked when no prop had a literal type. With `variant: 'primary' | 'secondary'`,
+`meta.story()` demanded `variant` again ([#36125](https://github.com/storybookjs/storybook/issues/36125),
+[#32829](https://github.com/storybookjs/storybook/issues/32829) for enums).
+
+## Why TypeScript cannot do this in one object
+
+TypeScript infers all type parameters of a call at once, and it checks the argument object property by
+property. The component args (`TArgs`) come from `component`, but `args` sits in the same object, so while
+`args` is checked, `TArgs` is not known yet. Three things follow:
+
+- Literals have no contextual type and widen: `'primary'` becomes `string`.
+- Array literals have no tuple context: `['x', 1]` becomes `(string | number)[]`.
+- Callbacks get no contextual signature from the component.
+
+The original signature captured the args with a type parameter constrained to the component args:
+
+```ts
+TMetaArgs extends Partial<TArgs>,
+>(meta: { component?: ComponentType<TArgs>; args?: TMetaArgs })
+```
+
+The widened `{ variant: string }` does not satisfy `Partial<{ variant: 'primary' | 'secondary' }>`. When an
+inferred type fails its constraint, TypeScript replaces it with the constraint itself. The constraint is
+all-optional, our "did meta provide anything" guard treats an all-optional type as empty, and the story
+demands every arg again.
+
+The TypeScript team has drawn this line deliberately. Since TypeScript 4.7, "intra-expression inference"
+([microsoft/TypeScript#48538](https://github.com/microsoft/TypeScript/pull/48538)) lets inferences flow from
+earlier to later properties of one object literal, but only into context-sensitive functions (functions with
+untyped parameters), never into plain values. The PR calls the direction limitation "a long standing
+limitation of our inference algorithm, and one that isn't likely to change". The closest open request is
+[microsoft/TypeScript#47599](https://github.com/microsoft/TypeScript/issues/47599); nothing on the 7.x
+iteration plans touches this. `const` type parameters (TypeScript 5.0) keep literals but still do not know
+the component, and `NoInfer` (5.4) only blocks inference.
+
+## What we do
+
+1. **Widen the constraint** so the widened args TypeScript infers satisfy it and nothing falls back.
+2. **Check the primitive args exactly** afterwards, because widening only lost precision there.
+
+```ts
+export type MetaArgsConstraint<TArgs> = { [K in keyof TArgs]?: Widen<TArgs[K]> };
+
+export type MetaArgsInput<TInput, TArgs> = TInput & Partial<Pick<TArgs, PrimitiveKeys<TArgs>>>;
+```
+
+Every renderer's `meta()` uses them the same way:
+
+```ts
+TMetaArgs extends MetaArgsConstraint<TArgs & T['args']>,
+>(meta: { args?: MetaArgsInput<TMetaArgs, TArgs & T['args']> })
+```
+
+`Widen` maps literal types to their primitives (type-fest's `LiteralToPrimitive`), recursing into arrays and
+objects and leaving functions alone. `PrimitiveKeys` is a one-line local type rather than type-fest's
+`ConditionalKeys`, whose extra machinery makes TypeScript give up ("union type too complex") on the
+unconstrained `TArgs` of the render-only overloads. The exact check covers primitives only, on purpose: a function or object type in it would hand a
+contextual signature to a callback in `args` while `TArgs` is still being inferred, and TypeScript reports
+that as a circular return type (`TS7023`) for any `() => {}` in the args, including one nested inside an
+object or array arg. Function, object and array args are still validated, through the constraint, the way
+they always were.
+
+### What this gives up
+
+Literal precision inside object, array and tuple args is checked widened only. `nested: { mode: 'c' }`
+and `tuple: [1, 'x']` are accepted when the component declares `mode: 'a' | 'b'` and `tuple: ['x', number]`.
+Top-level literals, enums, template literals, function signatures and handler parameter inference are all
+exact.
+
+### What we tried and rejected
+
+| Attempt                                                                | Result                                                                                                       |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `const TMetaArgs` (the fix proposed in #36134 and #36150)              | Keeps literals, but infers arrays as `readonly` tuples, which fail a mutable `string[]` prop: same fallback. Needs TypeScript 5.0. |
+| `const TMetaArgs extends Partial<ReadonlyDeep<TArgs>>`                 | Works, but `meta.input.args` becomes deeply readonly and literal; `meta.input.args.items` no longer fits a `string[]` prop. Undoing that with `WritableDeep` breaks the `Meta` constraint and story optionality. |
+| Unconstrained `TMetaArgs` plus `args?: TMetaArgs & Partial<TArgs>`     | Fixes every literal case, but `onDismiss: () => {}` in meta args is a circular return type: the validator hands the callback a signature that still refers to `TArgs`. |
+| Exclude only top-level function args from the check                    | Same circularity for a `() => {}` nested in an object or array arg.                                          |
+| Replace nested function types in the check with `(...args: any) => any` | No circularity, but handler parameters lose their inferred types everywhere.                                |
+| Exclude every arg that contains a function anywhere                    | Works, but needs a recursive "contains a function" type that nobody can explain without this document.       |
+
+## What would make this unnecessary
+
+Fixing `TArgs` before `args` is checked removes all of the above. Two API shapes do that, and both are the
+pattern libraries with the same problem use (tRPC, TanStack, Hono, Zod):
+
+```ts
+preview.meta(Button, { args: { variant: 'primary' } });
+preview.component(Button).meta({ args: { variant: 'primary' } });
+```
+
+With either, the original `TMetaArgs extends Partial<TArgs>` is enough, `args` is contextually typed by the
+real props, and literals, tuples and callbacks all come out exact. This is a public API change and a
+separate decision.
+
+## How to verify a change
+
+The type tests live next to each `meta()` signature: `code/renderers/react/src/csf-factories.test.tsx`,
+`code/renderers/vue3/src/csf-factories.test.ts`, `code/renderers/web-components/src/csf-factories.test.ts`,
+`code/frameworks/angular/src/client/csf-factories.test.ts` and
+`code/frameworks/angular-vite/src/client/csf-factories.test.ts`. The "Literal args" tests cover the cases in
+this document, including a `() => {}` nested inside an object arg. Run `yarn nx check <project>` for each
+package; the React check runs in seconds with the native compiler.

--- a/code/core/src/csf/csf-factories.ts
+++ b/code/core/src/csf/csf-factories.ts
@@ -10,7 +10,7 @@ import type {
   TestFunction,
 } from 'storybook/internal/types';
 
-import type { SetOptional } from 'type-fest';
+import type { LiteralToPrimitive, Primitive, SetOptional } from 'type-fest';
 
 import {
   combineParameters,
@@ -91,42 +91,34 @@ export function isPreview(input: unknown): input is Preview<Renderer> {
 
 type AnyFunction = (...args: any) => any;
 
+type PrimitiveKeys<T> = { [K in keyof T]-?: T[K] extends Primitive ? K : never }[keyof T];
+
 type Widen<T> = T extends AnyFunction
   ? T
-  : T extends string
-    ? string
-    : T extends number
-      ? number
-      : T extends boolean
-        ? boolean
-        : T extends bigint
-          ? bigint
-          : T extends symbol
-            ? symbol
-            : T extends readonly (infer E)[]
-              ? readonly Widen<E>[]
-              : T extends object
-                ? { [K in keyof T]: Widen<T[K]> }
-                : T;
+  : T extends Primitive
+    ? LiteralToPrimitive<T>
+    : T extends readonly (infer E)[]
+      ? readonly Widen<E>[]
+      : T extends object
+        ? { [K in keyof T]: Widen<T[K]> }
+        : T;
 
 /**
  * The constraint for the args a `meta()` call captures: the component args with every literal
- * widened to its primitive. TypeScript widens the literals in an args object literal before it
- * checks the constraint, and an inferred type that fails its constraint is replaced by that
- * constraint, which would drop the captured keys.
+ * widened to its primitive. TypeScript infers the component args from the same object literal, so
+ * it widens the literals in `args` before it checks this constraint. A constraint that demands the
+ * exact literals would reject the inferred args and replace them with the constraint itself, which
+ * drops the captured keys. See ./csf-factories-meta-args.md.
  */
 export type MetaArgsConstraint<TArgs> = { [K in keyof TArgs]?: Widen<TArgs[K]> };
 
 /**
- * The `args` a `meta()` call accepts: the captured args, validated against the component args.
- *
- * Function-typed args are validated through the constraint only. A contextual signature that
- * still refers to the component args type parameter makes TypeScript report a circular return
- * type for a `() => {}` arg.
+ * The `args` a `meta()` call accepts: the captured args, plus an exact check of the primitive args
+ * whose literal types the widened constraint gave up. It covers primitives only on purpose: a
+ * function or object type here would hand a contextual signature to the callbacks in `args` while
+ * the component args are still being inferred, which TypeScript reports as a circular return type.
  */
-export type MetaArgsInput<TInput, TArgs> = TInput & {
-  [K in keyof TArgs as NonNullable<TArgs[K]> extends AnyFunction ? never : K]?: TArgs[K];
-};
+export type MetaArgsInput<TInput, TArgs> = TInput & Partial<Pick<TArgs, PrimitiveKeys<TArgs>>>;
 
 export interface Meta<
   TRenderer extends Renderer,

--- a/code/core/src/csf/csf-factories.ts
+++ b/code/core/src/csf/csf-factories.ts
@@ -89,6 +89,19 @@ export function isPreview(input: unknown): input is Preview<Renderer> {
   return input != null && typeof input === 'object' && '_tag' in input && input?._tag === 'Preview';
 }
 
+// Polyfill of the TS 5.4 builtin so the published types keep validating on older TypeScript.
+type NoInfer<T> = [T][T extends any ? 0 : never];
+
+/**
+ * The `args` a `meta()` call accepts: the args as passed when they fit the component args,
+ * otherwise the component args so that TypeScript points at the offending property.
+ *
+ * The component args never take part in inference, so a literal value in `args` cannot widen them.
+ */
+export type MetaArgsInput<TInput, TArgs> = [TInput] extends [NoInfer<Partial<TArgs>>]
+  ? TInput & NoInfer<Partial<TArgs>>
+  : NoInfer<Partial<TArgs>>;
+
 export interface Meta<
   TRenderer extends Renderer,
   TMetaInput extends ComponentAnnotations<TRenderer, TRenderer['args']> = ComponentAnnotations<

--- a/code/core/src/csf/csf-factories.ts
+++ b/code/core/src/csf/csf-factories.ts
@@ -89,18 +89,44 @@ export function isPreview(input: unknown): input is Preview<Renderer> {
   return input != null && typeof input === 'object' && '_tag' in input && input?._tag === 'Preview';
 }
 
-// Polyfill of the TS 5.4 builtin so the published types keep validating on older TypeScript.
-type NoInfer<T> = [T][T extends any ? 0 : never];
+type AnyFunction = (...args: any) => any;
+
+type Widen<T> = T extends AnyFunction
+  ? T
+  : T extends string
+    ? string
+    : T extends number
+      ? number
+      : T extends boolean
+        ? boolean
+        : T extends bigint
+          ? bigint
+          : T extends symbol
+            ? symbol
+            : T extends readonly (infer E)[]
+              ? readonly Widen<E>[]
+              : T extends object
+                ? { [K in keyof T]: Widen<T[K]> }
+                : T;
 
 /**
- * The `args` a `meta()` call accepts: the args as passed when they fit the component args,
- * otherwise the component args so that TypeScript points at the offending property.
- *
- * The component args never take part in inference, so a literal value in `args` cannot widen them.
+ * The constraint for the args a `meta()` call captures: the component args with every literal
+ * widened to its primitive. TypeScript widens the literals in an args object literal before it
+ * checks the constraint, and an inferred type that fails its constraint is replaced by that
+ * constraint, which would drop the captured keys.
  */
-export type MetaArgsInput<TInput, TArgs> = [TInput] extends [NoInfer<Partial<TArgs>>]
-  ? TInput & NoInfer<Partial<TArgs>>
-  : NoInfer<Partial<TArgs>>;
+export type MetaArgsConstraint<TArgs> = { [K in keyof TArgs]?: Widen<TArgs[K]> };
+
+/**
+ * The `args` a `meta()` call accepts: the captured args, validated against the component args.
+ *
+ * Function-typed args are validated through the constraint only. A contextual signature that
+ * still refers to the component args type parameter makes TypeScript report a circular return
+ * type for a `() => {}` arg.
+ */
+export type MetaArgsInput<TInput, TArgs> = TInput & {
+  [K in keyof TArgs as NonNullable<TArgs[K]> extends AnyFunction ? never : K]?: TArgs[K];
+};
 
 export interface Meta<
   TRenderer extends Renderer,

--- a/code/frameworks/angular-vite/src/client/csf-factories.test.ts
+++ b/code/frameworks/angular-vite/src/client/csf-factories.test.ts
@@ -121,12 +121,16 @@ describe('Args can be provided in multiple ways', () => {
     });
   });
   it('✅ Literal args provided in meta do not need to be repeated in the story', () => {
-    type LiteralProps = { variant: 'primary' | 'secondary'; items: string[] };
+    type LiteralProps = {
+      variant: 'primary' | 'secondary';
+      items: string[];
+      slots: { header: () => void };
+    };
 
     {
       const meta = preview.type<{ args: LiteralProps }>().meta({
         component: ButtonComponent,
-        args: { variant: 'primary', items: [] },
+        args: { variant: 'primary', items: [], slots: { header: () => {} } },
       });
       const Basic = meta.story();
       const Secondary = meta.story({ args: { variant: 'secondary' } });
@@ -134,7 +138,7 @@ describe('Args can be provided in multiple ways', () => {
     {
       const meta = preview.meta({
         render: (args: LiteralProps) => ({ template: '<div></div>', props: args }),
-        args: { variant: 'primary', items: [] },
+        args: { variant: 'primary', items: [], slots: { header: () => {} } },
       });
       const Basic = meta.story();
     }

--- a/code/frameworks/angular-vite/src/client/csf-factories.test.ts
+++ b/code/frameworks/angular-vite/src/client/csf-factories.test.ts
@@ -120,6 +120,45 @@ describe('Args can be provided in multiple ways', () => {
       render: (args) => ({ template: '<div>Hello world</div>' }),
     });
   });
+  it('✅ Literal args provided in meta do not need to be repeated in the story', () => {
+    type LiteralProps = { variant: 'primary' | 'secondary'; items: string[] };
+
+    {
+      const meta = preview.type<{ args: LiteralProps }>().meta({
+        component: ButtonComponent,
+        args: { variant: 'primary', items: [] },
+      });
+      const Basic = meta.story();
+      const Secondary = meta.story({ args: { variant: 'secondary' } });
+    }
+    {
+      const meta = preview.meta({
+        render: (args: LiteralProps) => ({ template: '<div></div>', props: args }),
+        args: { variant: 'primary', items: [] },
+      });
+      const Basic = meta.story();
+    }
+  });
+
+  it('❌ Literal args provided in meta are still validated', () => {
+    type LiteralProps = { variant: 'primary' | 'secondary'; items: string[] };
+
+    {
+      const meta = preview.type<{ args: LiteralProps }>().meta({
+        component: ButtonComponent,
+        args: { variant: 'primary' },
+      });
+      // @ts-expect-error items not provided ❌
+      const Basic = meta.story();
+    }
+    {
+      const meta = preview.type<{ args: LiteralProps }>().meta({
+        component: ButtonComponent,
+        // @ts-expect-error tertiary is not a valid variant ❌
+        args: { variant: 'tertiary', items: [] },
+      });
+    }
+  });
 });
 
 type ThemeData = 'light' | 'dark';

--- a/code/frameworks/angular-vite/src/client/preview.ts
+++ b/code/frameworks/angular-vite/src/client/preview.ts
@@ -2,12 +2,14 @@ import type {
   AddonTypes,
   InferTypes,
   Meta,
+  MetaArgsInput,
   Preview,
   PreviewAddon,
   Story,
 } from 'storybook/internal/csf';
 import { definePreview as definePreviewBase } from 'storybook/internal/csf';
 import type {
+  Args,
   ArgsStoryFn,
   ComponentAnnotations,
   DecoratorFunction,
@@ -96,12 +98,12 @@ export interface AngularPreview<T extends AddonTypes> extends Preview<AngularRen
   meta<
     C extends abstract new (...args: any) => any,
     Decorators extends DecoratorFunction<AngularRenderer & T, any>,
-    // Try to make Exact<Partial<TArgs>, TMetaArgs> work
-    TMetaArgs extends Partial<InferComponentArgs<C> & T['args']>,
+    // A constraint here makes TS fall back to it for literal args, so story() re-requires them.
+    TMetaArgs extends Args,
   >(
     meta: {
       component?: C;
-      args?: TMetaArgs;
+      args?: MetaArgsInput<TMetaArgs, InferComponentArgs<C> & T['args']>;
       decorators?: Decorators | Decorators[];
     } & Omit<
       ComponentAnnotations<AngularRenderer & T, InferComponentArgs<C> & T['args']>,
@@ -117,11 +119,11 @@ export interface AngularPreview<T extends AddonTypes> extends Preview<AngularRen
   meta<
     TArgs,
     Decorators extends DecoratorFunction<AngularRenderer & T, any>,
-    TMetaArgs extends Partial<TArgs & T['args']>,
+    TMetaArgs extends Args,
   >(
     meta: {
       render?: ArgsStoryFn<AngularRenderer & T, TArgs & T['args']>;
-      args?: TMetaArgs;
+      args?: MetaArgsInput<TMetaArgs, TArgs & T['args']>;
       decorators?: Decorators | Decorators[];
     } & Omit<
       ComponentAnnotations<AngularRenderer & T, TArgs & T['args']>,

--- a/code/frameworks/angular-vite/src/client/preview.ts
+++ b/code/frameworks/angular-vite/src/client/preview.ts
@@ -2,6 +2,7 @@ import type {
   AddonTypes,
   InferTypes,
   Meta,
+  MetaArgsConstraint,
   MetaArgsInput,
   Preview,
   PreviewAddon,
@@ -9,7 +10,6 @@ import type {
 } from 'storybook/internal/csf';
 import { definePreview as definePreviewBase } from 'storybook/internal/csf';
 import type {
-  Args,
   ArgsStoryFn,
   ComponentAnnotations,
   DecoratorFunction,
@@ -98,8 +98,7 @@ export interface AngularPreview<T extends AddonTypes> extends Preview<AngularRen
   meta<
     C extends abstract new (...args: any) => any,
     Decorators extends DecoratorFunction<AngularRenderer & T, any>,
-    // A constraint here makes TS fall back to it for literal args, so story() re-requires them.
-    TMetaArgs extends Args,
+    TMetaArgs extends MetaArgsConstraint<InferComponentArgs<C> & T['args']>,
   >(
     meta: {
       component?: C;
@@ -119,7 +118,7 @@ export interface AngularPreview<T extends AddonTypes> extends Preview<AngularRen
   meta<
     TArgs,
     Decorators extends DecoratorFunction<AngularRenderer & T, any>,
-    TMetaArgs extends Args,
+    TMetaArgs extends MetaArgsConstraint<TArgs & T['args']>,
   >(
     meta: {
       render?: ArgsStoryFn<AngularRenderer & T, TArgs & T['args']>;

--- a/code/frameworks/angular/src/client/csf-factories.test.ts
+++ b/code/frameworks/angular/src/client/csf-factories.test.ts
@@ -122,12 +122,16 @@ describe('Args can be provided in multiple ways', () => {
   });
 
   it('✅ Literal args provided in meta do not need to be repeated in the story', () => {
-    type LiteralProps = { variant: 'primary' | 'secondary'; items: string[] };
+    type LiteralProps = {
+      variant: 'primary' | 'secondary';
+      items: string[];
+      slots: { header: () => void };
+    };
 
     {
       const meta = preview.type<{ args: LiteralProps }>().meta({
         component: ButtonComponent,
-        args: { variant: 'primary', items: [] },
+        args: { variant: 'primary', items: [], slots: { header: () => {} } },
       });
       const Basic = meta.story();
       const Secondary = meta.story({ args: { variant: 'secondary' } });
@@ -135,7 +139,7 @@ describe('Args can be provided in multiple ways', () => {
     {
       const meta = preview.meta({
         render: (args: LiteralProps) => ({ template: '<div></div>', props: args }),
-        args: { variant: 'primary', items: [] },
+        args: { variant: 'primary', items: [], slots: { header: () => {} } },
       });
       const Basic = meta.story();
     }

--- a/code/frameworks/angular/src/client/csf-factories.test.ts
+++ b/code/frameworks/angular/src/client/csf-factories.test.ts
@@ -120,6 +120,46 @@ describe('Args can be provided in multiple ways', () => {
       render: (args) => ({ template: '<div>Hello world</div>' }),
     });
   });
+
+  it('✅ Literal args provided in meta do not need to be repeated in the story', () => {
+    type LiteralProps = { variant: 'primary' | 'secondary'; items: string[] };
+
+    {
+      const meta = preview.type<{ args: LiteralProps }>().meta({
+        component: ButtonComponent,
+        args: { variant: 'primary', items: [] },
+      });
+      const Basic = meta.story();
+      const Secondary = meta.story({ args: { variant: 'secondary' } });
+    }
+    {
+      const meta = preview.meta({
+        render: (args: LiteralProps) => ({ template: '<div></div>', props: args }),
+        args: { variant: 'primary', items: [] },
+      });
+      const Basic = meta.story();
+    }
+  });
+
+  it('❌ Literal args provided in meta are still validated', () => {
+    type LiteralProps = { variant: 'primary' | 'secondary'; items: string[] };
+
+    {
+      const meta = preview.type<{ args: LiteralProps }>().meta({
+        component: ButtonComponent,
+        args: { variant: 'primary' },
+      });
+      // @ts-expect-error items not provided ❌
+      const Basic = meta.story();
+    }
+    {
+      const meta = preview.type<{ args: LiteralProps }>().meta({
+        component: ButtonComponent,
+        // @ts-expect-error tertiary is not a valid variant ❌
+        args: { variant: 'tertiary', items: [] },
+      });
+    }
+  });
 });
 
 type ThemeData = 'light' | 'dark';

--- a/code/frameworks/angular/src/client/preview.ts
+++ b/code/frameworks/angular/src/client/preview.ts
@@ -2,12 +2,14 @@ import type {
   AddonTypes,
   InferTypes,
   Meta,
+  MetaArgsInput,
   Preview,
   PreviewAddon,
   Story,
 } from 'storybook/internal/csf';
 import { definePreview as definePreviewBase } from 'storybook/internal/csf';
 import type {
+  Args,
   ArgsStoryFn,
   ComponentAnnotations,
   DecoratorFunction,
@@ -96,12 +98,12 @@ export interface AngularPreview<T extends AddonTypes> extends Preview<AngularRen
   meta<
     C extends abstract new (...args: any) => any,
     Decorators extends DecoratorFunction<AngularRenderer & T, any>,
-    // Try to make Exact<Partial<TArgs>, TMetaArgs> work
-    TMetaArgs extends Partial<InferComponentArgs<C> & T['args']>,
+    // A constraint here makes TS fall back to it for literal args, so story() re-requires them.
+    TMetaArgs extends Args,
   >(
     meta: {
       component?: C;
-      args?: TMetaArgs;
+      args?: MetaArgsInput<TMetaArgs, InferComponentArgs<C> & T['args']>;
       decorators?: Decorators | Decorators[];
     } & Omit<
       ComponentAnnotations<AngularRenderer & T, InferComponentArgs<C> & T['args']>,
@@ -117,11 +119,11 @@ export interface AngularPreview<T extends AddonTypes> extends Preview<AngularRen
   meta<
     TArgs,
     Decorators extends DecoratorFunction<AngularRenderer & T, any>,
-    TMetaArgs extends Partial<TArgs & T['args']>,
+    TMetaArgs extends Args,
   >(
     meta: {
       render?: ArgsStoryFn<AngularRenderer & T, TArgs & T['args']>;
-      args?: TMetaArgs;
+      args?: MetaArgsInput<TMetaArgs, TArgs & T['args']>;
       decorators?: Decorators | Decorators[];
     } & Omit<
       ComponentAnnotations<AngularRenderer & T, TArgs & T['args']>,

--- a/code/frameworks/angular/src/client/preview.ts
+++ b/code/frameworks/angular/src/client/preview.ts
@@ -2,6 +2,7 @@ import type {
   AddonTypes,
   InferTypes,
   Meta,
+  MetaArgsConstraint,
   MetaArgsInput,
   Preview,
   PreviewAddon,
@@ -9,7 +10,6 @@ import type {
 } from 'storybook/internal/csf';
 import { definePreview as definePreviewBase } from 'storybook/internal/csf';
 import type {
-  Args,
   ArgsStoryFn,
   ComponentAnnotations,
   DecoratorFunction,
@@ -98,8 +98,7 @@ export interface AngularPreview<T extends AddonTypes> extends Preview<AngularRen
   meta<
     C extends abstract new (...args: any) => any,
     Decorators extends DecoratorFunction<AngularRenderer & T, any>,
-    // A constraint here makes TS fall back to it for literal args, so story() re-requires them.
-    TMetaArgs extends Args,
+    TMetaArgs extends MetaArgsConstraint<InferComponentArgs<C> & T['args']>,
   >(
     meta: {
       component?: C;
@@ -119,7 +118,7 @@ export interface AngularPreview<T extends AddonTypes> extends Preview<AngularRen
   meta<
     TArgs,
     Decorators extends DecoratorFunction<AngularRenderer & T, any>,
-    TMetaArgs extends Args,
+    TMetaArgs extends MetaArgsConstraint<TArgs & T['args']>,
   >(
     meta: {
       render?: ArgsStoryFn<AngularRenderer & T, TArgs & T['args']>;

--- a/code/renderers/react/src/csf-factories.test.tsx
+++ b/code/renderers/react/src/csf-factories.test.tsx
@@ -105,6 +105,71 @@ describe('Args can be provided in multiple ways', () => {
       render: (args) => <div>Hello world</div>,
     });
   });
+
+  it('✅ Literal args provided in meta do not need to be repeated in the story', () => {
+    type LiteralProps = { variant: 'primary' | 'secondary'; disabled: boolean; items: string[] };
+    const Literal: (props: LiteralProps) => ReactElement = () => <></>;
+
+    {
+      const meta = preview.meta({
+        component: Literal,
+        args: { variant: 'primary', disabled: false, items: [] },
+      });
+      const Basic = meta.story();
+      const Secondary = meta.story({ args: { variant: 'secondary' } });
+    }
+    {
+      const meta = preview
+        .type<{ args: { extra?: boolean } }>()
+        .meta({ component: Literal, args: { variant: 'primary', disabled: false, items: [] } });
+      const Basic = meta.story();
+    }
+    {
+      const meta = preview.meta({
+        render: (args: LiteralProps) => <div>{args.variant}</div>,
+        args: { variant: 'primary', disabled: false, items: [] },
+      });
+      const Basic = meta.story();
+    }
+  });
+
+  it('✅ Enum and template literal args provided in meta do not need to be repeated in the story', () => {
+    enum Size {
+      Small = 'small',
+      Large = 'large',
+    }
+    type EnumProps = { size: Size; id: `id-${string}` };
+    const Enum: (props: EnumProps) => ReactElement = () => <></>;
+
+    const meta = preview.meta({ component: Enum, args: { size: Size.Small, id: 'id-1' } });
+    const Basic = meta.story();
+  });
+
+  it('❌ Literal args provided in meta are still validated', () => {
+    type LiteralProps = { variant: 'primary' | 'secondary'; disabled: boolean };
+    const Literal: (props: LiteralProps) => ReactElement = () => <></>;
+
+    {
+      const meta = preview.meta({ component: Literal, args: { variant: 'primary' } });
+      // @ts-expect-error disabled not provided ❌
+      const Basic = meta.story();
+    }
+    {
+      const meta = preview.meta({
+        component: Literal,
+        // @ts-expect-error tertiary is not a valid variant ❌
+        args: { variant: 'tertiary', disabled: false },
+      });
+    }
+    {
+      const meta = preview.meta({
+        component: Literal,
+        args: { variant: 'primary', disabled: false },
+      });
+      // @ts-expect-error tertiary is not a valid variant ❌
+      const Basic = meta.story({ args: { variant: 'tertiary' } });
+    }
+  });
 });
 
 it('✅ Void functions are not changed', () => {

--- a/code/renderers/react/src/csf-factories.test.tsx
+++ b/code/renderers/react/src/csf-factories.test.tsx
@@ -112,27 +112,35 @@ describe('Args can be provided in multiple ways', () => {
       disabled: boolean;
       items: string[];
       onDismiss?: () => void;
+      slots: { header: () => void };
     };
     const Literal: (props: LiteralProps) => ReactElement = () => <></>;
 
     {
       const meta = preview.meta({
         component: Literal,
-        args: { variant: 'primary', disabled: false, items: [], onDismiss: () => {} },
+        args: {
+          variant: 'primary',
+          disabled: false,
+          items: [],
+          onDismiss: () => {},
+          slots: { header: () => {} },
+        },
       });
       const Basic = meta.story();
       const Secondary = meta.story({ args: { variant: 'secondary' } });
     }
     {
-      const meta = preview
-        .type<{ args: { extra?: boolean } }>()
-        .meta({ component: Literal, args: { variant: 'primary', disabled: false, items: [] } });
+      const meta = preview.type<{ args: { extra?: boolean } }>().meta({
+        component: Literal,
+        args: { variant: 'primary', disabled: false, items: [], slots: { header: () => {} } },
+      });
       const Basic = meta.story();
     }
     {
       const meta = preview.meta({
         render: (args: LiteralProps) => <div>{args.variant}</div>,
-        args: { variant: 'primary', disabled: false, items: [] },
+        args: { variant: 'primary', disabled: false, items: [], slots: { header: () => {} } },
       });
       const Basic = meta.story();
     }

--- a/code/renderers/react/src/csf-factories.test.tsx
+++ b/code/renderers/react/src/csf-factories.test.tsx
@@ -107,13 +107,18 @@ describe('Args can be provided in multiple ways', () => {
   });
 
   it('✅ Literal args provided in meta do not need to be repeated in the story', () => {
-    type LiteralProps = { variant: 'primary' | 'secondary'; disabled: boolean; items: string[] };
+    type LiteralProps = {
+      variant: 'primary' | 'secondary';
+      disabled: boolean;
+      items: string[];
+      onDismiss?: () => void;
+    };
     const Literal: (props: LiteralProps) => ReactElement = () => <></>;
 
     {
       const meta = preview.meta({
         component: Literal,
-        args: { variant: 'primary', disabled: false, items: [] },
+        args: { variant: 'primary', disabled: false, items: [], onDismiss: () => {} },
       });
       const Basic = meta.story();
       const Secondary = meta.story({ args: { variant: 'secondary' } });

--- a/code/renderers/react/src/preview.tsx
+++ b/code/renderers/react/src/preview.tsx
@@ -5,6 +5,7 @@ import type {
   AddonTypes,
   InferTypes,
   Meta,
+  MetaArgsConstraint,
   MetaArgsInput,
   Preview,
   Story,
@@ -124,8 +125,7 @@ export interface ReactPreview<T extends AddonTypes> extends Preview<ReactTypes &
   meta<
     TArgs extends Args,
     Decorators extends DecoratorFunction<ReactTypes & T, any>,
-    // A constraint here makes TS fall back to it for literal args, so story() re-requires them.
-    TMetaArgs extends Args,
+    TMetaArgs extends MetaArgsConstraint<TArgs & T['args']>,
   >(
     meta: {
       render?: ArgsStoryFn<ReactTypes & T, TArgs & T['args']>;

--- a/code/renderers/react/src/preview.tsx
+++ b/code/renderers/react/src/preview.tsx
@@ -1,7 +1,14 @@
 import type { ComponentType } from 'react';
 
 import { definePreview as definePreviewBase } from 'storybook/internal/csf';
-import type { AddonTypes, InferTypes, Meta, Preview, Story } from 'storybook/internal/csf';
+import type {
+  AddonTypes,
+  InferTypes,
+  Meta,
+  MetaArgsInput,
+  Preview,
+  Story,
+} from 'storybook/internal/csf';
 import type { PreviewAddon } from 'storybook/internal/csf';
 import type {
   Args,
@@ -117,14 +124,14 @@ export interface ReactPreview<T extends AddonTypes> extends Preview<ReactTypes &
   meta<
     TArgs extends Args,
     Decorators extends DecoratorFunction<ReactTypes & T, any>,
-    // Try to make Exact<Partial<TArgs>, TMetaArgs> work
-    TMetaArgs extends Partial<TArgs & T['args']>,
+    // A constraint here makes TS fall back to it for literal args, so story() re-requires them.
+    TMetaArgs extends Args,
   >(
     meta: {
       render?: ArgsStoryFn<ReactTypes & T, TArgs & T['args']>;
       component?: ComponentType<TArgs>;
       decorators?: Decorators | Decorators[];
-      args?: TMetaArgs;
+      args?: MetaArgsInput<TMetaArgs, TArgs & T['args']>;
     } & Omit<
       ComponentAnnotations<ReactTypes & T, TArgs>,
       'decorators' | 'component' | 'args' | 'render'

--- a/code/renderers/vue3/src/csf-factories.test.ts
+++ b/code/renderers/vue3/src/csf-factories.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, expectTypeOf, it, test } from 'vitest';
 
 import type { Canvas } from 'storybook/internal/types';
 
-import { h } from 'vue';
+import { type PropType, defineComponent, h } from 'vue';
 
 import BaseLayout from './__tests__/BaseLayout.vue';
 import Button from './__tests__/Button.vue';
@@ -98,6 +98,52 @@ describe('StoryObj', () => {
       const Basic = meta.story({
         args: { label: 'good' },
       });
+    }
+  });
+
+  const LiteralButton = defineComponent({
+    props: {
+      label: { type: String as PropType<'A' | 'B'>, required: true },
+      items: { type: Array as PropType<string[]>, required: true },
+    },
+    render: () => h('button'),
+  });
+
+  it('✅ Literal args provided in meta do not need to be repeated in the story', () => {
+    {
+      const meta = preview.meta({ component: LiteralButton, args: { label: 'A', items: [] } });
+      const Basic = meta.story();
+      const B = meta.story({ args: { label: 'B' } });
+    }
+    {
+      const meta = preview
+        .type<{ args: { extra?: boolean } }>()
+        .meta({ component: LiteralButton, args: { label: 'A', items: [] } });
+      const Basic = meta.story();
+    }
+    {
+      const meta = preview.meta({
+        render: (args: { label: 'A' | 'B' }) => h('button', args.label),
+        args: { label: 'A' },
+      });
+      const Basic = meta.story();
+    }
+  });
+
+  it('❌ Literal args provided in meta are still validated', () => {
+    {
+      const meta = preview.meta({ component: LiteralButton, args: { label: 'A' } });
+      // @ts-expect-error items not provided ❌
+      const Basic = meta.story();
+    }
+    {
+      // @ts-expect-error C is not a valid label ❌
+      const meta = preview.meta({ component: LiteralButton, args: { label: 'C', items: [] } });
+    }
+    {
+      const meta = preview.meta({ component: LiteralButton, args: { label: 'A', items: [] } });
+      // @ts-expect-error C is not a valid label ❌
+      const Basic = meta.story({ args: { label: 'C' } });
     }
   });
 });

--- a/code/renderers/vue3/src/csf-factories.test.ts
+++ b/code/renderers/vue3/src/csf-factories.test.ts
@@ -128,6 +128,14 @@ describe('StoryObj', () => {
       });
       const Basic = meta.story();
     }
+    {
+      const meta = preview.type<{ args: { theme: 'light' | 'dark' } }>().meta({
+        render: (args: { label: 'A' | 'B' }) => h('button', args.label),
+        args: { label: 'A', theme: 'light' },
+      });
+      const Basic = meta.story();
+      const Dark = meta.story({ args: { theme: 'dark' } });
+    }
   });
 
   it('❌ Literal args provided in meta are still validated', () => {

--- a/code/renderers/vue3/src/csf-factories.test.ts
+++ b/code/renderers/vue3/src/csf-factories.test.ts
@@ -105,20 +105,25 @@ describe('StoryObj', () => {
     props: {
       label: { type: String as PropType<'A' | 'B'>, required: true },
       items: { type: Array as PropType<string[]>, required: true },
+      slots: { type: Object as PropType<{ header: () => void }>, required: true },
     },
     render: () => h('button'),
   });
 
   it('✅ Literal args provided in meta do not need to be repeated in the story', () => {
     {
-      const meta = preview.meta({ component: LiteralButton, args: { label: 'A', items: [] } });
+      const meta = preview.meta({
+        component: LiteralButton,
+        args: { label: 'A', items: [], slots: { header: () => {} } },
+      });
       const Basic = meta.story();
       const B = meta.story({ args: { label: 'B' } });
     }
     {
-      const meta = preview
-        .type<{ args: { extra?: boolean } }>()
-        .meta({ component: LiteralButton, args: { label: 'A', items: [] } });
+      const meta = preview.type<{ args: { extra?: boolean } }>().meta({
+        component: LiteralButton,
+        args: { label: 'A', items: [], slots: { header: () => {} } },
+      });
       const Basic = meta.story();
     }
     {
@@ -146,10 +151,16 @@ describe('StoryObj', () => {
     }
     {
       // @ts-expect-error C is not a valid label ❌
-      const meta = preview.meta({ component: LiteralButton, args: { label: 'C', items: [] } });
+      const meta = preview.meta({
+        component: LiteralButton,
+        args: { label: 'C', items: [], slots: { header: () => {} } },
+      });
     }
     {
-      const meta = preview.meta({ component: LiteralButton, args: { label: 'A', items: [] } });
+      const meta = preview.meta({
+        component: LiteralButton,
+        args: { label: 'A', items: [], slots: { header: () => {} } },
+      });
       // @ts-expect-error C is not a valid label ❌
       const Basic = meta.story({ args: { label: 'C' } });
     }

--- a/code/renderers/vue3/src/preview.ts
+++ b/code/renderers/vue3/src/preview.ts
@@ -118,7 +118,7 @@ export interface VuePreview<T extends AddonTypes> extends Preview<VueTypes & T> 
   >(
     meta: {
       render?: ArgsStoryFn<VueTypes & T, TArgs>;
-      args?: MetaArgsInput<TMetaArgs, TArgs>;
+      args?: MetaArgsInput<TMetaArgs, TArgs & T['args']>;
       decorators?: Decorators | Decorators[];
     } & Omit<
       ComponentAnnotations<VueTypes & T, TArgs & T['args']>,

--- a/code/renderers/vue3/src/preview.ts
+++ b/code/renderers/vue3/src/preview.ts
@@ -2,6 +2,7 @@ import type {
   AddonTypes,
   InferTypes,
   Meta,
+  MetaArgsInput,
   Preview,
   PreviewAddon,
   Story,
@@ -92,12 +93,12 @@ export interface VuePreview<T extends AddonTypes> extends Preview<VueTypes & T> 
   meta<
     C,
     Decorators extends DecoratorFunction<VueTypes & T, any>,
-    // Try to make Exact<Partial<TArgs>, TMetaArgs> work
-    TMetaArgs extends Partial<ComponentPropsAndSlots<C> & T['args']>,
+    // A constraint here makes TS fall back to it for literal args, so story() re-requires them.
+    TMetaArgs extends Args,
   >(
     meta: {
       component?: C;
-      args?: TMetaArgs;
+      args?: MetaArgsInput<TMetaArgs, ComponentPropsAndSlots<C> & T['args']>;
       decorators?: Decorators | Decorators[];
     } & Omit<
       ComponentAnnotations<VueTypes & T, ComponentPropsAndSlots<C> & T['args']>,
@@ -113,12 +114,11 @@ export interface VuePreview<T extends AddonTypes> extends Preview<VueTypes & T> 
   meta<
     TArgs extends Args,
     Decorators extends DecoratorFunction<VueTypes & T, any>,
-    // Try to make Exact<Partial<TArgs>, TMetaArgs> work
-    TMetaArgs extends Partial<TArgs>,
+    TMetaArgs extends Args,
   >(
     meta: {
       render?: ArgsStoryFn<VueTypes & T, TArgs>;
-      args?: TMetaArgs;
+      args?: MetaArgsInput<TMetaArgs, TArgs>;
       decorators?: Decorators | Decorators[];
     } & Omit<
       ComponentAnnotations<VueTypes & T, TArgs & T['args']>,

--- a/code/renderers/vue3/src/preview.ts
+++ b/code/renderers/vue3/src/preview.ts
@@ -2,6 +2,7 @@ import type {
   AddonTypes,
   InferTypes,
   Meta,
+  MetaArgsConstraint,
   MetaArgsInput,
   Preview,
   PreviewAddon,
@@ -93,8 +94,7 @@ export interface VuePreview<T extends AddonTypes> extends Preview<VueTypes & T> 
   meta<
     C,
     Decorators extends DecoratorFunction<VueTypes & T, any>,
-    // A constraint here makes TS fall back to it for literal args, so story() re-requires them.
-    TMetaArgs extends Args,
+    TMetaArgs extends MetaArgsConstraint<ComponentPropsAndSlots<C> & T['args']>,
   >(
     meta: {
       component?: C;
@@ -114,7 +114,7 @@ export interface VuePreview<T extends AddonTypes> extends Preview<VueTypes & T> 
   meta<
     TArgs extends Args,
     Decorators extends DecoratorFunction<VueTypes & T, any>,
-    TMetaArgs extends Args,
+    TMetaArgs extends MetaArgsConstraint<TArgs & T['args']>,
   >(
     meta: {
       render?: ArgsStoryFn<VueTypes & T, TArgs>;

--- a/code/renderers/web-components/src/csf-factories.test.ts
+++ b/code/renderers/web-components/src/csf-factories.test.ts
@@ -153,6 +153,14 @@ describe('Args can be provided in multiple ways', () => {
       });
       const Basic = meta.story();
     }
+    {
+      const meta = preview.type<{ args: { theme: 'light' | 'dark' } }>().meta({
+        render: (args: LiteralProps) => html`<div>${args.variant}</div>`,
+        args: { variant: 'primary', items: [], theme: 'light' },
+      });
+      const Basic = meta.story();
+      const Dark = meta.story({ args: { theme: 'dark' } });
+    }
   });
 
   it('❌ Literal args provided in meta are still validated', () => {

--- a/code/renderers/web-components/src/csf-factories.test.ts
+++ b/code/renderers/web-components/src/csf-factories.test.ts
@@ -136,12 +136,16 @@ describe('Args can be provided in multiple ways', () => {
   });
 
   it('✅ Literal args provided in meta do not need to be repeated in the story', () => {
-    type LiteralProps = { variant: 'primary' | 'secondary'; items: string[] };
+    type LiteralProps = {
+      variant: 'primary' | 'secondary';
+      items: string[];
+      slots: { header: () => void };
+    };
 
     {
       const meta = preview.type<{ args: LiteralProps }>().meta({
         component: 'my-button',
-        args: { variant: 'primary', items: [] },
+        args: { variant: 'primary', items: [], slots: { header: () => {} } },
       });
       const Basic = meta.story();
       const Secondary = meta.story({ args: { variant: 'secondary' } });
@@ -149,14 +153,14 @@ describe('Args can be provided in multiple ways', () => {
     {
       const meta = preview.meta({
         render: (args: LiteralProps) => html`<div>${args.variant}</div>`,
-        args: { variant: 'primary', items: [] },
+        args: { variant: 'primary', items: [], slots: { header: () => {} } },
       });
       const Basic = meta.story();
     }
     {
       const meta = preview.type<{ args: { theme: 'light' | 'dark' } }>().meta({
         render: (args: LiteralProps) => html`<div>${args.variant}</div>`,
-        args: { variant: 'primary', items: [], theme: 'light' },
+        args: { variant: 'primary', items: [], slots: { header: () => {} }, theme: 'light' },
       });
       const Basic = meta.story();
       const Dark = meta.story({ args: { theme: 'dark' } });

--- a/code/renderers/web-components/src/csf-factories.test.ts
+++ b/code/renderers/web-components/src/csf-factories.test.ts
@@ -134,6 +134,46 @@ describe('Args can be provided in multiple ways', () => {
         `,
     });
   });
+
+  it('✅ Literal args provided in meta do not need to be repeated in the story', () => {
+    type LiteralProps = { variant: 'primary' | 'secondary'; items: string[] };
+
+    {
+      const meta = preview.type<{ args: LiteralProps }>().meta({
+        component: 'my-button',
+        args: { variant: 'primary', items: [] },
+      });
+      const Basic = meta.story();
+      const Secondary = meta.story({ args: { variant: 'secondary' } });
+    }
+    {
+      const meta = preview.meta({
+        render: (args: LiteralProps) => html`<div>${args.variant}</div>`,
+        args: { variant: 'primary', items: [] },
+      });
+      const Basic = meta.story();
+    }
+  });
+
+  it('❌ Literal args provided in meta are still validated', () => {
+    type LiteralProps = { variant: 'primary' | 'secondary'; items: string[] };
+
+    {
+      const meta = preview.type<{ args: LiteralProps }>().meta({
+        component: 'my-button',
+        args: { variant: 'primary' },
+      });
+      // @ts-expect-error items not provided ❌
+      const Basic = meta.story();
+    }
+    {
+      const meta = preview.meta({
+        render: (args: LiteralProps) => html`<div>${args.variant}</div>`,
+        // @ts-expect-error tertiary is not a valid variant ❌
+        args: { variant: 'tertiary', items: [] },
+      });
+    }
+  });
 });
 
 type ThemeData = 'light' | 'dark';

--- a/code/renderers/web-components/src/preview.ts
+++ b/code/renderers/web-components/src/preview.ts
@@ -2,6 +2,7 @@ import type {
   AddonTypes,
   InferTypes,
   Meta,
+  MetaArgsConstraint,
   MetaArgsInput,
   Preview,
   PreviewAddon,
@@ -9,7 +10,6 @@ import type {
 } from 'storybook/internal/csf';
 import { definePreview as definePreviewBase } from 'storybook/internal/csf';
 import type {
-  Args,
   ArgsStoryFn,
   ComponentAnnotations,
   DecoratorFunction,
@@ -104,8 +104,7 @@ export interface WebComponentsPreview<T extends AddonTypes> extends Preview<
   meta<
     C extends keyof HTMLElementTagNameMap,
     Decorators extends DecoratorFunction<WebComponentsTypes & T, any>,
-    // A constraint here makes TS fall back to it for literal args, so story() re-requires them.
-    TMetaArgs extends Args,
+    TMetaArgs extends MetaArgsConstraint<InferArgsFromComponent<C> & T['args']>,
   >(
     meta: {
       component?: C;
@@ -128,7 +127,7 @@ export interface WebComponentsPreview<T extends AddonTypes> extends Preview<
   meta<
     TArgs,
     Decorators extends DecoratorFunction<WebComponentsTypes & T, any>,
-    TMetaArgs extends Args,
+    TMetaArgs extends MetaArgsConstraint<TArgs & T['args']>,
   >(
     meta: {
       render?: ArgsStoryFn<WebComponentsTypes & T, TArgs>;

--- a/code/renderers/web-components/src/preview.ts
+++ b/code/renderers/web-components/src/preview.ts
@@ -2,12 +2,14 @@ import type {
   AddonTypes,
   InferTypes,
   Meta,
+  MetaArgsInput,
   Preview,
   PreviewAddon,
   Story,
 } from 'storybook/internal/csf';
 import { definePreview as definePreviewBase } from 'storybook/internal/csf';
 import type {
+  Args,
   ArgsStoryFn,
   ComponentAnnotations,
   DecoratorFunction,
@@ -102,12 +104,12 @@ export interface WebComponentsPreview<T extends AddonTypes> extends Preview<
   meta<
     C extends keyof HTMLElementTagNameMap,
     Decorators extends DecoratorFunction<WebComponentsTypes & T, any>,
-    // Try to make Exact<Partial<TArgs>, TMetaArgs> work
-    TMetaArgs extends InferArgsFromComponent<C> & Partial<T['args']>,
+    // A constraint here makes TS fall back to it for literal args, so story() re-requires them.
+    TMetaArgs extends Args,
   >(
     meta: {
       component?: C;
-      args?: TMetaArgs;
+      args?: MetaArgsInput<TMetaArgs, InferArgsFromComponent<C> & T['args']>;
       decorators?: Decorators | Decorators[];
     } & Omit<
       ComponentAnnotations<WebComponentsTypes & T, InferArgsFromComponent<C> & T['args']>,
@@ -126,12 +128,11 @@ export interface WebComponentsPreview<T extends AddonTypes> extends Preview<
   meta<
     TArgs,
     Decorators extends DecoratorFunction<WebComponentsTypes & T, any>,
-    // Try to make Exact<Partial<TArgs>, TMetaArgs> work
-    TMetaArgs extends Partial<TArgs>,
+    TMetaArgs extends Args,
   >(
     meta: {
       render?: ArgsStoryFn<WebComponentsTypes & T, TArgs>;
-      args?: TMetaArgs;
+      args?: MetaArgsInput<TMetaArgs, TArgs>;
       decorators?: Decorators | Decorators[];
     } & Omit<
       ComponentAnnotations<WebComponentsTypes & T, TArgs & T['args']>,

--- a/code/renderers/web-components/src/preview.ts
+++ b/code/renderers/web-components/src/preview.ts
@@ -132,7 +132,7 @@ export interface WebComponentsPreview<T extends AddonTypes> extends Preview<
   >(
     meta: {
       render?: ArgsStoryFn<WebComponentsTypes & T, TArgs>;
-      args?: MetaArgsInput<TMetaArgs, TArgs>;
+      args?: MetaArgsInput<TMetaArgs, TArgs & T['args']>;
       decorators?: Decorators | Decorators[];
     } & Omit<
       ComponentAnnotations<WebComponentsTypes & T, TArgs & T['args']>,


### PR DESCRIPTION
Closes #36125, closes #32829

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

**The bug.** When a component has a required prop with a literal type and meta supplies it, the story still had to supply it again:

```ts
const meta = preview.meta({
  component: Button, // props: { variant: 'primary' | 'secondary' }
  args: { variant: 'primary' },
});

export const Default = meta.story(); // ❌ Expected 1 arguments, but got 0
```

Same for enums and template literals (#32829). A prop typed `string` worked fine.

**The cause.** `meta()` captures the args you pass in a type parameter constrained to the component props. The props are inferred from the same object literal, so TypeScript does not know them yet while it checks `args`, and it widens `'primary'` to `string`. The widened args fail the constraint, TypeScript falls back to the constraint itself (all optional), and our "did meta provide anything" guard reads that as "nothing".

**The fix.** Two types in `storybook/internal/csf`, used by all five `meta()` signatures (React, Vue 3, Web Components, Angular, Angular-Vite):

1. `MetaArgsConstraint` widens the constraint, so the widened args satisfy it and nothing falls back.
2. `MetaArgsInput` checks the primitive args exactly afterwards, because widening only lost precision there.

```ts
export type MetaArgsConstraint<TArgs> = { [K in keyof TArgs]?: Widen<TArgs[K]> };
export type MetaArgsInput<TInput, TArgs> = TInput & Partial<Pick<TArgs, PrimitiveKeys<TArgs>>>;
```

The exact check covers primitives only, on purpose. A function or object type in it would hand a contextual signature to a `() => {}` in the args while the props are still being inferred, which TypeScript reports as a circular return type. Functions, objects and arrays are still validated through the constraint, as before, and handler parameters in meta args keep their inferred types.

**What changes for users.** Literal, enum and template-literal args supplied in meta no longer need to be repeated in stories. An invalid literal is still rejected, now on the `meta.args` property instead of confusingly at `meta.story()`. `meta.input.args` is typed as it always was (`variant: string`), and editor completions in `args` are unchanged. Works within the TypeScript 4.9 peer range.

**What it gives up.** Literal precision inside object, array and tuple args is checked widened only: `nested: { mode: 'c' }` passes for a prop typed `mode: 'a' | 'b'`.

**Why not `const TMetaArgs`** (#36134, #36150). It needs TypeScript 5.0 and infers array literals as readonly tuples, which fail a mutable `string[]` prop through the same fallback. That breaks metas with array args that work today and leaves the reported case broken whenever an array prop sits next to the literal one. Credit to @akuumaa, who first proposed checking on the `args` field, and to @unional for the React diagnosis and repro.

**Read more.** [`code/core/src/csf/csf-factories-meta-args.md`](https://github.com/storybookjs/storybook/blob/kasper/csf-factories-literal-meta-args/code/core/src/csf/csf-factories-meta-args.md) explains why TypeScript cannot infer this in one object literal (microsoft/TypeScript#48538, microsoft/TypeScript#47599), the six variants that were measured and rejected, and the API shapes that would make the machinery unnecessary, such as `preview.meta(Button, { args })`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Type tests in each renderer's `csf-factories.test` file:

- a literal arg supplied in meta can be omitted in the story, with and without `.type()`, next to array, function and `() => {}` args (top-level and nested inside an object arg), and through the `render` overload
- enum and template-literal args (React, #32829)
- an invalid literal is still rejected, at meta and at story level
- a required arg missing from both is still required

They run under `yarn nx run-many -t check` and `yarn test csf-factories`.

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. `yarn nx run-many -t check` passes, including the manager stories in `code/core`.
2. Revert `code/renderers/react/src/preview.tsx` and run `yarn nx check react`: the new tests fail with `TS2554: Expected 1 arguments, but got 0`.
3. Optional, the reporters' repros against a canary: https://github.com/bodograumann/repro-sb-csfnext-meta-litral-args (Vue 3, `npm run typecheck`) and https://github.com/cyberuni/storybook-csf-meta-args-repro (React, `src/stepper.stories.tsx`).

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No user-facing documentation changes. `code/core/src/csf/csf-factories-meta-args.md` documents the design for maintainers.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

