### PR TITLE
Addon MCP: Suppress preview-stories when display-review is active

### DIFF
--- a/code/addons/mcp/src/preset.test.ts
+++ b/code/addons/mcp/src/preset.test.ts
@@ -407,72 +407,84 @@ describe('experimental_devServer', () => {
     expect(html).not.toMatch(/\{\{[A-Z_]+\}\}/);
   });
 
-  it('marks stories-preview disabled whenever review-create is available', async () => {
-    const render = async ({
-      reviewEnabled,
-      reviewEnabledForCli,
-    }: {
-      reviewEnabled: boolean;
-      reviewEnabledForCli: boolean;
-    }) => {
-      vi.mocked(getToolAvailability).mockResolvedValueOnce({
-        moduleGraphSupported: true,
-        changeDetectionEnabled: true,
-        reviewEnabled,
-        reviewEnabledForCli,
-        docsEnabled: false,
-        docsEnabledForCli: false,
-        docsHasManifests: false,
-        docsFeatureEnabled: false,
-        testSupported: false,
-        a11yEnabled: false,
-        docgenServer: false,
-      });
+  describe('stories-preview availability', () => {
+    let availability: Awaited<ReturnType<typeof getToolAvailability>>;
+    let getHandler: any;
 
-      let getHandler: any;
+    beforeEach(() => {
+      vi.mocked(getToolAvailability).mockImplementation(async () => availability);
+
       mockApp.get = vi.fn((_path, handler) => {
         getHandler = handler;
       });
-
-      await (experimental_devServer as any)(mockApp, mockOptions);
-
-      const mockRes = { writeHead: vi.fn(), end: vi.fn() } as any;
-      await getHandler({ headers: { accept: 'text/html' } } as any, mockRes);
-
-      return mockRes.end.mock.calls[0][0] as string;
-    };
-
-    const badgeFor = (html: string, tool: string) =>
-      html.match(
-        new RegExp(`<code>${tool}</code>\\s*<span class="toolset-status (enabled|disabled)"`)
-      )?.[1];
-
-    const withDirectReview = await render({
-      reviewEnabled: true,
-      reviewEnabledForCli: true,
     });
 
-    expect(badgeFor(withDirectReview, 'stories-preview')).toBe('disabled');
-    expect(badgeFor(withDirectReview, 'review-create')).toBe('enabled');
-    expect(withDirectReview).toContain(
-      '<code>stories-preview</code> is suppressed while <code>review-create</code> is available.'
-    );
-
-    const withCliReview = await render({
-      reviewEnabled: false,
-      reviewEnabledForCli: true,
+    afterEach(() => {
+      vi.mocked(getToolAvailability).mockReset();
     });
 
-    expect(badgeFor(withCliReview, 'stories-preview')).toBe('disabled');
-    expect(badgeFor(withCliReview, 'review-create')).toBe('enabled');
+    it('marks stories-preview disabled whenever review-create is available', async () => {
+      const render = async ({
+        reviewEnabled,
+        reviewEnabledForCli,
+      }: {
+        reviewEnabled: boolean;
+        reviewEnabledForCli: boolean;
+      }) => {
+        availability = {
+          moduleGraphSupported: true,
+          changeDetectionEnabled: true,
+          reviewEnabled,
+          reviewEnabledForCli,
+          docsEnabled: false,
+          docsEnabledForCli: false,
+          docsHasManifests: false,
+          docsFeatureEnabled: false,
+          testSupported: false,
+          a11yEnabled: false,
+          docgenServer: false,
+        };
 
-    const withoutReview = await render({
-      reviewEnabled: false,
-      reviewEnabledForCli: false,
+        await (experimental_devServer as any)(mockApp, mockOptions);
+
+        const mockRes = { writeHead: vi.fn(), end: vi.fn() } as any;
+        await getHandler({ headers: { accept: 'text/html' } } as any, mockRes);
+
+        return mockRes.end.mock.calls[0][0] as string;
+      };
+
+      const badgeFor = (html: string, tool: string) =>
+        html.match(
+          new RegExp(`<code>${tool}</code>\\s*<span class="toolset-status (enabled|disabled)"`)
+        )?.[1];
+
+      const withDirectReview = await render({
+        reviewEnabled: true,
+        reviewEnabledForCli: true,
+      });
+
+      expect(badgeFor(withDirectReview, 'stories-preview')).toBe('disabled');
+      expect(badgeFor(withDirectReview, 'review-create')).toBe('enabled');
+      expect(withDirectReview).toContain(
+        '<code>stories-preview</code> is suppressed while <code>review-create</code> is available.'
+      );
+
+      const withCliReview = await render({
+        reviewEnabled: false,
+        reviewEnabledForCli: true,
+      });
+
+      expect(badgeFor(withCliReview, 'stories-preview')).toBe('disabled');
+      expect(badgeFor(withCliReview, 'review-create')).toBe('enabled');
+
+      const withoutReview = await render({
+        reviewEnabled: false,
+        reviewEnabledForCli: false,
+      });
+
+      expect(badgeFor(withoutReview, 'stories-preview')).toBe('enabled');
+      expect(badgeFor(withoutReview, 'review-create')).toBe('disabled');
     });
-
-    expect(badgeFor(withoutReview, 'stories-preview')).toBe('enabled');
-    expect(badgeFor(withoutReview, 'review-create')).toBe('disabled');
   });
 
   it('names the missing manifest prerequisite instead of claiming the framework is unsupported', async () => {

--- a/code/addons/mcp/src/preset.test.ts
+++ b/code/addons/mcp/src/preset.test.ts
@@ -476,6 +476,9 @@ describe('experimental_devServer', () => {
 
       expect(badgeFor(withCliReview, 'stories-preview')).toBe('disabled');
       expect(badgeFor(withCliReview, 'review-create')).toBe('enabled');
+      expect(withCliReview).toContain(
+        '<code>stories-preview</code> is suppressed while <code>review-create</code> is available.'
+      );
 
       const withoutReview = await render({
         reviewEnabled: false,

--- a/code/addons/mcp/src/preset.test.ts
+++ b/code/addons/mcp/src/preset.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { Options } from 'storybook/internal/types';
 import { getToolAvailability } from 'storybook/internal/core-server';
-import { experimental_devServer } from './preset.ts';
+import type { Options } from 'storybook/internal/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as mcpHandlerModule from './mcp-handler.ts';
+import { experimental_devServer } from './preset.ts';
 import { registerCoreToolsetsForTest } from './test-support/register-core-toolsets.ts';
 
 // `getToolAvailability` now lives in core (`storybook/internal/core-server`) and composes its own
@@ -342,6 +342,7 @@ describe('experimental_devServer', () => {
 
     const html = mockRes.end.mock.calls[0][0] as string;
     for (const tool of [
+      'stories-preview',
       'stories-find-by-component',
       'stories-changed',
       'review-create',
@@ -394,11 +395,84 @@ describe('experimental_devServer', () => {
         new RegExp(`<code>${tool}</code>\\s*<span class="toolset-status (enabled|disabled)"`)
       )?.[1];
 
-    for (const tool of ['stories-find-by-component', 'stories-changed', 'review-create']) {
+    for (const tool of [
+      'stories-find-by-component',
+      'stories-changed',
+      'review-create',
+      'stories-preview',
+    ]) {
       expect(badgeFor(tool)).toBe('disabled');
     }
     expect(html).toContain('The <code>dev</code> toolset is disabled via addon options.');
     expect(html).not.toMatch(/\{\{[A-Z_]+\}\}/);
+  });
+
+  it('marks stories-preview disabled whenever review-create is available', async () => {
+    const render = async ({
+      reviewEnabled,
+      reviewEnabledForCli,
+    }: {
+      reviewEnabled: boolean;
+      reviewEnabledForCli: boolean;
+    }) => {
+      vi.mocked(getToolAvailability).mockResolvedValueOnce({
+        moduleGraphSupported: true,
+        changeDetectionEnabled: true,
+        reviewEnabled,
+        reviewEnabledForCli,
+        docsEnabled: false,
+        docsEnabledForCli: false,
+        docsHasManifests: false,
+        docsFeatureEnabled: false,
+        testSupported: false,
+        a11yEnabled: false,
+        docgenServer: false,
+      });
+
+      let getHandler: any;
+      mockApp.get = vi.fn((_path, handler) => {
+        getHandler = handler;
+      });
+
+      await (experimental_devServer as any)(mockApp, mockOptions);
+
+      const mockRes = { writeHead: vi.fn(), end: vi.fn() } as any;
+      await getHandler({ headers: { accept: 'text/html' } } as any, mockRes);
+
+      return mockRes.end.mock.calls[0][0] as string;
+    };
+
+    const badgeFor = (html: string, tool: string) =>
+      html.match(
+        new RegExp(`<code>${tool}</code>\\s*<span class="toolset-status (enabled|disabled)"`)
+      )?.[1];
+
+    const withDirectReview = await render({
+      reviewEnabled: true,
+      reviewEnabledForCli: true,
+    });
+
+    expect(badgeFor(withDirectReview, 'stories-preview')).toBe('disabled');
+    expect(badgeFor(withDirectReview, 'review-create')).toBe('enabled');
+    expect(withDirectReview).toContain(
+      '<code>stories-preview</code> is suppressed while <code>review-create</code> is available.'
+    );
+
+    const withCliReview = await render({
+      reviewEnabled: false,
+      reviewEnabledForCli: true,
+    });
+
+    expect(badgeFor(withCliReview, 'stories-preview')).toBe('disabled');
+    expect(badgeFor(withCliReview, 'review-create')).toBe('enabled');
+
+    const withoutReview = await render({
+      reviewEnabled: false,
+      reviewEnabledForCli: false,
+    });
+
+    expect(badgeFor(withoutReview, 'stories-preview')).toBe('enabled');
+    expect(badgeFor(withoutReview, 'review-create')).toBe('disabled');
   });
 
   it('names the missing manifest prerequisite instead of claiming the framework is unsupported', async () => {

--- a/code/addons/mcp/src/preset.ts
+++ b/code/addons/mcp/src/preset.ts
@@ -1,21 +1,21 @@
-import { mcpServerHandler } from './mcp-handler.ts';
-import type { PresetPropertyFn, StorybookConfigRaw } from 'storybook/internal/types';
-import { AddonOptions, type AddonOptionsInput } from './types.ts';
-import * as v from 'valibot';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import path from 'node:path';
 import {
   createLocalDocsAccess,
   getEffectiveToolAvailability,
   getToolAvailability,
   loadManifests,
 } from 'storybook/internal/core-server';
-import htmlTemplate from './template.html';
-import path from 'node:path';
+import { logger } from 'storybook/internal/node-logger';
+import type { PresetPropertyFn, StorybookConfigRaw } from 'storybook/internal/types';
+import * as v from 'valibot';
 import { extractBearerToken, type ManifestProvider } from './auth/index.ts';
 import { resolveCompositionSources } from './auth/resolve-composition-sources.ts';
-import { logger } from 'storybook/internal/node-logger';
-import type { IncomingMessage, ServerResponse } from 'node:http';
 import { DEFAULT_MCP_ENDPOINT } from './constants.ts';
+import { mcpServerHandler } from './mcp-handler.ts';
 import { buildStorybookAiMetadata, type StorybookAiMetadata } from './storybook-ai-metadata.ts';
+import htmlTemplate from './template.html';
+import { AddonOptions, type AddonOptionsInput } from './types.ts';
 import { getStoryIndex } from './utils/get-story-index.ts';
 
 export const previewAnnotations: PresetPropertyFn<'previewAnnotations'> = async (
@@ -187,11 +187,11 @@ export const experimental_devServer: PresetPropertyFn<
       ? ' <span class="toolset-status enabled">+ accessibility</span>'
       : '';
 
-    // `stories-find-by-component`, `stories-changed`, and `review-create` are gated
-    // independently of the `dev` toolset — `stories-find-by-component` needs the dependency
-    // graph, `stories-changed` needs the `changeDetection` feature flag, and
-    // `review-create` additionally needs the opt-in `experimentalReview` feature flag —
-    // so each shows its own badge.
+    // `stories-preview`, `stories-find-by-component`, `stories-changed`, and `review-create`
+    // are gated independently of the `dev` toolset. `stories-preview` is suppressed whenever
+    // `review-create` is available, `stories-find-by-component` needs the dependency graph,
+    // `stories-changed` needs the `changeDetection` feature flag, and `review-create`
+    // additionally needs the opt-in `experimentalReview` feature flag.
     // When the whole `dev` toolset is turned off via addon options every dev tool is
     // disabled regardless of its own gate, so explain that instead of the per-tool reasons.
     const devNoticeLines = !isDevEnabled
@@ -205,6 +205,8 @@ export const experimental_devServer: PresetPropertyFn<
             (reviewEnabledForCli
               ? `<code>review-create</code> is enabled for <code>storybook ai</code> CLI clients (the Claude/Codex plugins); direct MCP clients need the <code>experimentalReview</code> feature flag.`
               : `<code>review-create</code> requires the <code>changeDetection</code> feature flag and is off when <code>experimentalReview</code> is set to <code>false</code>.`),
+          reviewEnabledForCli &&
+            `<code>stories-preview</code> is suppressed while <code>review-create</code> is available.`,
         ].filter(Boolean);
     const devNotice = devNoticeLines.length
       ? `<div class="toolset-notice">${devNoticeLines.join('<br>')}</div>`
@@ -214,6 +216,7 @@ export const experimental_devServer: PresetPropertyFn<
 
     const html = htmlTemplate
       .replaceAll('{{DEV_STATUS}}', isDevEnabled ? 'enabled' : 'disabled')
+      .replaceAll('{{PREVIEW_STATUS}}', statusWord(isDevEnabled && !reviewEnabledForCli))
       .replaceAll(
         '{{STORIES_BY_COMPONENT_STATUS}}',
         statusWord(isDevEnabled && moduleGraphSupported)

--- a/code/addons/mcp/src/storybook-ai-metadata.test.ts
+++ b/code/addons/mcp/src/storybook-ai-metadata.test.ts
@@ -1,17 +1,16 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { registerCoreToolsetsForTest } from './test-support/register-core-toolsets.ts';
-import { McpServer } from 'tmcp';
 import { ValibotJsonSchemaAdapter } from '@tmcp/adapter-valibot';
-import { logger } from 'storybook/internal/node-logger';
 import {
   getEffectiveToolAvailability,
   getToolAvailability,
   isModuleGraphSupportedByBuilder,
   type ToolAvailability,
 } from 'storybook/internal/core-server';
-import { buildStorybookAiMetadata } from './storybook-ai-metadata.ts';
-import type { AddonContext } from './types.ts';
+import { logger } from 'storybook/internal/node-logger';
 import { toMcpToolName } from 'storybook/internal/toolsets-docs';
+import { McpServer } from 'tmcp';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildStorybookAiMetadata } from './storybook-ai-metadata.ts';
+import { registerCoreToolsetsForTest } from './test-support/register-core-toolsets.ts';
 import {
   DISPLAY_REVIEW_TOOL_NAME,
   GET_STORIES_BY_COMPONENT_TOOL_NAME,
@@ -20,6 +19,7 @@ import {
   RUN_STORY_TESTS_TOOL_NAME,
 } from './tools/tool-names.ts';
 import { registerAddonMcpTools } from './tools/tool-registry.ts';
+import type { AddonContext } from './types.ts';
 
 // `getToolAvailability` and `isModuleGraphSupportedByBuilder` now live in core
 // (`storybook/internal/core-server`) and compose their own sub-probes internally, so this file
@@ -343,7 +343,7 @@ describe('buildStorybookAiMetadata', () => {
       ...first,
       tools: [
         {
-          name: PREVIEW_STORIES_TOOL_NAME,
+          name: GET_UI_BUILDING_INSTRUCTIONS_TOOL_NAME,
           description: 'stale descriptor',
           inputSchema: { type: 'object' },
         },
@@ -353,9 +353,11 @@ describe('buildStorybookAiMetadata', () => {
 
     expect(merged.instructions).toBe(first.instructions);
     expect(merged.tools.map((tool) => tool.name)).toEqual(first.tools.map((tool) => tool.name));
-    expect(merged.tools.filter((tool) => tool.name === PREVIEW_STORIES_TOOL_NAME)).toHaveLength(1);
     expect(
-      merged.tools.find((tool) => tool.name === PREVIEW_STORIES_TOOL_NAME)?.description
+      merged.tools.filter((tool) => tool.name === GET_UI_BUILDING_INSTRUCTIONS_TOOL_NAME)
+    ).toHaveLength(1);
+    expect(
+      merged.tools.find((tool) => tool.name === GET_UI_BUILDING_INSTRUCTIONS_TOOL_NAME)?.description
     ).not.toBe('stale descriptor');
   });
 
@@ -398,6 +400,7 @@ describe('buildStorybookAiMetadata', () => {
     const metadata = await buildStorybookAiMetadata(createOptions());
 
     expect(metadata.tools.map((tool) => tool.name)).toContain(DISPLAY_REVIEW_TOOL_NAME);
+    expect(metadata.tools.map((tool) => tool.name)).not.toContain(PREVIEW_STORIES_TOOL_NAME);
     expect(metadata.instructions).toContain(DISPLAY_REVIEW_TOOL_NAME);
   });
 
@@ -520,6 +523,14 @@ describe('tool availability variants', () => {
 
     expect(withReview).toContain(DISPLAY_REVIEW_TOOL_NAME);
     expect(withoutReview).not.toContain(DISPLAY_REVIEW_TOOL_NAME);
+  });
+
+  it('offers no preview tool while a review is available', async () => {
+    const withReview = await names({});
+    const withoutReview = await names({ reviewEnabled: false });
+
+    expect(withReview).not.toContain(PREVIEW_STORIES_TOOL_NAME);
+    expect(withoutReview).toContain(PREVIEW_STORIES_TOOL_NAME);
   });
 
   it('offers no test tool when addon-vitest is absent', async () => {

--- a/code/addons/mcp/src/template.html
+++ b/code/addons/mcp/src/template.html
@@ -201,7 +201,10 @@
             <span class="toolset-status {{DEV_STATUS}}">{{DEV_STATUS}}</span>
           </div>
           <ul class="toolset-tools">
-            <li><code>stories-preview</code></li>
+            <li>
+              <code>stories-preview</code>
+              <span class="toolset-status {{PREVIEW_STATUS}}">{{PREVIEW_STATUS}}</span>
+            </li>
             <li><code>get-storybook-story-instructions</code></li>
             <li>
               <code>stories-changed</code>

--- a/code/addons/mcp/src/tools/get-storybook-story-instructions.test.ts
+++ b/code/addons/mcp/src/tools/get-storybook-story-instructions.test.ts
@@ -1,15 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { McpServer } from 'tmcp';
 import { ValibotJsonSchemaAdapter } from '@tmcp/adapter-valibot';
+import { McpServer } from 'tmcp';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AddonContext } from '../types.ts';
 import {
   addGetUIBuildingInstructionsTool,
   buildStorybookStoryInstructions,
 } from './get-storybook-story-instructions.ts';
-import type { AddonContext } from '../types.ts';
 import {
-  PREVIEW_STORIES_TOOL_NAME,
   GET_CHANGED_STORIES_TOOL_NAME,
   GET_UI_BUILDING_INSTRUCTIONS_TOOL_NAME,
+  PREVIEW_STORIES_TOOL_NAME,
 } from './tool-names.ts';
 
 // Review/addon-vitest availability now resolve through core's `getReviewStatus`/
@@ -198,9 +198,8 @@ describe('getUIBuildingInstructionsTool', () => {
     // Check that no placeholders remain
     expect(instructions).not.toContain('{{FRAMEWORK}}');
     expect(instructions).not.toContain('{{RENDERER}}');
-    expect(instructions).not.toContain('{{PREVIEW_STORIES_TOOL_NAME}}');
+    expect(instructions).not.toContain('{{PREVIEW_LINK_GUIDANCE}}');
     expect(instructions).not.toContain('{{STORY_LINKING_WORKFLOW}}');
-    expect(instructions).not.toContain('{{CHANGED_STORY_FALLBACK_LINK_GUIDANCE}}');
     expect(instructions).not.toContain('{{FINAL_LINKS_GUIDANCE}}');
     expect(instructions).not.toContain('{{DOCS_WORKFLOW_GUIDANCE}}');
   });
@@ -300,7 +299,7 @@ describe('getUIBuildingInstructionsTool', () => {
     expect(instructions).toContain('Story IDs must come from that call');
     expect(instructions).toContain('never construct them from file names');
     expect(instructions).toContain('Feed the discovered IDs into **review-create**');
-    expect(instructions).not.toContain('first, then use `stories-preview`');
+    expect(instructions).not.toContain(PREVIEW_STORIES_TOOL_NAME);
   });
 
   // The per-request context override must win over the feature-flag gate:
@@ -340,6 +339,7 @@ describe('getUIBuildingInstructionsTool', () => {
 
     expect(instructions).toContain('## 👀 Review your changes');
     expect(instructions).toContain('Feed the discovered IDs into **review-create**');
+    expect(instructions).not.toContain(PREVIEW_STORIES_TOOL_NAME);
   });
 
   it('tells the agent to include preview URLs when review is disabled', async () => {
@@ -376,6 +376,7 @@ describe('getUIBuildingInstructionsTool', () => {
     const instructions = response.result?.content[0].text as string;
 
     expect(instructions).toContain('include every returned preview URL');
+    expect(instructions).toContain(PREVIEW_STORIES_TOOL_NAME);
     expect(instructions).not.toContain('## 👀 Review your changes');
     expect(instructions).not.toContain('present links in this order');
   });

--- a/code/addons/mcp/src/tools/preview-stories.ts
+++ b/code/addons/mcp/src/tools/preview-stories.ts
@@ -1,5 +1,5 @@
-import url from 'node:url';
 import fs from 'node:fs/promises';
+import url from 'node:url';
 
 import type { McpServer } from 'tmcp';
 
@@ -15,7 +15,10 @@ export const PREVIEW_STORIES_RESOURCE_URI = `ui://${PREVIEW_STORIES_TOOL_NAME}/p
  * The app reads the tool result's `structuredContent`, so it is bound to the preview tool's output
  * contract rather than to its implementation.
  */
-export async function addPreviewStoriesResource(server: McpServer<any, AddonContext>) {
+export async function addPreviewStoriesResource(
+  server: McpServer<any, AddonContext>,
+  enabled: () => boolean = () => true
+) {
   const previewStoryAppScript = await fs.readFile(
     url.fileURLToPath(
       import.meta.resolve('@storybook/addon-mcp/internal/preview-stories-app-script')
@@ -31,6 +34,7 @@ export async function addPreviewStoriesResource(server: McpServer<any, AddonCont
       description: 'App resource for the Preview Stories tool',
       uri: PREVIEW_STORIES_RESOURCE_URI,
       mimeType: 'text/html;profile=mcp-app',
+      enabled,
     },
     () => {
       const origin = server.ctx.custom!.origin;

--- a/code/addons/mcp/src/tools/tool-registry.test.ts
+++ b/code/addons/mcp/src/tools/tool-registry.test.ts
@@ -10,9 +10,9 @@ import { clearToolsetRegistry, defineToolset, registerToolset } from 'storybook/
 import * as v from 'valibot';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { ToolAvailability } from 'storybook/internal/core-server';
 import { collectTelemetry } from '../telemetry.ts';
 import { registerCoreToolsetsForTest } from '../test-support/register-core-toolsets.ts';
-import type { ToolAvailability } from 'storybook/internal/core-server';
 import {
   type AddonToolRegistryContext,
   getAddonToolMetadata,
@@ -125,23 +125,47 @@ describe('the preview app resource', () => {
     registerCoreToolsetsForTest();
   });
 
-  // The resource ships with the preview tool: a client that cannot see the tool must not see the
-  // ui:// resource either.
-  it('is registered exactly when the dev toolset is enabled', async () => {
+  it('is registered only when the preview tool can be available at boot', async () => {
     const enabled = makeServer();
     const enabledResource = vi.fn();
     enabled.server.resource = enabledResource;
     await registerAddonMcpTools(enabled.server, { availability: availabilityWith() });
     expect(enabledResource).toHaveBeenCalledTimes(1);
 
-    const disabled = makeServer();
-    const disabledResource = vi.fn();
-    disabled.server.resource = disabledResource;
-    await registerAddonMcpTools(disabled.server, {
+    const reviewEnabled = makeServer();
+    const reviewEnabledResource = vi.fn();
+    reviewEnabled.server.resource = reviewEnabledResource;
+    await registerAddonMcpTools(reviewEnabled.server, {
+      availability: availabilityWith({ reviewEnabled: true }),
+    });
+    expect(reviewEnabledResource).not.toHaveBeenCalled();
+
+    const devDisabled = makeServer();
+    const devDisabledResource = vi.fn();
+    devDisabled.server.resource = devDisabledResource;
+    await registerAddonMcpTools(devDisabled.server, {
       availability: availabilityWith(),
       toolsets: { dev: false, docs: true, test: true },
     });
-    expect(disabledResource).not.toHaveBeenCalled();
+    expect(devDisabledResource).not.toHaveBeenCalled();
+  });
+
+  it('follows the preview tool per-request gates', async () => {
+    const { server } = makeServer();
+    const resource = vi.fn();
+    server.resource = resource;
+
+    await registerAddonMcpTools(server, { availability: availabilityWith() });
+
+    const definition = resource.mock.calls[0]![0];
+    expect(await definition.enabled()).toBe(true);
+
+    server.ctx.custom.reviewEnabled = true;
+    expect(await definition.enabled()).toBe(false);
+
+    server.ctx.custom.reviewEnabled = false;
+    server.ctx.custom.toolsets = { dev: false };
+    expect(await definition.enabled()).toBe(false);
   });
 });
 

--- a/code/addons/mcp/src/tools/tool-registry.ts
+++ b/code/addons/mcp/src/tools/tool-registry.ts
@@ -168,6 +168,12 @@ const docsToolDefinitions: AddonToolDefinition[] = [
 const addonToolDefinitions: AddonToolDefinition[] = [
   fromToolset({
     toolset: 'dev',
+    available: ({ availability }) => !availability.reviewEnabled,
+    wrapEnabled:
+      (server, { availability }, enabled) =>
+      async () =>
+        ((await enabled?.()) ?? true) &&
+        !(server.ctx.custom?.reviewEnabled ?? availability.reviewEnabled),
     options: {
       method: 'stories.preview',
       extras: { _meta: { ui: { resourceUri: PREVIEW_STORIES_RESOURCE_URI } } },
@@ -292,11 +298,15 @@ export async function registerAddonMcpTools(
   server: McpServer<any, AddonContext>,
   context: AddonToolRegistryContext
 ) {
-  // The preview app resource ships with the preview tool: when the dev toolset is disabled the
-  // tool is absent, and the resource must not appear in resources/list either — the same boot
-  // gate the tool's own registration uses below.
-  if (isToolsetEnabled('dev', context.toolsets)) {
-    await addPreviewStoriesResource(server);
+  // The preview app resource follows the same static and per-request gates as the preview tool,
+  // so resources/list cannot expose UI for a tool that tools/list suppresses.
+  if (isToolsetEnabled('dev', context.toolsets) && !context.availability.reviewEnabled) {
+    await addPreviewStoriesResource(
+      server,
+      () =>
+        isToolsetEnabled('dev', server.ctx.custom?.toolsets) &&
+        !(server.ctx.custom?.reviewEnabled ?? context.availability.reviewEnabled)
+    );
   }
 
   for (const definition of addonToolDefinitions) {

--- a/code/core/src/cli/skills/content/build-server-instructions.test.ts
+++ b/code/core/src/cli/skills/content/build-server-instructions.test.ts
@@ -52,7 +52,7 @@ describe('buildServerInstructions', () => {
 
       - Before creating or editing components or stories, call **get-storybook-story-instructions**; its output is the source of truth for imports, story patterns, and testing conventions.
       - After editing anything that changes how the UI looks — components, stories, styles, themes, tokens — call **stories-changed** to discover the affected stories.
-      - End your final response with the review section from **review-create**'s result — never substitute preview URLs. **stories-preview** is only for mid-loop iteration or a requested direct link. If nothing visually changed, say so.
+      - End your final response with the review section from **review-create**'s result — never substitute preview URLs. If nothing visually changed, say so.
       - After a visually observable UI change, or when the user asks to see or browse stories/components, call **review-create** (again on each iteration) and follow its description and result. Visual work is not done until the review is published; any newly created story MUST be included.
       - Only use story IDs returned by tools — never derive them from file names or memory. **stories-find-by-component** maps any input to stories; its description covers the workflow. No matches means no stories exist yet — say so.
 
@@ -89,7 +89,7 @@ describe('buildServerInstructions', () => {
 
       - Before creating or editing components or stories, call **get-storybook-story-instructions**; its output is the source of truth for imports, story patterns, and testing conventions.
       - After editing anything that changes how the UI looks — components, stories, styles, themes, tokens — call **stories-changed** to discover the affected stories.
-      - End your final response with the review section from **review-create**'s result — never substitute preview URLs. **stories-preview** is only for mid-loop iteration or a requested direct link. If nothing visually changed, say so.
+      - End your final response with the review section from **review-create**'s result — never substitute preview URLs. If nothing visually changed, say so.
       - After a visually observable UI change, or when the user asks to see or browse stories/components, call **review-create** (again on each iteration) and follow its description and result. Visual work is not done until the review is published; any newly created story MUST be included.
       - Only use story IDs returned by tools — never derive them from file names or memory. **stories-find-by-component** maps any input to stories; its description covers the workflow. No matches means no stories exist yet — say so."
     `);
@@ -163,8 +163,7 @@ describe('buildServerInstructions', () => {
     expect(instructions).toContain(
       '- After editing anything that changes how the UI looks, call **stories-find-by-component** with the files you touched.'
     );
-    expect(instructions).not.toContain('then **stories-preview** for their preview URLs');
-    expect(instructions).toContain('**stories-preview** is only for mid-loop iteration');
+    expect(instructions).not.toContain('stories-preview');
   });
 
   it('keeps the after-change step discovery-first when review is on without discovery tools', () => {
@@ -181,7 +180,7 @@ describe('buildServerInstructions', () => {
     expect(instructions).toContain(
       '- After editing anything that changes how the UI looks, identify the affected stories.'
     );
-    expect(instructions).not.toContain('call **stories-preview** to retrieve preview URLs');
+    expect(instructions).not.toContain('stories-preview');
   });
 
   it('keeps the default (review off) instructions under the 2,048-char client truncation limit', () => {
@@ -297,7 +296,7 @@ describe('buildServerInstructions', () => {
       expect(instructions).not.toContain('get-storybook-story-instructions');
     });
 
-    it('renders review, preview, and discovery references as CLI commands', () => {
+    it('renders review and discovery references as CLI commands', () => {
       const instructions = buildServerInstructions({
         transport: 'cli',
         devEnabled: true,
@@ -310,7 +309,7 @@ describe('buildServerInstructions', () => {
 
       expect(instructions).toContain('**npx storybook tools stories find-by-component**');
       expect(instructions).toContain('**npx storybook tools review create**');
-      expect(instructions).toContain('**npx storybook tools stories preview**');
+      expect(instructions).not.toContain('npx storybook tools stories preview');
       expect(instructions).not.toContain('review-create');
       expect(instructions).not.toContain('stories-preview');
       expect(instructions).not.toContain('stories-find-by-component');

--- a/code/core/src/cli/skills/content/build-server-instructions.ts
+++ b/code/core/src/cli/skills/content/build-server-instructions.ts
@@ -33,9 +33,9 @@ export type ServerInstructionsInputs = {
  * the workflow trigger must live in tool descriptions and tool results.
  *
  * Keyed on whether `review-create` is available in this Storybook setup.
- * When available, the guidance covers both paths: ending with a review section
- * after publishing, or falling back to preview URLs when no review was published
- * (e.g. non-visual refactors).
+ * When available, visually observable changes end with a review section.
+ * If a change has no visually observable impact, the agent says so instead
+ * of publishing a review or presenting preview URLs.
  */
 export function getFinalLinksGuidance(
   transport: SkillTransport,
@@ -43,7 +43,7 @@ export function getFinalLinksGuidance(
 ): string {
   const ref = getToolName({ transport });
   return reviewToolAvailable
-    ? `In your final user-facing response, show one set of links — never both. If you published a review with **${ref('review.create')}**, finish your reply with a dedicated review section as the very last thing in the output: its own top-level heading on a line by itself (for example \`## 👀 Review your changes\`), then a one-line explanation that the review shows the handful of stories most relevant to this change and that, because it is AI-curated, results may be inaccurate or incomplete, then on the next line the review page as a markdown link prefixed with a 👉 so it is easy to spot, using the returned \`reviewUrl\` (for example \`👉 [Open the Storybook review page](<reviewUrl>)\`). Nothing should come after this section. Never also list the individual story or preview URLs. Avoid internal jargon like "collection" or "trigger" in anything the user reads — those are terms from this tooling, not words that mean anything to them; use plain language unless the user used the term first. A visually observable change is not finished until its review is published — never substitute preview URLs for the review. Only when there is no review because the change has no visually observable impact, say so plainly; include preview URLs only if the user asked to see specific stories.`
+    ? `In your final user-facing response, show one set of links — never both. If you published a review with **${ref('review.create')}**, finish your reply with a dedicated review section as the very last thing in the output: its own top-level heading on a line by itself (for example \`## 👀 Review your changes\`), then a one-line explanation that the review shows the handful of stories most relevant to this change and that, because it is AI-curated, results may be inaccurate or incomplete, then on the next line the review page as a markdown link prefixed with a 👉 so it is easy to spot, using the returned \`reviewUrl\` (for example \`👉 [Open the Storybook review page](<reviewUrl>)\`). Nothing should come after this section. Never also list the individual story or preview URLs. Avoid internal jargon like "collection" or "trigger" in anything the user reads — those are terms from this tooling, not words that mean anything to them; use plain language unless the user used the term first. A visually observable change is not finished until its review is published — never substitute preview URLs for the review. If the change has no visually observable impact, say so plainly instead of publishing a review.`
     : 'In your final user-facing response, include every returned preview URL so the user can verify the visual result, ordered consistently (changed-stories fallback first if relevant, then the specific preview URLs).';
 }
 
@@ -92,9 +92,8 @@ export function buildServerInstructions({
         : 'After editing anything that changes how the UI looks, identify the affected stories.';
     // Terse pointer only: the full link-presentation rule reaches the agent
     // through the get-storybook-story-instructions output (getFinalLinksGuidance)
-    // and the review-create and stories-preview tool results, which are
-    // never truncated.
-    const finalLinksStep = `End your final response with the review section from **${ref('review.create')}**'s result — never substitute preview URLs. **${ref('stories.preview')}** is only for mid-loop iteration or a requested direct link. If nothing visually changed, say so.`;
+    // and the review-create tool result, which is never truncated.
+    const finalLinksStep = `End your final response with the review section from **${ref('review.create')}**'s result — never substitute preview URLs. If nothing visually changed, say so.`;
     sections.push(
       devInstructions
         .replaceAll('{{GET_STORYBOOK_STORY_INSTRUCTIONS}}', skillRef('write-story'))

--- a/code/core/src/cli/skills/content/build-story-instructions.test.ts
+++ b/code/core/src/cli/skills/content/build-story-instructions.test.ts
@@ -15,6 +15,7 @@ describe('buildStoryInstructions transport refs', () => {
   it('MCP transport names MCP tools', () => {
     const text = buildStoryInstructions({ ...baseInputs, transport: 'mcp' });
     expect(text).toContain('stories-changed');
+    expect(text).not.toContain('stories-preview');
     expect(text).toContain('test-run');
     expect(text).not.toContain('npx storybook tools');
   });
@@ -22,6 +23,7 @@ describe('buildStoryInstructions transport refs', () => {
   it('CLI transport names tools CLI commands', () => {
     const text = buildStoryInstructions({ ...baseInputs, transport: 'cli' });
     expect(text).toContain('npx storybook tools stories changed');
+    expect(text).not.toContain('npx storybook tools stories preview');
     expect(text).toContain('npx storybook tools test run');
     expect(text).not.toContain('stories-changed');
   });
@@ -42,14 +44,13 @@ describe('buildStoryInstructions placeholder resolution', () => {
 
     expect(instructions).toContain('@storybook/react-vite');
     expect(instructions).toContain('@storybook/react');
-    expect(instructions).toContain('stories-preview');
     expect(instructions).toContain('stories-changed');
+    expect(instructions).not.toContain('stories-preview');
 
     expect(instructions).not.toContain('{{FRAMEWORK}}');
     expect(instructions).not.toContain('{{RENDERER}}');
-    expect(instructions).not.toContain('{{PREVIEW_STORIES}}');
+    expect(instructions).not.toContain('{{PREVIEW_LINK_GUIDANCE}}');
     expect(instructions).not.toContain('{{STORY_LINKING_WORKFLOW}}');
-    expect(instructions).not.toContain('{{CHANGED_STORY_FALLBACK_LINK_GUIDANCE}}');
     expect(instructions).not.toContain('{{FINAL_LINKS_GUIDANCE}}');
     expect(instructions).not.toContain('{{DOCS_WORKFLOW_GUIDANCE}}');
   });
@@ -103,7 +104,7 @@ describe('buildStoryInstructions review-aware link guidance', () => {
     expect(instructions).toContain('Story IDs must come from that call');
     expect(instructions).toContain('never construct them from file names');
     expect(instructions).toContain('Feed the discovered IDs into **review-create**');
-    expect(instructions).not.toContain('first, then use `stories-preview`');
+    expect(instructions).not.toContain('stories-preview');
   });
 
   it('tells the agent to include preview URLs when review is disabled', () => {
@@ -114,6 +115,7 @@ describe('buildStoryInstructions review-aware link guidance', () => {
     });
 
     expect(instructions).toContain('include every returned preview URL');
+    expect(instructions).toContain('stories-preview');
     expect(instructions).not.toContain('## 👀 Review your changes');
     expect(instructions).not.toContain('present links in this order');
   });

--- a/code/core/src/cli/skills/content/build-story-instructions.ts
+++ b/code/core/src/cli/skills/content/build-story-instructions.ts
@@ -42,12 +42,16 @@ export function buildStoryInstructions({
   // The two channels must state the same workflow.
   const storyLinkingWorkflow = changeDetectionEnabled
     ? reviewEnabled
-      ? `After changing any component or story, call \`${ref('stories.changed')}\` to discover the new, modified, and related stories affected by your change. Story IDs must come from that call (or a fallback discovery tool such as ${ref('stories.findByComponent')} for shared-infrastructure changes) — never construct them from file names, export names, or memory. Feed the discovered IDs into **${ref('review.create')}** when the change is visually observable; use \`${ref('stories.preview')}\` only while iterating on a specific story.`
+      ? `After changing any component or story, call \`${ref('stories.changed')}\` to discover the new, modified, and related stories affected by your change. Story IDs must come from that call (or a fallback discovery tool such as ${ref('stories.findByComponent')} for shared-infrastructure changes) — never construct them from file names, export names, or memory. Feed the discovered IDs into **${ref('review.create')}** when the change is visually observable.`
       : `After changing UI, call \`${ref('stories.changed')}\` first, then use \`${ref('stories.preview')}\` with selected \`storyId\` values from those results.`
     : `After changing UI, call \`${ref('stories.preview')}\` and share the most relevant links for the changes.`;
   const changedStoryFallbackLinkGuidance = changeDetectionEnabled
     ? `When sharing preview/story links (not when ending with a review section): if you did not pass every changed story into \`${ref('stories.preview')}\`, include this Storybook fallback link so the user can view the complete changed list: \`/?statuses=affected;modified;new\`.`
     : `When sharing preview/story links (not when ending with a review section) and you passed only a subset into \`${ref('stories.preview')}\`, mention that additional relevant stories may exist in Storybook.`;
+  const previewLinkGuidance = reviewEnabled
+    ? ''
+    : `- When sharing preview/story links, pass only the most relevant story IDs into **${ref('stories.preview')}** (generally no more than 5) so the returned URL list stays manageable. Include every URL returned by that call in your final response — do not drop links there.
+- ${changedStoryFallbackLinkGuidance}`;
 
   /**
    * Injected into the story instructions when the documentation toolset is
@@ -69,8 +73,7 @@ This Storybook exposes component documentation tools. Before creating or changin
     .replace('\n{{DOCS_WORKFLOW_GUIDANCE}}', docsEnabled ? docsWorkflowGuidance : '')
     .replace('{{STORY_LINKING_WORKFLOW}}', storyLinkingWorkflow)
     .replace('{{FINAL_LINKS_GUIDANCE}}', getFinalLinksGuidance(transport, reviewEnabled))
-    .replace('{{PREVIEW_STORIES}}', ref('stories.preview'))
-    .replace('{{CHANGED_STORY_FALLBACK_LINK_GUIDANCE}}', changedStoryFallbackLinkGuidance);
+    .replace('{{PREVIEW_LINK_GUIDANCE}}', previewLinkGuidance);
 
   if (testSupported) {
     const a11yFixSuffix = a11yEnabled ? ' (see a11y guidelines below)' : '';

--- a/code/core/src/cli/skills/content/instructions/storybook-story-instructions.md
+++ b/code/core/src/cli/skills/content/instructions/storybook-story-instructions.md
@@ -149,6 +149,5 @@ play: async ({ canvas }) => {
 - ALWAYS provide story links after any changes to stories files, including changes to existing stories.
 - {{STORY_LINKING_WORKFLOW}}
 - {{FINAL_LINKS_GUIDANCE}}
-- When you will share preview/story links (i.e. when you are not collapsing everything into a single review section), pass only the most relevant story IDs into **{{PREVIEW_STORIES}}** (generally no more than 5) so the returned URL list stays manageable. Include every URL returned by that call in your final response — do not drop links there.
-- {{CHANGED_STORY_FALLBACK_LINK_GUIDANCE}}
+{{PREVIEW_LINK_GUIDANCE}}
 - After changing any UI components, ALWAYS search for related stories that might cover the changes you've made. If you find any, provide the story links to the user. THIS IS VERY IMPORTANT, as it allows the user to visually inspect the changes you've made. Even later in a session when changing UI components or stories that have already been linked to previously, YOU MUST PROVIDE THE LINKS AGAIN.


### PR DESCRIPTION
Closes #35440

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

When `review-create` is available, the MCP server no longer exposes `stories-preview` or its associated app resource. This prevents agents from choosing the preview workflow instead of creating a review.

The change:

* keeps generated AI metadata, live `tools/list`, and `resources/list` aligned
* applies both the static availability gate and the per-request context override
* shows the correct `stories-preview` status and explanation on the `/mcp` landing page
* removes references to the unavailable preview tool from review-specific agent instructions while retaining them when review is disabled
* adds unit coverage for tool, resource, metadata, landing-page, and instruction behavior

ChatGPT assisted with repository research and additional implementation review. I made and reviewed the final changes and ran the automated tests and the two-state landing-page check myself.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

* [ ] stories
* [x] unit tests
* [ ] integration tests
* [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

1. Generate a sandbox with `yarn task sandbox --template react-vite/default-ts --start-from auto`.
2. In the generated sandbox’s `.storybook/main.ts`, set `features.experimentalReview` to `true` while keeping `features.changeDetection` enabled.
3. Start the sandbox with `yarn storybook`.
4. Open `http://localhost:6006/mcp`. Verify that `review-create` is enabled, `stories-preview` is disabled, and the page explains that preview is suppressed while review is available.
5. Connect an MCP client to `http://localhost:6006/mcp` and list its tools. Verify that `review-create` is offered and `stories-preview` is not.
6. Set `features.experimentalReview` explicitly to `false`, restart Storybook, and repeat the checks. Verify that `stories-preview` is enabled again and `review-create` is disabled.

The explicit `false` in the final step is important because review availability is channel-aware when `experimentalReview` is unset.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

* [ ] Add or update documentation reflecting your changes
* [ ] If you are deprecating/removing a feature, make sure to update
  [[MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

* [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
* [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
* [ ] Make sure this PR contains **one** of the labels below:

   <details>
     <summary>Available labels</summary>

  * `bug`: Internal changes that fixes incorrect behavior.
  * `maintenance`: User-facing maintenance tasks.
  * `dependencies`: Upgrading (sometimes downgrading) dependencies.
  * `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  * `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  * `documentation`: Documentation **only** changes. Will not show up in release changelog.
  * `feature request`: Introducing a new feature.
  * `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  * `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->

## 🦋 Canary Release - 🚫 Not run

<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [[Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml)](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

<!-- BENCHMARK_SECTION -->