### PR TITLE
Docs: Explain the as const workaround for literal args in preview.meta

### DIFF
--- a/docs/api/csf/csf-next.mdx
+++ b/docs/api/csf/csf-next.mdx
@@ -100,27 +100,29 @@ const meta = preview.meta({
 
 <a name="literal-args" />
 
-**In TypeScript, args with literal types need `as const`.** When a prop is typed as a union of literals (`'primary' | 'secondary'`), an enum, or a template literal, and you provide it in the `args` of `preview.meta`, TypeScript widens the value (`'primary'` becomes `string`) before it can compare it to the prop type. The meta then loses track of every arg it provided, and each story reports:
+**In TypeScript, args with literal types need `as const`.** When a prop is typed as a union of literals (strings, numbers, or enum members) or as a template literal, and you provide a value for it in the `args` of `preview.meta`, TypeScript widens the value (`'primary'` becomes `string`) before it can compare it to the prop type. The meta then loses track of every arg it provided, not only that one, and each `meta.story()` call that relies on those args reports:
 
 ```text
-Expected 1 arguments, but got 0
+Expected 1 arguments, but got 0.
 ```
 
-Add `as const` to each such value. Do not add it to the whole `args` object: that also turns array values into readonly tuples, which fail array-typed props in the same way.
+Add `as const` to each such value. Do not add it to the whole `args` object: that also turns array values into readonly tuples, which fail array-typed props in the same way. For example:
 
 ```ts title="Button.stories.ts"
+// ...from above
+
 const meta = preview.meta({
-  component: Button, // variant: 'primary' | 'secondary'
+  component: Button, // props: { variant: 'primary' | 'secondary'; items: string[] }
   args: {
     variant: 'primary' as const, // ✅ keeps the literal type
-    items: ['a', 'b'], // arrays stay as they are
+    items: ['a', 'b'], // ✅ arrays stay as they are
   },
 });
 
-export const Primary = meta.story(); // ✅ variant is already provided
+export const Primary = meta.story(); // ✅ variant and items are already provided
 ```
 
-This is a limitation of how TypeScript infers types within a single object literal. We plan to remove the need for `as const` in Storybook 11, when the minimum supported TypeScript version becomes 5.0. Progress is tracked in [#36125](https://github.com/storybookjs/storybook/issues/36125).
+Removing the need for `as const` is planned for Storybook 11, when the minimum supported TypeScript version becomes 5.0 and `preview.meta` can keep the literal types itself. See [#36125](https://github.com/storybookjs/storybook/issues/36125).
 
 </Callout>
 
@@ -593,7 +595,7 @@ The [`preview.type`](#previewtypemeta) function allows you to specify custom typ
 
 ### Why does `meta.story()` report "Expected 1 arguments, but got 0" for an arg I provided in `preview.meta`?
 
-`meta.story()` reports this error whenever a required prop is provided by neither the meta nor the story. If you did provide it in the `args` of `preview.meta` and the prop has a literal union, enum, or template literal type, TypeScript lost track of it. Add `as const` to that value. See [args with literal types](#literal-args).
+`meta.story()` reports this whenever a required prop is provided by neither the meta nor the story. If the meta did provide it, and any value in the meta's `args` has a union of literals or a template literal type, see [args with literal types](#literal-args).
 
 ### Will this format work with MDX docs pages?
 

--- a/docs/api/csf/csf-next.mdx
+++ b/docs/api/csf/csf-next.mdx
@@ -96,6 +96,34 @@ const meta = preview.meta({
 });
 ```
 
+<Callout variant="warning">
+
+<a name="literal-args" />
+
+**In TypeScript, args with literal types need `as const`.** When a prop is typed as a union of literals (`'primary' | 'secondary'`), an enum, or a template literal, and you provide it in the `args` of `preview.meta`, TypeScript widens the value (`'primary'` becomes `string`) before it can compare it to the prop type. The meta then loses track of every arg it provided, and each story reports:
+
+```text
+Expected 1 arguments, but got 0
+```
+
+Add `as const` to each such value. Do not add it to the whole `args` object: that also turns array values into readonly tuples, which fail array-typed props in the same way.
+
+```ts title="Button.stories.ts"
+const meta = preview.meta({
+  component: Button, // variant: 'primary' | 'secondary'
+  args: {
+    variant: 'primary' as const, // ✅ keeps the literal type
+    items: ['a', 'b'], // arrays stay as they are
+  },
+});
+
+export const Primary = meta.story(); // ✅ variant is already provided
+```
+
+This is a limitation of how TypeScript infers types within a single object literal. We plan to remove the need for `as const` in Storybook 11, when the minimum supported TypeScript version becomes 5.0. Progress is tracked in [#36125](https://github.com/storybookjs/storybook/issues/36125).
+
+</Callout>
+
 <Callout variant="info" icon="💡">
 
 <a name="subpath-imports" />
@@ -562,6 +590,10 @@ While using CSF Next, you can still use the older formats, as long as they are n
 ### How do I use custom arg types with this format?
 
 The [`preview.type`](#previewtypemeta) function allows you to specify custom types for your story's args, which can be used to provide type safety for custom arg types.
+
+### Why does `meta.story()` report "Expected 1 arguments, but got 0"?
+
+The component has a required prop with a literal type, an enum, or a template literal type, and you provided it in the `args` of `preview.meta`. Add `as const` to that value. See [args with literal types](#literal-args).
 
 ### Will this format work with MDX docs pages?
 

--- a/docs/api/csf/csf-next.mdx
+++ b/docs/api/csf/csf-next.mdx
@@ -591,9 +591,9 @@ While using CSF Next, you can still use the older formats, as long as they are n
 
 The [`preview.type`](#previewtypemeta) function allows you to specify custom types for your story's args, which can be used to provide type safety for custom arg types.
 
-### Why does `meta.story()` report "Expected 1 arguments, but got 0"?
+### Why does `meta.story()` report "Expected 1 arguments, but got 0" for an arg I provided in `preview.meta`?
 
-The component has a required prop with a literal type, an enum, or a template literal type, and you provided it in the `args` of `preview.meta`. Add `as const` to that value. See [args with literal types](#literal-args).
+`meta.story()` reports this error whenever a required prop is provided by neither the meta nor the story. If you did provide it in the `args` of `preview.meta` and the prop has a literal union, enum, or template literal type, TypeScript lost track of it. Add `as const` to that value. See [args with literal types](#literal-args).
 
 ### Will this format work with MDX docs pages?
 


### PR DESCRIPTION
Related to #36125 and #32829

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Documented the `as const` workaround for literal args in `preview.meta` on the CSF Next page, in a callout under `preview.meta` and as an FAQ entry.

When a component has a required prop typed as a literal union, an enum, or a template literal, and you provide it in `meta.args`, every `meta.story()` reports `Expected 1 arguments, but got 0`. TypeScript widens the value (`'primary'` → `string`) before it checks it against the prop type, the inferred meta args fail their constraint, and the meta loses track of every arg it provided. Adding `as const` to that value keeps the literal type. The callout also says why `as const` on the whole `args` object does not work (array values become readonly tuples, which fail array-typed props the same way), quotes the error message so it can be found by searching, and points to #36125 for the planned Storybook 11 fix.

Why docs instead of a type fix now: #36185 explored every type-level fix that stays within the TypeScript 4.9 peer range. Each one either regresses array args, leaks readonly types into `meta.input.args`, or needs rules about function-typed args that nobody can maintain. The clean fix is a `const` type parameter, which needs TypeScript 5.0 and therefore Storybook 11. Until then the workaround is one token per value.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Documentation only.

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

No manual test needed beyond reading the rendered page. The workaround itself was verified in #36185's type tests: `variant: 'primary' as const` keeps the meta args, and `as const` on the whole `args` object collapses them when an array arg is present.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>
