### PR TITLE
Addon-Vitest: Prebundle the project annotations setup file

### DIFF
--- a/code/addons/vitest/src/vitest-plugin/index.test.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { validateConfigurationFiles } from 'storybook/internal/common';
 import { StoryIndexGenerator, experimental_loadStorybook } from 'storybook/internal/core-server';
@@ -74,7 +74,7 @@ async function getPluginConfig(invokingRoot: string) {
     throw new Error('The plugin config hook returned no test config');
   }
 
-  return { root: config.root, test: config.test };
+  return { root: config.root, test: config.test, optimizeDeps: config.optimizeDeps };
 }
 
 describe('story test patterns', () => {
@@ -94,5 +94,17 @@ describe('story test patterns', () => {
 
     expect(config.root).toBe(PACKAGE_ROOT);
     expect(config.test.include).toEqual(['stories/**/*.stories.tsx']);
+  });
+});
+
+describe('dependency optimization', () => {
+  it('prebundles the automatically injected setup files', async () => {
+    const config = await getPluginConfig(PACKAGE_ROOT);
+
+    assert(Array.isArray(config.test.setupFiles));
+    expect(config.test.setupFiles).toContain(
+      '@storybook/addon-vitest/internal/setup-file-with-project-annotations'
+    );
+    expect(config.optimizeDeps?.include).toEqual(expect.arrayContaining(config.test.setupFiles));
   });
 });

--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -430,6 +430,7 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
         optimizeDeps: {
           include: [
             '@storybook/addon-vitest/internal/setup-file',
+            '@storybook/addon-vitest/internal/setup-file-with-project-annotations',
             '@storybook/addon-vitest/internal/setup-file.browser.4',
             '@storybook/addon-vitest/internal/global-setup',
             '@storybook/addon-vitest/internal/test-utils',


### PR DESCRIPTION

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

The Vitest plugin automatically adds `@storybook/addon-vitest/internal/setup-file-with-project-annotations` to `test.setupFiles`, but omits it from `optimizeDeps.include`. Add the missing entry alongside the other internal setup files so Vite prebundles the annotations setup module for browser tests.

This ports an existing one-line patch for `@storybook/addon-vitest@10.6.0` to the current source. The regression test invokes the plugin's config hook and checks that its automatically injected setup files are included in dependency optimization. The existing configuration tests are renamed from `vitest-root.test.ts` to `index.test.ts` to cover both story roots and dependency optimization.

Prepared with Codex assistance at the contributor's request.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Validation with Node.js 22.22.3:

- `yarn test --config code/addons/vitest/vitest.config.ts code/addons/vitest`: 182 tests passed across 16 files.
- The new regression test failed before the fix because the annotations setup file was missing from `optimizeDeps.include`, and passed after the fix.
- `yarn nx check addon-vitest --output-style=stream`: passed, including compilation of the addon and workspace dependencies; no type errors in the addon under the repository's package-scoped checker.
- `cd code && yarn fmt:write`: passed.
- `cd code && yarn lint:js:cmd addons/vitest/src/vitest-plugin/index.ts addons/vitest/src/vitest-plugin/index.test.ts`: passed with existing warnings about the `pathe` default import in unchanged code.

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

No separate manual UI test is required for this configuration-only change. To verify the returned Vite configuration locally:

1. From the repository root, run `yarn` and `yarn nx compile addon-vitest`.
2. Run `yarn test --config code/addons/vitest/vitest.config.ts code/addons/vitest/src/vitest-plugin/index.test.ts --reporter=verbose`.
3. Confirm that `prebundles the automatically injected setup files` and both story-root tests pass. The regression test checks that the annotations setup module is injected and that every injected setup file is included in `optimizeDeps.include`.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No public API or configuration option changes; no documentation update is needed.

## Checklist for Maintainers

Suggested labels: `bug`, `ci:normal`, `qa:skip`.

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
