### PR TITLE
CI: Derive Danger branch version from the package version

### DIFF
--- a/scripts/dangerfile.ts
+++ b/scripts/dangerfile.ts
@@ -31,7 +31,13 @@ const { labels } = danger.github.issue;
 
 const prLogConfig = pkg['pr-log'];
 
-const branchVersion = Versions.MINOR;
+const isPrerelease = pkg.version.includes('-');
+const isFirstOfMajor = /^\d+\.0\.0(-|$)/.test(pkg.version);
+const branchVersion = !isPrerelease
+  ? Versions.PATCH
+  : isFirstOfMajor
+    ? Versions.MAJOR
+    : Versions.MINOR;
 const targetBranch = danger.github.pr.base.ref;
 const isReleasePr = ['latest-release', 'next-release'].includes(targetBranch);
 const author = danger.github.pr.user;


### PR DESCRIPTION
Closes #

## What I did

Danger forbids the `BREAKING CHANGE` label whenever `branchVersion` is not `MAJOR`, but `branchVersion` was hardcoded to `MINOR` in `scripts/dangerfile.ts` and nobody flipped it when `next` moved to `11.0.0-alpha.0`. As a result, Danger currently fails every SB11 breaking-change PR (e.g. #35437).

Instead of re-hardcoding the value, this derives it from `code/package.json` (already imported by the dangerfile), so it can never go stale again:

```ts
const isPrerelease = pkg.version.includes('-');
const isFirstOfMajor = /^\d+\.0\.0(-|$)/.test(pkg.version);
const branchVersion = !isPrerelease
  ? Versions.PATCH
  : isFirstOfMajor
    ? Versions.MAJOR
    : Versions.MINOR;
```

| version          | derived |
| ---------------- | ------- |
| `11.0.0-alpha.0` | MAJOR   |
| `11.0.0-rc.1`    | MAJOR   |
| `10.5.0-alpha.2` | MINOR   |
| `10.4.2`         | PATCH   |
| `11.0.0`         | PATCH   |

Behavior change vs today: on the 11.0 prerelease line, `BREAKING CHANGE` becomes an allowed label (it is currently forbidden), and `feature request` stays allowed. On stable branches (`main`), `feature request` becomes forbidden as a PATCH-line label, which matches the release policy.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Confirm the Danger job passes on this PR (it carries the `build` label, valid on any line).
2. After merge, relabel or rerun Danger on a `BREAKING CHANGE`-labeled PR targeting `next` (e.g. #35437) and confirm the "PR is marked with \"BREAKING CHANGE\" label" failure is gone.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->