### PR TITLE
CLI: Support Node.js prerelease builds in CLI version check

### DIFF
--- a/code/core/src/bin/dispatcher.ts
+++ b/code/core/src/bin/dispatcher.ts
@@ -8,7 +8,11 @@ import { join } from 'pathe';
 import { getProcessAncestry } from 'process-ancestry';
 import { dedent } from 'ts-dedent';
 
-import { MIN_SUPPORTED_NODE_DESCRIPTION, isNodeVersionSupported } from '../common/node-version.ts';
+import {
+  MIN_SUPPORTED_NODE_DESCRIPTION,
+  isNodeVersionSupported,
+  parseNodeVersion,
+} from '../common/node-version.ts';
 import versions from '../common/versions.ts';
 import { resolvePackageDir } from '../shared/utils/module.ts';
 
@@ -23,7 +27,7 @@ import { resolvePackageDir } from '../shared/utils/module.ts';
  * - Init is routed to the create-storybook package via the detected package manager
  * - External CLI tools (upgrade, doctor, etc.) are routed to @storybook/cli the same way
  */
-const [major, minor, patch] = process.versions.node.split('.').map(Number);
+const { major, minor, patch } = parseNodeVersion();
 if (!isNodeVersionSupported(major, minor, patch)) {
   logger.error(
     dedent`To run Storybook, you need Node.js version ${MIN_SUPPORTED_NODE_DESCRIPTION}.

--- a/code/core/src/common/node-version.test.ts
+++ b/code/core/src/common/node-version.test.ts
@@ -11,6 +11,7 @@ import {
   MIN_SUPPORTED_NODE_DESCRIPTION,
   formatMinVersion,
   isNodeVersionSupported,
+  parseNodeVersion,
 } from './node-version.ts';
 
 describe('node-version', () => {
@@ -77,6 +78,33 @@ describe('node-version', () => {
   describe('MIN_SUPPORTED_NODE_DESCRIPTION', () => {
     it('formats current minimums as human-readable string', () => {
       expect(MIN_SUPPORTED_NODE_DESCRIPTION).toBe('20.19+ or 22.12+');
+    });
+  });
+
+  describe('parseNodeVersion', () => {
+    it('parses a plain release version', () => {
+      expect(parseNodeVersion('24.19.0')).toEqual({ major: 24, minor: 19, patch: 0 });
+    });
+
+    it('strips prerelease segments so supported prerelease builds pass (issue #36143)', () => {
+      expect(parseNodeVersion('22.12.0-rc.1')).toEqual({ major: 22, minor: 12, patch: 0 });
+      expect(parseNodeVersion('20.19.0-nightly20240519abcdef')).toEqual({
+        major: 20,
+        minor: 19,
+        patch: 0,
+      });
+    });
+
+    it('strips build metadata', () => {
+      expect(parseNodeVersion('22.12.0+build.1')).toEqual({ major: 22, minor: 12, patch: 0 });
+    });
+
+    it('normalizes missing components to 0', () => {
+      expect(parseNodeVersion('22')).toEqual({ major: 22, minor: 0, patch: 0 });
+    });
+
+    it('treats unparseable segments as 0 instead of NaN', () => {
+      expect(parseNodeVersion('x.y.z')).toEqual({ major: 0, minor: 0, patch: 0 });
     });
   });
 });

--- a/code/core/src/common/node-version.ts
+++ b/code/core/src/common/node-version.ts
@@ -57,3 +57,24 @@ export function isNodeVersionSupported(major: number, minor: number, patch: numb
 
   return satisfies(`${major}.${minor}.${patch}`, supportedRange);
 }
+
+/**
+ * Parse a Node.js version string (e.g. `process.versions.node`) into its
+ * major/minor/patch components.
+ *
+ * Prerelease and build-metadata segments are stripped before parsing, so that
+ * prerelease builds of a supported version (e.g. `24.0.0-rc.1` or
+ * `20.19.0-nightly20240519abcdef`) are recognized as supported instead of
+ * producing a `NaN` patch component. Missing components are normalized to 0
+ * (e.g. "22" -> 22.0.0), matching the normalization expected by
+ * {@link isNodeVersionSupported}.
+ */
+export function parseNodeVersion(version: string = process.versions.node): MinNodeVersion {
+  const [major = 0, minor = 0, patch = 0] = version
+    .split('-')[0]
+    .split('+')[0]
+    .split('.')
+    .map((part) => Number.parseInt(part, 10) || 0);
+
+  return { major, minor, patch };
+}


### PR DESCRIPTION
Closes #36143

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The CLI dispatcher rejected every Node.js prerelease build (e.g. `22.12.0-rc.1`, `20.19.0-nightly20240519abcdef`). `process.versions.node` was split on `.` and mapped through `Number`, so the patch segment of a prerelease build (`0-rc.1`) parsed to `NaN`, and `isNodeVersionSupported` failed even though the underlying release is inside the supported range.

This PR adds a `parseNodeVersion` helper next to `isNodeVersionSupported` in `code/core/src/common/node-version.ts`. It strips prerelease (`-...`) and build-metadata (`+...`) segments and normalizes missing components to `0` — the normalization the existing doc comment already expected from callers — and `code/core/src/bin/dispatcher.ts` now uses it.

**AI disclosure:** AI coding assistance (Claude via Cline) was used to draft this change; the root-cause analysis, fix, and test results were reviewed by a human and validated against the local test suite before submission.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

New cases in `code/core/src/common/node-version.test.ts` cover plain releases, prerelease and nightly builds (the failing class from the issue), build metadata, missing components, and unparseable segments.

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

Manual testing is applicable:

1. On a Node.js prerelease build (verify with `node -p process.version`, e.g. `v22.12.0-rc.1`), run a CLI entry point such as `npx storybook@next info` — before this change it exits with the minimum-version error; with this change it proceeds normally.
2. On a supported release (e.g. Node `22.12.0`), run the same command to confirm no behavior change.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No documentation update is needed; this is an internal version-check fix with no user-facing API change.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
