### PR TITLE
Telemetry: One tools-command record per invocation with CLI toolset and tool names

### DIFF
--- a/code/addons/mcp/src/tools/tool-registry.ts
+++ b/code/addons/mcp/src/tools/tool-registry.ts
@@ -95,7 +95,7 @@ const createToolsetEnabled =
  */
 function fromToolset(
   definition: Omit<AddonToolDefinition, 'name' | 'getMetadata' | 'register'> & {
-    options: Omit<ToolsetToolOptions, 'toolset'>;
+    options: ToolsetToolOptions;
     available?: (context: AddonToolRegistryContext) => boolean;
     /** Narrows the tool further per request, on top of the toolset gate. */
     wrapEnabled?: (
@@ -105,8 +105,7 @@ function fromToolset(
     ) => ToolEnabled;
   }
 ): AddonToolDefinition {
-  const { options: methodOptions, available, wrapEnabled, ...rest } = definition;
-  const options: ToolsetToolOptions = { ...methodOptions, toolset: definition.toolset };
+  const { options, available, wrapEnabled, ...rest } = definition;
   return {
     ...rest,
     // Read from the constant, not the registry: this array is built at import time, while toolsets
@@ -148,8 +147,8 @@ function docsToolDefinition(
 ): AddonToolDefinition {
   const forContext = (context: AddonToolRegistryContext): ToolsetToolOptions =>
     context.multiSource
-      ? { method, toolset: 'docs', resolveToolset: (server) => compositionDocsToolset(server) }
-      : { method, toolset: 'docs' };
+      ? { method, resolveToolset: (server) => compositionDocsToolset(server) }
+      : { method };
 
   return {
     name: toMcpToolName(method),

--- a/code/addons/mcp/src/tools/tool-registry.ts
+++ b/code/addons/mcp/src/tools/tool-registry.ts
@@ -141,14 +141,19 @@ function compositionDocsToolset(server?: McpServer<any, AddonContext>): DocsTool
   });
 }
 
+const DOCS_EVENT_NAMES = {
+  'docs.list': 'tool:listAllDocumentation',
+  'docs.show': 'tool:getDocumentation',
+  'docs.showStory': 'tool:getDocumentationForStory',
+} as const;
+
 /** The docs tools, in the two shapes the registry needs: registered toolset, or per-request one. */
-function docsToolDefinition(
-  method: 'docs.list' | 'docs.show' | 'docs.showStory'
-): AddonToolDefinition {
-  const forContext = (context: AddonToolRegistryContext): ToolsetToolOptions =>
-    context.multiSource
-      ? { method, resolveToolset: (server) => compositionDocsToolset(server) }
-      : { method };
+function docsToolDefinition(method: keyof typeof DOCS_EVENT_NAMES): AddonToolDefinition {
+  const forContext = (context: AddonToolRegistryContext): ToolsetToolOptions => ({
+    method,
+    mcpEventName: DOCS_EVENT_NAMES[method],
+    ...(context.multiSource ? { resolveToolset: (server) => compositionDocsToolset(server) } : {}),
+  });
 
   return {
     name: toMcpToolName(method),
@@ -172,6 +177,7 @@ const addonToolDefinitions: AddonToolDefinition[] = [
     toolset: 'dev',
     options: {
       method: 'stories.preview',
+      mcpEventName: 'tool:previewStories',
       extras: { _meta: { ui: { resourceUri: PREVIEW_STORIES_RESOURCE_URI } } },
     },
   }),
@@ -206,12 +212,12 @@ const addonToolDefinitions: AddonToolDefinition[] = [
   fromToolset({
     toolset: 'dev',
     available: ({ availability }) => availability.changeDetectionEnabled,
-    options: { method: 'stories.changed' },
+    options: { method: 'stories.changed', mcpEventName: 'tool:getChangedStories' },
   }),
   fromToolset({
     toolset: 'dev',
     available: ({ availability }) => availability.moduleGraphSupported,
-    options: { method: 'stories.findByComponent' },
+    options: { method: 'stories.findByComponent', mcpEventName: 'tool:getStoriesByComponent' },
   }),
   fromToolset({
     toolset: 'dev',
@@ -226,13 +232,14 @@ const addonToolDefinitions: AddonToolDefinition[] = [
         (server.ctx.custom?.reviewEnabled ?? availability.reviewEnabled),
     options: {
       method: 'review.create',
+      mcpEventName: 'tool:displayReview',
       wrapSchema: withFriendlyErrors,
     },
   }),
   fromToolset({
     toolset: 'test',
     available: ({ availability }) => availability.testSupported,
-    options: { method: 'test.run' },
+    options: { method: 'test.run', mcpEventName: 'tool:runStoryTests' },
   }),
   // Docs run on the core docs toolset in both modes. A composition builds its toolset per request,
   // because the sources it reads and the provider that fetches them belong to the request.

--- a/code/addons/mcp/src/tools/tool-registry.ts
+++ b/code/addons/mcp/src/tools/tool-registry.ts
@@ -105,8 +105,8 @@ function fromToolset(
     ) => ToolEnabled;
   }
 ): AddonToolDefinition {
-  const { available, wrapEnabled, ...rest } = definition;
-  const options: ToolsetToolOptions = { ...definition.options, toolset: definition.toolset };
+  const { options: methodOptions, available, wrapEnabled, ...rest } = definition;
+  const options: ToolsetToolOptions = { ...methodOptions, toolset: definition.toolset };
   return {
     ...rest,
     // Read from the constant, not the registry: this array is built at import time, while toolsets

--- a/code/addons/mcp/src/tools/tool-registry.ts
+++ b/code/addons/mcp/src/tools/tool-registry.ts
@@ -23,6 +23,7 @@ import { GET_UI_BUILDING_INSTRUCTIONS_TOOL_NAME } from './tool-names.ts';
 import {
   getToolsetToolMetadata,
   registerToolsetTool,
+  type McpToolsetGroup,
   type ToolsetToolOptions,
 } from './toolset-tools.ts';
 
@@ -52,12 +53,11 @@ export type AddonToolRegistryContext = {
   options?: Options;
 };
 
-type AddonToolset = keyof NonNullable<AddonContext['toolsets']>;
 type ToolEnabled = Parameters<McpServer<any, AddonContext>['tool']>[0]['enabled'];
 
 type AddonToolDefinition = {
   name: string;
-  toolset: AddonToolset;
+  toolset: McpToolsetGroup;
   available?: (context: AddonToolRegistryContext) => boolean;
   getMetadata: (context: AddonToolRegistryContext) => ToolMetadata;
   register: (
@@ -68,8 +68,10 @@ type AddonToolDefinition = {
   getLocalTool?: (context: AddonToolRegistryContext & { options: Options }) => StorybookAiLocalTool;
 };
 
-const isToolsetEnabled = (toolset: AddonToolset, toolsets: AddonContext['toolsets'] | undefined) =>
-  toolsets?.[toolset] ?? true;
+const isToolsetEnabled = (
+  toolset: McpToolsetGroup,
+  toolsets: AddonContext['toolsets'] | undefined
+) => toolsets?.[toolset] ?? true;
 
 const isToolAvailable = (definition: AddonToolDefinition, context: AddonToolRegistryContext) =>
   definition.available?.(context) ?? true;
@@ -80,7 +82,7 @@ const isMetadataToolEnabled = (
 ) => isToolsetEnabled(definition.toolset, context.toolsets) && isToolAvailable(definition, context);
 
 const createToolsetEnabled =
-  (server: McpServer<any, AddonContext>, toolset: AddonToolset): ToolEnabled =>
+  (server: McpServer<any, AddonContext>, toolset: McpToolsetGroup): ToolEnabled =>
   () =>
     server.ctx.custom?.toolsets?.[toolset] ?? true;
 
@@ -93,7 +95,7 @@ const createToolsetEnabled =
  */
 function fromToolset(
   definition: Omit<AddonToolDefinition, 'name' | 'getMetadata' | 'register'> & {
-    options: ToolsetToolOptions;
+    options: Omit<ToolsetToolOptions, 'toolset'>;
     available?: (context: AddonToolRegistryContext) => boolean;
     /** Narrows the tool further per request, on top of the toolset gate. */
     wrapEnabled?: (
@@ -103,7 +105,8 @@ function fromToolset(
     ) => ToolEnabled;
   }
 ): AddonToolDefinition {
-  const { options, available, wrapEnabled, ...rest } = definition;
+  const { available, wrapEnabled, ...rest } = definition;
+  const options: ToolsetToolOptions = { ...definition.options, toolset: definition.toolset };
   return {
     ...rest,
     // Read from the constant, not the registry: this array is built at import time, while toolsets
@@ -145,8 +148,8 @@ function docsToolDefinition(
 ): AddonToolDefinition {
   const forContext = (context: AddonToolRegistryContext): ToolsetToolOptions =>
     context.multiSource
-      ? { method, resolveToolset: (server) => compositionDocsToolset(server) }
-      : { method };
+      ? { method, toolset: 'docs', resolveToolset: (server) => compositionDocsToolset(server) }
+      : { method, toolset: 'docs' };
 
   return {
     name: toMcpToolName(method),

--- a/code/addons/mcp/src/tools/toolset-tools.test.ts
+++ b/code/addons/mcp/src/tools/toolset-tools.test.ts
@@ -240,6 +240,21 @@ describe('toolset-backed MCP tools', () => {
     }
   );
 
+  it('keeps the adapter-owned toolset when a handler payload carries one', async () => {
+    registerStubStoriesToolset({
+      handler: async (_input: unknown, ctx: any) => {
+        await ctx.telemetry?.('tool:previewStories', { toolset: 'test', inputStoryCount: 1 });
+        return { ok: true, data: { stories: [] }, markdown: '' };
+      },
+    });
+
+    await callToolsetMethod(makeServer(), previewOptions, { id: 'button--primary' });
+
+    expect(collectTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'tool:previewStories', toolset: 'dev' })
+    );
+  });
+
   it('emits no telemetry when the session disabled it', async () => {
     registerStubStoriesToolset();
 

--- a/code/addons/mcp/src/tools/toolset-tools.test.ts
+++ b/code/addons/mcp/src/tools/toolset-tools.test.ts
@@ -39,7 +39,7 @@ function registerStubStoriesToolset(
                 ok: true,
                 data: { stories, extraNotInContract: 'internal' },
                 markdown: stories.map((story) => story.previewUrl).join('\n'),
-                telemetry: { event: 'tool:previewStories', counters: { inputStoryCount: 1 } },
+                telemetry: { event: 'tool:previewStories', payload: { inputStoryCount: 1 } },
               };
             }),
         },

--- a/code/addons/mcp/src/tools/toolset-tools.test.ts
+++ b/code/addons/mcp/src/tools/toolset-tools.test.ts
@@ -39,7 +39,7 @@ function registerStubStoriesToolset(
                 ok: true,
                 data: { stories, extraNotInContract: 'internal' },
                 markdown: stories.map((story) => story.previewUrl).join('\n'),
-                telemetry: { event: 'tool:previewStories', payload: { inputStoryCount: 1 } },
+                telemetry: { payload: { inputStoryCount: 1 } },
               };
             }),
         },
@@ -54,7 +54,7 @@ function makeServer(custom: Record<string, unknown> = {}) {
   } as any;
 }
 
-const previewOptions = { method: 'stories.preview' } as const;
+const previewOptions = { method: 'stories.preview', mcpEventName: 'tool:previewStories' } as const;
 
 describe('toolset-backed MCP tools', () => {
   beforeEach(() => {
@@ -143,7 +143,11 @@ describe('toolset-backed MCP tools', () => {
       }) as any
     );
 
-    const result = await callToolsetMethod(makeServer(), { method: 'stories.changed' }, {});
+    const result = await callToolsetMethod(
+      makeServer(),
+      { method: 'stories.changed', mcpEventName: 'tool:getChangedStories' },
+      {}
+    );
 
     expect(result.content).toEqual([{ type: 'text', text: 'no changes' }]);
     expect(result.structuredContent).toBeUndefined();
@@ -216,7 +220,7 @@ describe('toolset-backed MCP tools', () => {
     expect(vi.mocked(logger.error).mock.calls[0][0]).toContain('boom');
   });
 
-  it('sends the report on the outcome as the addon-mcp event', async () => {
+  it('sends the report on the outcome under the legacy event name the addon keeps', async () => {
     registerStubStoriesToolset();
 
     await callToolsetMethod(makeServer(), previewOptions, { id: 'button--primary' });

--- a/code/addons/mcp/src/tools/toolset-tools.test.ts
+++ b/code/addons/mcp/src/tools/toolset-tools.test.ts
@@ -34,10 +34,7 @@ function registerStubStoriesToolset(
           handler:
             overrides.handler ??
             (async (input: { id: string }, ctx) => {
-              await ctx.telemetry?.('tool:previewStories', {
-                toolset: 'dev',
-                inputStoryCount: 1,
-              });
+              await ctx.telemetry?.('tool:previewStories', { inputStoryCount: 1 });
               const stories = [{ previewUrl: `${ctx.origin}/?path=/story/${input.id}` }];
               return {
                 ok: true,
@@ -57,7 +54,7 @@ function makeServer(custom: Record<string, unknown> = {}) {
   } as any;
 }
 
-const previewOptions = { method: 'stories.preview' } as const;
+const previewOptions = { method: 'stories.preview', toolset: 'dev' } as const;
 
 describe('toolset-backed MCP tools', () => {
   beforeEach(() => {
@@ -146,7 +143,11 @@ describe('toolset-backed MCP tools', () => {
       }) as any
     );
 
-    const result = await callToolsetMethod(makeServer(), { method: 'stories.changed' }, {});
+    const result = await callToolsetMethod(
+      makeServer(),
+      { method: 'stories.changed', toolset: 'dev' },
+      {}
+    );
 
     expect(result.content).toEqual([{ type: 'text', text: 'no changes' }]);
     expect(result.structuredContent).toBeUndefined();
@@ -219,19 +220,25 @@ describe('toolset-backed MCP tools', () => {
     expect(vi.mocked(logger.error).mock.calls[0][0]).toContain('boom');
   });
 
-  it('forwards method telemetry with the surface fields the adapter owns', async () => {
-    registerStubStoriesToolset();
+  it.each(['dev', 'docs', 'test'] as const)(
+    'forwards method telemetry with the MCP grouping %s the adapter owns',
+    async (toolset) => {
+      registerStubStoriesToolset();
 
-    await callToolsetMethod(makeServer(), previewOptions, { id: 'button--primary' });
+      await callToolsetMethod(
+        makeServer(),
+        { ...previewOptions, toolset },
+        { id: 'button--primary' }
+      );
 
-    expect(collectTelemetry).toHaveBeenCalledWith(
-      expect.objectContaining({
+      expect(collectTelemetry).toHaveBeenCalledWith({
         event: 'tool:previewStories',
-        toolset: 'dev',
+        server: expect.anything(),
+        toolset,
         inputStoryCount: 1,
-      })
-    );
-  });
+      });
+    }
+  );
 
   it('emits no telemetry when the session disabled it', async () => {
     registerStubStoriesToolset();

--- a/code/addons/mcp/src/tools/toolset-tools.test.ts
+++ b/code/addons/mcp/src/tools/toolset-tools.test.ts
@@ -54,7 +54,7 @@ function makeServer(custom: Record<string, unknown> = {}) {
   } as any;
 }
 
-const previewOptions = { method: 'stories.preview', toolset: 'dev' } as const;
+const previewOptions = { method: 'stories.preview' } as const;
 
 describe('toolset-backed MCP tools', () => {
   beforeEach(() => {
@@ -143,11 +143,7 @@ describe('toolset-backed MCP tools', () => {
       }) as any
     );
 
-    const result = await callToolsetMethod(
-      makeServer(),
-      { method: 'stories.changed', toolset: 'dev' },
-      {}
-    );
+    const result = await callToolsetMethod(makeServer(), { method: 'stories.changed' }, {});
 
     expect(result.content).toEqual([{ type: 'text', text: 'no changes' }]);
     expect(result.structuredContent).toBeUndefined();
@@ -220,25 +216,19 @@ describe('toolset-backed MCP tools', () => {
     expect(vi.mocked(logger.error).mock.calls[0][0]).toContain('boom');
   });
 
-  it.each(['dev', 'docs', 'test'] as const)(
-    'reports the outcome with the MCP grouping %s in place of the report toolset and tool',
-    async (toolset) => {
-      registerStubStoriesToolset();
+  it('sends the report on the outcome as the addon-mcp event', async () => {
+    registerStubStoriesToolset();
 
-      await callToolsetMethod(
-        makeServer(),
-        { ...previewOptions, toolset },
-        { id: 'button--primary' }
-      );
+    await callToolsetMethod(makeServer(), previewOptions, { id: 'button--primary' });
 
-      expect(collectTelemetry).toHaveBeenCalledWith({
-        event: 'tool:previewStories',
-        server: expect.anything(),
-        toolset,
-        inputStoryCount: 1,
-      });
-    }
-  );
+    expect(collectTelemetry).toHaveBeenCalledWith({
+      event: 'tool:previewStories',
+      server: expect.anything(),
+      toolset: 'stories',
+      tool: 'preview',
+      inputStoryCount: 1,
+    });
+  });
 
   it('emits no telemetry for an outcome without a report', async () => {
     registerStubStoriesToolset({

--- a/code/addons/mcp/src/tools/toolset-tools.test.ts
+++ b/code/addons/mcp/src/tools/toolset-tools.test.ts
@@ -34,12 +34,12 @@ function registerStubStoriesToolset(
           handler:
             overrides.handler ??
             (async (input: { id: string }, ctx) => {
-              await ctx.telemetry?.('tool:previewStories', { inputStoryCount: 1 });
               const stories = [{ previewUrl: `${ctx.origin}/?path=/story/${input.id}` }];
               return {
                 ok: true,
                 data: { stories, extraNotInContract: 'internal' },
                 markdown: stories.map((story) => story.previewUrl).join('\n'),
+                telemetry: { event: 'tool:previewStories', counters: { inputStoryCount: 1 } },
               };
             }),
         },
@@ -221,7 +221,7 @@ describe('toolset-backed MCP tools', () => {
   });
 
   it.each(['dev', 'docs', 'test'] as const)(
-    'forwards method telemetry with the MCP grouping %s the adapter owns',
+    'reports the outcome with the MCP grouping %s in place of the report toolset and tool',
     async (toolset) => {
       registerStubStoriesToolset();
 
@@ -240,19 +240,14 @@ describe('toolset-backed MCP tools', () => {
     }
   );
 
-  it('keeps the adapter-owned toolset when a handler payload carries one', async () => {
+  it('emits no telemetry for an outcome without a report', async () => {
     registerStubStoriesToolset({
-      handler: async (_input: unknown, ctx: any) => {
-        await ctx.telemetry?.('tool:previewStories', { toolset: 'test', inputStoryCount: 1 });
-        return { ok: true, data: { stories: [] }, markdown: '' };
-      },
+      handler: async () => ({ ok: true, data: { stories: [] }, markdown: '' }),
     });
 
     await callToolsetMethod(makeServer(), previewOptions, { id: 'button--primary' });
 
-    expect(collectTelemetry).toHaveBeenCalledWith(
-      expect.objectContaining({ event: 'tool:previewStories', toolset: 'dev' })
-    );
+    expect(collectTelemetry).not.toHaveBeenCalled();
   });
 
   it('emits no telemetry when the session disabled it', async () => {

--- a/code/addons/mcp/src/tools/toolset-tools.ts
+++ b/code/addons/mcp/src/tools/toolset-tools.ts
@@ -114,8 +114,8 @@ async function reportToolsetTelemetry(
   if (!report || server.ctx.custom?.disableTelemetry) {
     return;
   }
-  const { event, counters, ...names } = report;
-  await collectTelemetry({ event, server, ...counters, ...names });
+  const { event, payload, ...names } = report;
+  await collectTelemetry({ event, server, ...payload, ...names });
 }
 
 /** Runs one toolset method and unwraps its outcome into an MCP tool result. */

--- a/code/addons/mcp/src/tools/toolset-tools.ts
+++ b/code/addons/mcp/src/tools/toolset-tools.ts
@@ -12,6 +12,8 @@ import { logger } from 'storybook/internal/node-logger';
 import { OpenServiceToolsetOutputMismatchError } from 'storybook/internal/server-errors';
 import {
   getToolset,
+  invokeToolsetMethod,
+  parseToolsetMethodId,
   resolveToolsetDescription,
   toMcpToolName,
   type AnyToolsetDefinition,
@@ -19,6 +21,7 @@ import {
   type ToolsetCtx,
   type ToolsetMethod,
   type ToolsetMethodId,
+  type ToolsetMethodReport,
 } from 'storybook/open-service';
 import type { McpServer } from 'tmcp';
 
@@ -98,19 +101,33 @@ async function toStructuredContent(
   return result.value as Record<string, unknown>;
 }
 
-function buildContext(server: Server, toolset: McpToolsetGroup): ToolsetCtx {
-  const custom = server.ctx.custom;
+function buildContext(server: Server): ToolsetCtx {
   return {
     transport: 'mcp',
     // The toolset origin is the complete UI base URL, including any deployment subpath.
-    origin: resolveToolsetOrigin(custom ?? {}),
+    origin: resolveToolsetOrigin(server.ctx.custom ?? {}),
     getService: (serviceId, serviceOptions) => getService(serviceId as any, serviceOptions) as any,
-    telemetry: custom?.disableTelemetry
-      ? undefined
-      : async (event, payload) => {
-          await collectTelemetry({ event, server, ...payload, toolset });
-        },
   };
+}
+
+/**
+ * Sends the method's usage report as the `addon-mcp` event.
+ *
+ * Backwards compatibility: `toolset` is the MCP grouping this tool is registered under (`dev`,
+ * `docs`, `test`), not the report's own CLI toolset name, because every `addon-mcp` record since
+ * the event exists classifies by that grouping and dashboards key on it. The report's `tool` is
+ * left out for the same reason. Once the `X-MCP-Toolsets` header goes (Storybook 11), this can
+ * forward the report's `toolset` and `tool` the way the CLI does.
+ */
+async function reportToolsetTelemetry(
+  server: Server,
+  toolset: McpToolsetGroup,
+  report: ToolsetMethodReport | undefined
+): Promise<void> {
+  if (!report || server.ctx.custom?.disableTelemetry) {
+    return;
+  }
+  await collectTelemetry({ event: report.event, server, ...report.counters, toolset });
 }
 
 /** Runs one toolset method and unwraps its outcome into an MCP tool result. */
@@ -121,10 +138,11 @@ export async function callToolsetMethod(
 ): Promise<StorybookAiToolCallResult> {
   const toolset = resolveToolset(options, server);
   const method = resolveMethod(toolset, options);
-  const ctx = buildContext(server, options.toolset);
+  const { methodName } = parseToolsetMethodId(options.method);
 
   try {
-    const outcome = await method.handler(input as never, ctx);
+    const outcome = await invokeToolsetMethod(toolset, methodName, input, buildContext(server));
+    await reportToolsetTelemetry(server, options.toolset, outcome.telemetry);
     const structuredContent = await toStructuredContent(method.output, outcome.data);
     const blocks = Array.isArray(outcome.markdown) ? outcome.markdown : [outcome.markdown];
 

--- a/code/addons/mcp/src/tools/toolset-tools.ts
+++ b/code/addons/mcp/src/tools/toolset-tools.ts
@@ -34,13 +34,12 @@ import type { StorybookAiToolCallResult } from './tool-registry.ts';
 type Server = McpServer<any, AddonContext>;
 type ToolEnabled = Parameters<Server['tool']>[0]['enabled'];
 
-// The `addon-mcp` event's frozen `toolset` classifier.
+// The grouping behind the enable gate and the `X-MCP-Toolsets` header; not a telemetry field.
 export type McpToolsetGroup = keyof NonNullable<AddonContext['toolsets']>;
 
 export type ToolsetToolOptions = {
   /** Which toolset method backs this MCP tool. */
   method: ToolsetMethodId;
-  toolset: McpToolsetGroup;
   /** Extra MCP-only tool metadata, e.g. the preview app resource. */
   extras?: Record<string, unknown>;
   /** Wraps the input schema before publishing it (used for friendlier validation errors). */
@@ -110,17 +109,13 @@ function buildContext(server: Server): ToolsetCtx {
 
 async function reportToolsetTelemetry(
   server: Server,
-  toolset: McpToolsetGroup,
   report: ToolsetMethodReport | undefined
 ): Promise<void> {
   if (!report || server.ctx.custom?.disableTelemetry) {
     return;
   }
-  // Backwards compatibility only: `toolset` is the MCP grouping the tool is registered under, not
-  // the report's CLI toolset name, and the report's `tool` is left out, because every `addon-mcp`
-  // record classifies by that grouping and dashboards key on it. Once the `X-MCP-Toolsets` header
-  // goes (Storybook 11), forward the report's `toolset` and `tool` the way the CLI does.
-  await collectTelemetry({ event: report.event, server, ...report.counters, toolset });
+  const { event, counters, ...names } = report;
+  await collectTelemetry({ event, server, ...counters, ...names });
 }
 
 /** Runs one toolset method and unwraps its outcome into an MCP tool result. */
@@ -135,7 +130,7 @@ export async function callToolsetMethod(
 
   try {
     const outcome = await invokeToolsetMethod(toolset, methodName, input, buildContext(server));
-    await reportToolsetTelemetry(server, options.toolset, outcome.telemetry);
+    await reportToolsetTelemetry(server, outcome.telemetry);
     const structuredContent = await toStructuredContent(method.output, outcome.data);
     const blocks = Array.isArray(outcome.markdown) ? outcome.markdown : [outcome.markdown];
 

--- a/code/addons/mcp/src/tools/toolset-tools.ts
+++ b/code/addons/mcp/src/tools/toolset-tools.ts
@@ -59,16 +59,14 @@ function resolveToolset(options: ToolsetToolOptions, server?: Server): AnyToolse
   if (options.resolveToolset) {
     return options.resolveToolset(server);
   }
-  const [toolsetId] = options.method.split('.');
-  return getToolset(toolsetId);
+  return getToolset(parseToolsetMethodId(options.method).toolsetId);
 }
 
 function resolveMethod(
   toolset: AnyToolsetDefinition,
   options: ToolsetToolOptions
 ): ToolsetMethod<any, AnyToolsetOutcome> {
-  const [, methodName] = options.method.split('.');
-  return toolset.methods[methodName];
+  return toolset.methods[parseToolsetMethodId(options.method).methodName];
 }
 
 /**
@@ -110,15 +108,6 @@ function buildContext(server: Server): ToolsetCtx {
   };
 }
 
-/**
- * Sends the method's usage report as the `addon-mcp` event.
- *
- * Backwards compatibility: `toolset` is the MCP grouping this tool is registered under (`dev`,
- * `docs`, `test`), not the report's own CLI toolset name, because every `addon-mcp` record since
- * the event exists classifies by that grouping and dashboards key on it. The report's `tool` is
- * left out for the same reason. Once the `X-MCP-Toolsets` header goes (Storybook 11), this can
- * forward the report's `toolset` and `tool` the way the CLI does.
- */
 async function reportToolsetTelemetry(
   server: Server,
   toolset: McpToolsetGroup,
@@ -127,6 +116,10 @@ async function reportToolsetTelemetry(
   if (!report || server.ctx.custom?.disableTelemetry) {
     return;
   }
+  // Backwards compatibility only: `toolset` is the MCP grouping the tool is registered under, not
+  // the report's CLI toolset name, and the report's `tool` is left out, because every `addon-mcp`
+  // record classifies by that grouping and dashboards key on it. Once the `X-MCP-Toolsets` header
+  // goes (Storybook 11), forward the report's `toolset` and `tool` the way the CLI does.
   await collectTelemetry({ event: report.event, server, ...report.counters, toolset });
 }
 
@@ -137,8 +130,8 @@ export async function callToolsetMethod(
   input: unknown
 ): Promise<StorybookAiToolCallResult> {
   const toolset = resolveToolset(options, server);
-  const method = resolveMethod(toolset, options);
   const { methodName } = parseToolsetMethodId(options.method);
+  const method = toolset.methods[methodName];
 
   try {
     const outcome = await invokeToolsetMethod(toolset, methodName, input, buildContext(server));

--- a/code/addons/mcp/src/tools/toolset-tools.ts
+++ b/code/addons/mcp/src/tools/toolset-tools.ts
@@ -31,9 +31,13 @@ import type { StorybookAiToolCallResult } from './tool-registry.ts';
 type Server = McpServer<any, AddonContext>;
 type ToolEnabled = Parameters<Server['tool']>[0]['enabled'];
 
+// The `addon-mcp` event's frozen `toolset` classifier.
+export type McpToolsetGroup = keyof NonNullable<AddonContext['toolsets']>;
+
 export type ToolsetToolOptions = {
   /** Which toolset method backs this MCP tool. */
   method: ToolsetMethodId;
+  toolset: McpToolsetGroup;
   /** Extra MCP-only tool metadata, e.g. the preview app resource. */
   extras?: Record<string, unknown>;
   /** Wraps the input schema before publishing it (used for friendlier validation errors). */
@@ -94,7 +98,7 @@ async function toStructuredContent(
   return result.value as Record<string, unknown>;
 }
 
-function buildContext(server: Server): ToolsetCtx {
+function buildContext(server: Server, toolset: McpToolsetGroup): ToolsetCtx {
   const custom = server.ctx.custom;
   return {
     transport: 'mcp',
@@ -104,11 +108,7 @@ function buildContext(server: Server): ToolsetCtx {
     telemetry: custom?.disableTelemetry
       ? undefined
       : async (event, payload) => {
-          await collectTelemetry({
-            event,
-            server,
-            ...payload,
-          });
+          await collectTelemetry({ event, server, toolset, ...payload });
         },
   };
 }
@@ -121,7 +121,7 @@ export async function callToolsetMethod(
 ): Promise<StorybookAiToolCallResult> {
   const toolset = resolveToolset(options, server);
   const method = resolveMethod(toolset, options);
-  const ctx = buildContext(server);
+  const ctx = buildContext(server, options.toolset);
 
   try {
     const outcome = await method.handler(input as never, ctx);

--- a/code/addons/mcp/src/tools/toolset-tools.ts
+++ b/code/addons/mcp/src/tools/toolset-tools.ts
@@ -40,6 +40,12 @@ export type McpToolsetGroup = keyof NonNullable<AddonContext['toolsets']>;
 export type ToolsetToolOptions = {
   /** Which toolset method backs this MCP tool. */
   method: ToolsetMethodId;
+  /**
+   * The `event` of this tool's `addon-mcp` record. These names predate the toolsets
+   * (`tool:getChangedStories`) and replace the generated `tool:stories_changed` on this surface
+   * only, so MCP usage data stays continuous across versions. The toolsets know nothing of them.
+   */
+  mcpEventName: string;
   /** Extra MCP-only tool metadata, e.g. the preview app resource. */
   extras?: Record<string, unknown>;
   /** Wraps the input schema before publishing it (used for friendlier validation errors). */
@@ -109,13 +115,14 @@ function buildContext(server: Server): ToolsetCtx {
 
 async function reportToolsetTelemetry(
   server: Server,
+  event: string,
   report: ToolsetMethodReport | undefined
 ): Promise<void> {
   if (!report || server.ctx.custom?.disableTelemetry) {
     return;
   }
-  const { event, payload, ...names } = report;
-  await collectTelemetry({ event, server, ...payload, ...names });
+  const { payload, toolset, tool } = report;
+  await collectTelemetry({ event, server, ...payload, toolset, tool });
 }
 
 /** Runs one toolset method and unwraps its outcome into an MCP tool result. */
@@ -130,7 +137,7 @@ export async function callToolsetMethod(
 
   try {
     const outcome = await invokeToolsetMethod(toolset, methodName, input, buildContext(server));
-    await reportToolsetTelemetry(server, outcome.telemetry);
+    await reportToolsetTelemetry(server, options.mcpEventName, outcome.telemetry);
     const structuredContent = await toStructuredContent(method.output, outcome.data);
     const blocks = Array.isArray(outcome.markdown) ? outcome.markdown : [outcome.markdown];
 

--- a/code/addons/mcp/src/tools/toolset-tools.ts
+++ b/code/addons/mcp/src/tools/toolset-tools.ts
@@ -108,7 +108,7 @@ function buildContext(server: Server, toolset: McpToolsetGroup): ToolsetCtx {
     telemetry: custom?.disableTelemetry
       ? undefined
       : async (event, payload) => {
-          await collectTelemetry({ event, server, toolset, ...payload });
+          await collectTelemetry({ event, server, ...payload, toolset });
         },
   };
 }

--- a/code/addons/vitest/src/node/toolset/definition.test.ts
+++ b/code/addons/vitest/src/node/toolset/definition.test.ts
@@ -449,7 +449,7 @@ No story found for story ID "gone--story"`);
         toolset: 'test',
         tool: 'run',
         event: 'tool:runStoryTests',
-        counters: {
+        payload: {
           runA11y: true,
           inputStoryCount: 1,
           matchedStoryCount: 1,
@@ -473,7 +473,7 @@ No story found for story ID "gone--story"`);
         toolset: 'test',
         tool: 'run',
         event: 'tool:runStoryTests',
-        counters: {
+        payload: {
           runA11y: false,
           inputStoryCount: 1,
           matchedStoryCount: 0,

--- a/code/addons/vitest/src/node/toolset/definition.test.ts
+++ b/code/addons/vitest/src/node/toolset/definition.test.ts
@@ -448,7 +448,6 @@ No story found for story ID "gone--story"`);
       await runTests({ stories: [{ storyId: 'button--primary' }] });
 
       expect(telemetry).toHaveBeenCalledWith('tool:runStoryTests', {
-        toolset: 'test',
         runA11y: true,
         inputStoryCount: 1,
         matchedStoryCount: 1,
@@ -468,7 +467,6 @@ No story found for story ID "gone--story"`);
       await runTests({ stories: [{ storyId: 'missing--story' }], a11y: false });
 
       expect(telemetry).toHaveBeenCalledWith('tool:runStoryTests', {
-        toolset: 'test',
         runA11y: false,
         inputStoryCount: 1,
         matchedStoryCount: 0,

--- a/code/addons/vitest/src/node/toolset/definition.test.ts
+++ b/code/addons/vitest/src/node/toolset/definition.test.ts
@@ -448,7 +448,7 @@ No story found for story ID "gone--story"`);
       expect(outcome.telemetry).toEqual({
         toolset: 'test',
         tool: 'run',
-        event: 'tool:runStoryTests',
+        event: 'tool:test_run',
         payload: {
           runA11y: true,
           inputStoryCount: 1,
@@ -472,7 +472,7 @@ No story found for story ID "gone--story"`);
       expect(outcome.telemetry).toEqual({
         toolset: 'test',
         tool: 'run',
-        event: 'tool:runStoryTests',
+        event: 'tool:test_run',
         payload: {
           runA11y: false,
           inputStoryCount: 1,

--- a/code/addons/vitest/src/node/toolset/definition.test.ts
+++ b/code/addons/vitest/src/node/toolset/definition.test.ts
@@ -1,5 +1,5 @@
 import type { StoryIndex } from 'storybook/internal/types';
-import type { ToolsetCtx } from 'storybook/open-service';
+import { invokeToolsetMethod, type ToolsetCtx } from 'storybook/open-service';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as v from 'valibot';
@@ -13,14 +13,12 @@ vi.mock('./run.ts', { spy: true });
 const index = { v: 5, entries: {} } as StoryIndex;
 const getIndex = vi.fn();
 const storyIndex = { getIndex };
-const telemetry = vi.fn();
 const channel = {} as never;
 
 const ctx = {
   transport: 'cli',
   origin: 'http://localhost:6006',
   getService: vi.fn() as ToolsetCtx['getService'],
-  telemetry,
 } satisfies ToolsetCtx;
 
 const mcpCtx = { ...ctx, transport: 'mcp' } satisfies ToolsetCtx;
@@ -75,7 +73,7 @@ function runTests(
   input: v.InferInput<typeof toolset.methods.run.input> = {},
   runCtx: ToolsetCtx = ctx
 ) {
-  return toolset.methods.run.handler(v.parse(toolset.methods.run.input, input), runCtx);
+  return invokeToolsetMethod(toolset, 'run', v.parse(toolset.methods.run.input, input), runCtx);
 }
 
 /** Runs and renders the way the MCP adapter does: one handler call, markdown from the outcome. */
@@ -445,16 +443,21 @@ No story found for story ID "gone--story"`);
         })
       );
 
-      await runTests({ stories: [{ storyId: 'button--primary' }] });
+      const outcome = await runTests({ stories: [{ storyId: 'button--primary' }] });
 
-      expect(telemetry).toHaveBeenCalledWith('tool:runStoryTests', {
-        runA11y: true,
-        inputStoryCount: 1,
-        matchedStoryCount: 1,
-        passingStoryCount: 1,
-        failingStoryCount: 0,
-        a11yViolationCount: 1,
-        unhandledErrorCount: 0,
+      expect(outcome.telemetry).toEqual({
+        toolset: 'test',
+        tool: 'run',
+        event: 'tool:runStoryTests',
+        counters: {
+          runA11y: true,
+          inputStoryCount: 1,
+          matchedStoryCount: 1,
+          passingStoryCount: 1,
+          failingStoryCount: 0,
+          a11yViolationCount: 1,
+          unhandledErrorCount: 0,
+        },
       });
     });
 
@@ -464,49 +467,30 @@ No story found for story ID "gone--story"`);
         notFoundMessages: ['No story found for story ID "missing--story"'],
       });
 
-      await runTests({ stories: [{ storyId: 'missing--story' }], a11y: false });
+      const outcome = await runTests({ stories: [{ storyId: 'missing--story' }], a11y: false });
 
-      expect(telemetry).toHaveBeenCalledWith('tool:runStoryTests', {
-        runA11y: false,
-        inputStoryCount: 1,
-        matchedStoryCount: 0,
-        passingStoryCount: 0,
-        failingStoryCount: 0,
-        a11yViolationCount: 0,
-        unhandledErrorCount: 0,
+      expect(outcome.telemetry).toEqual({
+        toolset: 'test',
+        tool: 'run',
+        event: 'tool:runStoryTests',
+        counters: {
+          runA11y: false,
+          inputStoryCount: 1,
+          matchedStoryCount: 0,
+          passingStoryCount: 0,
+          failingStoryCount: 0,
+          a11yViolationCount: 0,
+          unhandledErrorCount: 0,
+        },
       });
     });
 
     it('stays silent for a run that never reached a verdict', async () => {
       vi.mocked(runStoryTests).mockResolvedValue({ status: 'cancelled' });
 
-      await runTests();
+      const outcome = await runTests();
 
-      expect(telemetry).not.toHaveBeenCalled();
-    });
-
-    it.each([
-      ['completed', completedRun],
-      [
-        'no-stories',
-        {
-          status: 'no-stories' as const,
-          notFoundMessages: ['No story found for story ID "missing--story"'],
-        },
-      ],
-    ])('does not fail a %s result when telemetry rejects', async (_status, result) => {
-      vi.mocked(runStoryTests).mockResolvedValue(result);
-      const rejectingCtx: ToolsetCtx = {
-        ...ctx,
-        telemetry: async () => {
-          throw new Error('telemetry unavailable');
-        },
-      };
-
-      const outcome = await runTests({}, rejectingCtx);
-
-      expect(outcome.ok).toBe(true);
-      expect(outcome.data.status).toBe(result.status);
+      expect(outcome.telemetry).toBeUndefined();
     });
   });
 });

--- a/code/addons/vitest/src/node/toolset/definition.ts
+++ b/code/addons/vitest/src/node/toolset/definition.ts
@@ -166,7 +166,6 @@ async function reportRunTelemetry(data: TestRunData, input: RunInput, ctx: Tools
 
   if (data.status === 'no-stories') {
     await reportToolsetTelemetry(ctx, 'tool:runStoryTests', {
-      toolset: 'test',
       runA11y: data.a11y,
       inputStoryCount,
       matchedStoryCount: 0,
@@ -183,7 +182,6 @@ async function reportRunTelemetry(data: TestRunData, input: RunInput, ctx: Tools
   }
 
   await reportToolsetTelemetry(ctx, 'tool:runStoryTests', {
-    toolset: 'test',
     runA11y: data.a11y,
     inputStoryCount,
     // A partially resolved selector list never reaches a run, so every input matched by this point.

--- a/code/addons/vitest/src/node/toolset/definition.ts
+++ b/code/addons/vitest/src/node/toolset/definition.ts
@@ -165,7 +165,6 @@ function runTelemetry(data: TestRunData, input: RunInput): ToolsetTelemetryRepor
 
   if (data.status === 'no-stories') {
     return {
-      event: 'tool:runStoryTests',
       payload: {
         runA11y: data.a11y,
         inputStoryCount,
@@ -183,7 +182,6 @@ function runTelemetry(data: TestRunData, input: RunInput): ToolsetTelemetryRepor
   }
 
   return {
-    event: 'tool:runStoryTests',
     payload: {
       runA11y: data.a11y,
       inputStoryCount,

--- a/code/addons/vitest/src/node/toolset/definition.ts
+++ b/code/addons/vitest/src/node/toolset/definition.ts
@@ -3,8 +3,7 @@ import * as v from 'valibot';
 import { storyInputArraySchema, type StoryIndexAccess } from 'storybook/internal/core-server';
 import {
   defineToolset,
-  reportToolsetTelemetry,
-  type ToolsetCtx,
+  type ToolsetTelemetryReport,
   type ToolsetOutcome,
 } from 'storybook/open-service';
 
@@ -158,36 +157,41 @@ For visual/design accessibility violations (for example color contrast), ask the
 }
 
 /**
- * Reports a run that reached a verdict. A run that never got one — a channel error, a cancellation —
- * stays silent, so the event counts runs whose numbers mean something.
+ * The report for a run that reached a verdict. A run that never got one — a channel error, a
+ * cancellation — reports nothing, so the event counts runs whose numbers mean something.
  */
-async function reportRunTelemetry(data: TestRunData, input: RunInput, ctx: ToolsetCtx) {
+function runTelemetry(data: TestRunData, input: RunInput): ToolsetTelemetryReport | undefined {
   const inputStoryCount = input.stories?.length ?? 0;
 
   if (data.status === 'no-stories') {
-    await reportToolsetTelemetry(ctx, 'tool:runStoryTests', {
-      runA11y: data.a11y,
-      inputStoryCount,
-      matchedStoryCount: 0,
-      passingStoryCount: 0,
-      failingStoryCount: 0,
-      a11yViolationCount: 0,
-      unhandledErrorCount: 0,
-    });
-    return;
+    return {
+      event: 'tool:runStoryTests',
+      counters: {
+        runA11y: data.a11y,
+        inputStoryCount,
+        matchedStoryCount: 0,
+        passingStoryCount: 0,
+        failingStoryCount: 0,
+        a11yViolationCount: 0,
+        unhandledErrorCount: 0,
+      },
+    };
   }
 
   if (data.status !== 'completed') {
-    return;
+    return undefined;
   }
 
-  await reportToolsetTelemetry(ctx, 'tool:runStoryTests', {
-    runA11y: data.a11y,
-    inputStoryCount,
-    // A partially resolved selector list never reaches a run, so every input matched by this point.
-    matchedStoryCount: data.result.storyIds?.length ?? inputStoryCount,
-    ...summarizeTestRun(data.result, data.a11y),
-  });
+  return {
+    event: 'tool:runStoryTests',
+    counters: {
+      runA11y: data.a11y,
+      inputStoryCount,
+      // A partially resolved selector list never reaches a run, so every input matched by this point.
+      matchedStoryCount: data.result.storyIds?.length ?? inputStoryCount,
+      ...summarizeTestRun(data.result, data.a11y),
+    },
+  };
 }
 
 function isFailedRun(data: TestRunData): data is TestRunFailureData {
@@ -246,11 +250,11 @@ export function createTestToolset({ channel, storyIndex, a11yEnabled }: CreateTe
               a11y: input.a11y,
             });
             const data: TestRunData = { ...output, a11y: input.a11y };
-
-            await reportRunTelemetry(data, input, ctx);
-
             const markdown = formatTestRun(data, ctx);
-            return isFailedRun(data) ? { ok: false, data, markdown } : { ok: true, data, markdown };
+            const telemetry = runTelemetry(data, input);
+            return isFailedRun(data)
+              ? { ok: false, data, markdown, telemetry }
+              : { ok: true, data, markdown, telemetry };
           } finally {
             done();
           }

--- a/code/addons/vitest/src/node/toolset/definition.ts
+++ b/code/addons/vitest/src/node/toolset/definition.ts
@@ -166,7 +166,7 @@ function runTelemetry(data: TestRunData, input: RunInput): ToolsetTelemetryRepor
   if (data.status === 'no-stories') {
     return {
       event: 'tool:runStoryTests',
-      counters: {
+      payload: {
         runA11y: data.a11y,
         inputStoryCount,
         matchedStoryCount: 0,
@@ -184,7 +184,7 @@ function runTelemetry(data: TestRunData, input: RunInput): ToolsetTelemetryRepor
 
   return {
     event: 'tool:runStoryTests',
-    counters: {
+    payload: {
       runA11y: data.a11y,
       inputStoryCount,
       // A partially resolved selector list never reaches a run, so every input matched by this point.

--- a/code/core/src/cli/tools/architecture.md
+++ b/code/core/src/cli/tools/architecture.md
@@ -109,9 +109,12 @@ See [Load](../../shared/open-service/README.md#load).
 In local mode, `requiresDevServer` intercepts with start-your-Storybook guidance. In attached mode
 those methods run in the caller. `stories.preview` reads origin from the instance record.
 
-The CLI fires a `tools-command` invocation event after a run. The payload includes `attachMode`.
-Per-method toolset telemetry (`ctx.telemetry`) fires in the caller when the CLI passes a sink into
-`tools.call`. Command-level side effects and their telemetry run on the instance.
+The CLI and the SDK fire one `tools-command` record per invocation after a run. It carries the
+CLI spelling of the invoked `toolset` and `tool`, `success`, `outcome`, `duration`, the attach
+fields (`attachMode` among them), and the handler's own report — its legacy `event` name and its
+counters — merged in. The handler reports through `ctx.telemetry`, which the caller collects (over
+IPC from a child host) rather than sending separately. Command-level side effects run on the
+instance.
 
 ## SDK
 

--- a/code/core/src/cli/tools/architecture.md
+++ b/code/core/src/cli/tools/architecture.md
@@ -111,7 +111,7 @@ those methods run in the caller. `stories.preview` reads origin from the instanc
 
 The CLI and the SDK fire one `tools-command` record per invocation after a run; help lookups are
 excluded so they cannot skew success rates. The record is the handler's usage report — `toolset`
-and `tool` in CLI spelling, its legacy `event` name, and its counters, all returned on the outcome
+and `tool` in CLI spelling, its legacy `event` name, and its payload, all returned on the outcome
 by `invokeToolsetMethod` — plus `success`, `outcome`, `duration`, and the attach fields
 (`attachMode` among them). A child host's report rides inside the outcome that already crosses
 IPC. Command-level side effects run on the instance.

--- a/code/core/src/cli/tools/architecture.md
+++ b/code/core/src/cli/tools/architecture.md
@@ -109,7 +109,8 @@ See [Load](../../shared/open-service/README.md#load).
 In local mode, `requiresDevServer` intercepts with start-your-Storybook guidance. In attached mode
 those methods run in the caller. `stories.preview` reads origin from the instance record.
 
-The CLI and the SDK fire one `tools-command` record per invocation after a run. It carries the
+The CLI and the SDK fire one `tools-command` record per invocation after a run; help lookups are
+excluded so they cannot skew success rates. It carries the
 CLI spelling of the invoked `toolset` and `tool`, `success`, `outcome`, `duration`, the attach
 fields (`attachMode` among them), and the handler's own report — its legacy `event` name and its
 counters — merged in. The handler reports through `ctx.telemetry`, which the caller collects (over

--- a/code/core/src/cli/tools/architecture.md
+++ b/code/core/src/cli/tools/architecture.md
@@ -111,8 +111,8 @@ those methods run in the caller. `stories.preview` reads origin from the instanc
 
 The CLI and the SDK fire one `tools-command` record per invocation after a run; help lookups are
 excluded so they cannot skew success rates. The record is the handler's usage report — `toolset`
-and `tool` in CLI spelling, its legacy `event` name, and its payload, all returned on the outcome
-by `invokeToolsetMethod` — plus `success`, `outcome`, `duration`, and the attach fields
+and `tool` in CLI spelling, the generated `event` (`tool:docs_list`), and its payload, all returned
+on the outcome by `invokeToolsetMethod` — plus `success`, `outcome`, `duration`, and the attach fields
 (`attachMode` among them). A child host's report rides inside the outcome that already crosses
 IPC. Command-level side effects run on the instance.
 

--- a/code/core/src/cli/tools/architecture.md
+++ b/code/core/src/cli/tools/architecture.md
@@ -110,12 +110,11 @@ In local mode, `requiresDevServer` intercepts with start-your-Storybook guidance
 those methods run in the caller. `stories.preview` reads origin from the instance record.
 
 The CLI and the SDK fire one `tools-command` record per invocation after a run; help lookups are
-excluded so they cannot skew success rates. It carries the
-CLI spelling of the invoked `toolset` and `tool`, `success`, `outcome`, `duration`, the attach
-fields (`attachMode` among them), and the handler's own report — its legacy `event` name and its
-counters — merged in. The handler reports through `ctx.telemetry`, which the caller collects (over
-IPC from a child host) rather than sending separately. Command-level side effects run on the
-instance.
+excluded so they cannot skew success rates. The record is the handler's usage report — `toolset`
+and `tool` in CLI spelling, its legacy `event` name, and its counters, all returned on the outcome
+by `invokeToolsetMethod` — plus `success`, `outcome`, `duration`, and the attach fields
+(`attachMode` among them). A child host's report rides inside the outcome that already crosses
+IPC. Command-level side effects run on the instance.
 
 ## SDK
 

--- a/code/core/src/cli/tools/register.test.ts
+++ b/code/core/src/cli/tools/register.test.ts
@@ -139,7 +139,7 @@ describe('tools-command telemetry', () => {
         report: {
           toolset: 'stories',
           tool: 'changed',
-          event: 'tool:getChangedStories',
+          event: 'tool:stories_changed',
           payload: {
             storyCount: 4,
             newStoryCount: 1,
@@ -153,9 +153,9 @@ describe('tools-command telemetry', () => {
 
     expect(toolsCommandPayloads()).toEqual([
       {
-        event: 'tool:getChangedStories',
         toolset: 'stories',
         tool: 'changed',
+        event: 'tool:stories_changed',
         success: true,
         outcome: 'success',
         duration: expect.any(Number),
@@ -179,7 +179,7 @@ describe('tools-command telemetry', () => {
         report: {
           toolset: 'stories',
           tool: 'find-by-component',
-          event: 'tool:getStoriesByComponent',
+          event: 'tool:stories_findByComponent',
           payload: { componentCount: 1 },
         },
       })

--- a/code/core/src/cli/tools/register.test.ts
+++ b/code/core/src/cli/tools/register.test.ts
@@ -57,10 +57,7 @@ function parse(program: Command, argv: string[]) {
 function toolsCommandPayloads(): unknown[] {
   return vi
     .mocked(telemetry)
-    .mock.calls.filter(
-      ([eventType, payload]) =>
-        eventType === 'tools-command' && payload !== undefined && !('event' in payload)
-    )
+    .mock.calls.filter(([eventType]) => eventType === 'tools-command')
     .map(([, payload]) => payload);
 }
 
@@ -119,7 +116,8 @@ describe('tools-command telemetry', () => {
 
     expect(toolsCommandPayloads()).toEqual([
       {
-        command: 'docs list',
+        toolset: 'docs',
+        tool: 'list',
         success: true,
         outcome: 'success',
         client: 'cli',
@@ -131,6 +129,66 @@ describe('tools-command telemetry', () => {
       },
     ]);
     expect(sendTelemetryError).not.toHaveBeenCalled();
+  });
+
+  it('merges the handler report into the one tools-command record', async () => {
+    const { program } = buildProgram();
+    vi.mocked(runToolsCommand).mockImplementation(async (_invocation, deps) => {
+      await deps?.methodTelemetry?.('tool:getChangedStories', {
+        client: 'cli',
+        requestedMode: 'auto',
+        resolvedMode: 'local',
+        attachMode: 'local',
+        host: 'in-process',
+        storyCount: 4,
+        newStoryCount: 1,
+        modifiedStoryCount: 3,
+        affectedStoryCount: 0,
+      });
+      return successResult({ attachMode: 'local' });
+    });
+    await parse(program, ['tools', 'stories', 'changed']);
+
+    expect(toolsCommandPayloads()).toEqual([
+      {
+        event: 'tool:getChangedStories',
+        toolset: 'stories',
+        tool: 'changed',
+        success: true,
+        outcome: 'success',
+        duration: expect.any(Number),
+        client: 'cli',
+        requestedMode: 'auto',
+        resolvedMode: 'local',
+        attachMode: 'local',
+        host: 'in-process',
+        storyCount: 4,
+        newStoryCount: 1,
+        modifiedStoryCount: 3,
+        affectedStoryCount: 0,
+      },
+    ]);
+  });
+
+  it('keeps the handler report on the record when the run fails after it', async () => {
+    const { program } = buildProgram();
+    const error = new Error('boom');
+    vi.mocked(runToolsCommand).mockImplementation(async (_invocation, deps) => {
+      await deps?.methodTelemetry?.('tool:getChangedStories', { storyCount: 4 });
+      return successResult({ exitCode: 1, outcome: { kind: 'error', error } });
+    });
+    await parse(program, ['tools', 'stories', 'changed']);
+
+    expect(toolsCommandPayloads()).toEqual([
+      expect.objectContaining({
+        event: 'tool:getChangedStories',
+        toolset: 'stories',
+        tool: 'changed',
+        storyCount: 4,
+        success: false,
+        outcome: 'error',
+      }),
+    ]);
   });
 
   it('reports an attach-gate outcome from --attach', async () => {
@@ -149,7 +207,8 @@ describe('tools-command telemetry', () => {
 
     expect(toolsCommandPayloads()).toEqual([
       expect.objectContaining({
-        command: 'docs list',
+        toolset: 'docs',
+        tool: 'list',
         success: false,
         outcome: 'attach-gate',
         client: 'cli',
@@ -161,6 +220,27 @@ describe('tools-command telemetry', () => {
     expect(toolsCommandPayloads()[0]).not.toHaveProperty('resolvedMode');
     expect(toolsCommandPayloads()[0]).not.toHaveProperty('host');
     expect(sendTelemetryError).not.toHaveBeenCalled();
+  });
+
+  it('names no toolset or tool when the attach gate fired before any was parsed', async () => {
+    const { program } = buildProgram();
+    vi.mocked(runToolsCommand).mockResolvedValue(
+      successResult({
+        exitCode: 1,
+        output: 'No running Storybook',
+        outcome: { kind: 'attach-gate', reason: 'no-instance' },
+        requestedMode: 'attached',
+        attachMode: 'attached',
+        host: undefined,
+      })
+    );
+    await parse(program, ['tools', '--attach']);
+
+    expect(toolsCommandPayloads()).toEqual([
+      expect.objectContaining({ success: false, outcome: 'attach-gate' }),
+    ]);
+    expect(toolsCommandPayloads()[0]).not.toHaveProperty('toolset');
+    expect(toolsCommandPayloads()[0]).not.toHaveProperty('tool');
   });
 
   it('keeps requestedMode auto and attachGate on a successful local fallback', async () => {
@@ -178,7 +258,8 @@ describe('tools-command telemetry', () => {
 
     expect(toolsCommandPayloads()).toEqual([
       expect.objectContaining({
-        command: 'docs list',
+        toolset: 'docs',
+        tool: 'list',
         success: true,
         outcome: 'success',
         client: 'cli',
@@ -204,7 +285,8 @@ describe('tools-command telemetry', () => {
 
     expect(toolsCommandPayloads()).toEqual([
       expect.objectContaining({
-        command: 'nope list',
+        toolset: 'nope',
+        tool: 'list',
         success: false,
         outcome: 'intercept',
         interceptReason: 'unknown-toolset',
@@ -232,7 +314,8 @@ describe('tools-command telemetry', () => {
 
     expect(toolsCommandPayloads()).toEqual([
       expect.objectContaining({
-        command: 'docs list',
+        toolset: 'docs',
+        tool: 'list',
         success: false,
         outcome: 'error',
         client: 'cli',
@@ -272,7 +355,7 @@ describe('tools-command telemetry', () => {
     await parse(program, ['tools', './projects/secret-app', 'list']);
 
     expect(toolsCommandPayloads()).toEqual([
-      expect.objectContaining({ command: '(invalid) list' }),
+      expect.objectContaining({ toolset: '(invalid)', tool: 'list' }),
     ]);
   });
 
@@ -283,7 +366,8 @@ describe('tools-command telemetry', () => {
     expect(runToolsCommand).not.toHaveBeenCalled();
     expect(toolsCommandPayloads()).toEqual([
       expect.objectContaining({
-        command: 'docs list',
+        toolset: 'docs',
+        tool: 'list',
         success: false,
         outcome: 'intercept',
         interceptReason: 'invalid-arguments',

--- a/code/core/src/cli/tools/register.test.ts
+++ b/code/core/src/cli/tools/register.test.ts
@@ -133,20 +133,22 @@ describe('tools-command telemetry', () => {
 
   it('merges the handler report into the one tools-command record', async () => {
     const { program } = buildProgram();
-    vi.mocked(runToolsCommand).mockImplementation(async (_invocation, deps) => {
-      await deps?.methodTelemetry?.('tool:getChangedStories', {
-        client: 'cli',
-        requestedMode: 'auto',
-        resolvedMode: 'local',
+    vi.mocked(runToolsCommand).mockResolvedValue(
+      successResult({
         attachMode: 'local',
-        host: 'in-process',
-        storyCount: 4,
-        newStoryCount: 1,
-        modifiedStoryCount: 3,
-        affectedStoryCount: 0,
-      });
-      return successResult({ attachMode: 'local' });
-    });
+        report: {
+          toolset: 'stories',
+          tool: 'changed',
+          event: 'tool:getChangedStories',
+          counters: {
+            storyCount: 4,
+            newStoryCount: 1,
+            modifiedStoryCount: 3,
+            affectedStoryCount: 0,
+          },
+        },
+      })
+    );
     await parse(program, ['tools', 'stories', 'changed']);
 
     expect(toolsCommandPayloads()).toEqual([
@@ -170,24 +172,22 @@ describe('tools-command telemetry', () => {
     ]);
   });
 
-  it('keeps the handler report on the record when the run fails after it', async () => {
+  it('names the tool by its registered spelling, not by what the agent typed', async () => {
     const { program } = buildProgram();
-    const error = new Error('boom');
-    vi.mocked(runToolsCommand).mockImplementation(async (_invocation, deps) => {
-      await deps?.methodTelemetry?.('tool:getChangedStories', { storyCount: 4 });
-      return successResult({ exitCode: 1, outcome: { kind: 'error', error } });
-    });
-    await parse(program, ['tools', 'stories', 'changed']);
+    vi.mocked(runToolsCommand).mockResolvedValue(
+      successResult({
+        report: {
+          toolset: 'stories',
+          tool: 'find-by-component',
+          event: 'tool:getStoriesByComponent',
+          counters: { componentCount: 1 },
+        },
+      })
+    );
+    await parse(program, ['tools', 'stories', 'findByComponent']);
 
     expect(toolsCommandPayloads()).toEqual([
-      expect.objectContaining({
-        event: 'tool:getChangedStories',
-        toolset: 'stories',
-        tool: 'changed',
-        storyCount: 4,
-        success: false,
-        outcome: 'error',
-      }),
+      expect.objectContaining({ toolset: 'stories', tool: 'find-by-component', componentCount: 1 }),
     ]);
   });
 
@@ -383,8 +383,7 @@ describe('tools-command telemetry', () => {
     await parse(program, ['tools', '--port', '6006', 'docs', 'list']);
 
     expect(runToolsCommand).toHaveBeenCalledWith(
-      expect.objectContaining({ toolset: 'docs', tool: 'list', port: '6006' }),
-      expect.anything()
+      expect.objectContaining({ toolset: 'docs', tool: 'list', port: '6006' })
     );
   });
 

--- a/code/core/src/cli/tools/register.test.ts
+++ b/code/core/src/cli/tools/register.test.ts
@@ -140,7 +140,7 @@ describe('tools-command telemetry', () => {
           toolset: 'stories',
           tool: 'changed',
           event: 'tool:getChangedStories',
-          counters: {
+          payload: {
             storyCount: 4,
             newStoryCount: 1,
             modifiedStoryCount: 3,
@@ -180,7 +180,7 @@ describe('tools-command telemetry', () => {
           toolset: 'stories',
           tool: 'find-by-component',
           event: 'tool:getStoriesByComponent',
-          counters: { componentCount: 1 },
+          payload: { componentCount: 1 },
         },
       })
     );

--- a/code/core/src/cli/tools/register.ts
+++ b/code/core/src/cli/tools/register.ts
@@ -3,7 +3,6 @@ import { resolve } from 'node:path';
 
 import { sendTelemetryError, withTelemetry } from 'storybook/internal/core-server';
 import { logger } from 'storybook/internal/node-logger';
-import { telemetry } from 'storybook/internal/telemetry';
 import type { CLIOptions } from 'storybook/internal/types';
 
 import { Option, type Command } from 'commander';
@@ -11,6 +10,11 @@ import { Option, type Command } from 'commander';
 import type { ToolsetTelemetry } from '../../shared/open-service/toolset-definition.ts';
 import { resolveStorybookConfigDir } from './config-dir.ts';
 import { runToolsCommand, type ToolsRunResult } from './run.ts';
+import {
+  reportToolsCommandEvent,
+  sanitizeNamePart,
+  type MethodReport,
+} from './sdk/command-telemetry.ts';
 import { isJsonToolsRun, TOOLS_OPTION_SPECS, type ToolsOutputFlags } from './tool-tokens.ts';
 
 /** `handleCommandFailure` from `bin/core.ts`, passed in to avoid an import cycle. */
@@ -116,6 +120,10 @@ export function registerToolsPassthrough(
               // keep-alive the loop can drain mid-await and Node exits silently with code 0.
               const keepAlive = setInterval(() => {}, 60_000);
               const start = Date.now();
+              let report: MethodReport | undefined;
+              const methodTelemetry: ToolsetTelemetry = async (event, payload) => {
+                report = { event, payload };
+              };
               let result: ToolsRunResult;
               try {
                 if (options.attach && options.noAttach) {
@@ -137,7 +145,7 @@ export function registerToolsPassthrough(
                       attach: options.noAttach ? false : options.attach,
                       flags,
                     },
-                    { methodTelemetry: createMethodTelemetrySink(cliOptions) }
+                    { methodTelemetry }
                   );
                 }
               } finally {
@@ -150,7 +158,10 @@ export function registerToolsPassthrough(
                 // The tool has executed either way, so a failed `--output` write must not lose the
                 // event. Reporting after printing keeps a slow telemetry endpoint from ever
                 // delaying the user's result.
-                await reportToolsCommandTelemetry(toolset, tool, result, duration, cliOptions);
+                await reportToolsCommandTelemetry(
+                  { toolset, tool, result, duration, report },
+                  cliOptions
+                );
               }
             }
           ).catch(handleCommandFailure(options.logfile));
@@ -184,57 +195,31 @@ function pickCliOptions(options: ToolsPassthroughOptions): CLIOptions {
 }
 
 /**
- * The per-method toolset telemetry sink. Events pass through `telemetry()`, which honors the
- * resolved opt-out state, so the sink itself never has to know whether telemetry is enabled. They
- * report under the same `tools-command` event as the per-invocation record, distinguished by the
- * `event` field the method supplies (mirroring how MCP method events report under `addon-mcp`).
- */
-function createMethodTelemetrySink(cliOptions: CLIOptions): ToolsetTelemetry {
-  return async (event, payload) => {
-    try {
-      await telemetry('tools-command', { event, ...payload }, { configDir: cliOptions.configDir });
-    } catch (error) {
-      logger.debug(`Error collecting telemetry: ${String(error)}`);
-    }
-  };
-}
-
-/**
- * Tool and toolset names are a fixed, project-defined vocabulary of short identifiers. Anything
- * else is arbitrary agent input (a typo'd path, a stray flag value) that must not be sent
- * verbatim, so it is collapsed to a placeholder. The intercept reason still tells the failure
- * class apart.
- */
-function sanitizeNamePart(part: string): string {
-  return /^[\w-]{1,64}$/.test(part) ? part : '(invalid)';
-}
-
-/**
  * Fire the `tools-command` event, once per executed tool, modeled on the `ai-command` event
- * (storybookjs/storybook#35131). Help lookups are excluded so they cannot skew success rates.
- * Unexpected failures additionally go through the standard sanitized error path; `failure`
- * outcomes (the tool ran and reported bad news) do not.
+ * (storybookjs/storybook#35131). The handler's own report, collected during the run, is merged
+ * into the same record. Help lookups are excluded so they cannot skew success rates. Unexpected
+ * failures additionally go through the standard sanitized error path; `failure` outcomes (the
+ * tool ran and reported bad news) do not.
  */
 async function reportToolsCommandTelemetry(
-  toolset: string | undefined,
-  tool: string | undefined,
-  result: ToolsRunResult,
-  duration: number,
+  run: {
+    toolset: string | undefined;
+    tool: string | undefined;
+    result: ToolsRunResult;
+    duration: number;
+    report: MethodReport | undefined;
+  },
   cliOptions: CLIOptions
 ): Promise<void> {
+  const { toolset, tool, result, duration, report } = run;
   const { outcome } = result;
   if (outcome.kind === 'help') {
     return;
   }
-  const command =
-    [toolset, tool]
-      .filter((part): part is string => part !== undefined)
-      .map(sanitizeNamePart)
-      .join(' ') || '(none)';
-  await telemetry(
-    'tools-command',
+  await reportToolsCommandEvent(
     {
-      command,
+      ...(toolset !== undefined ? { toolset: sanitizeNamePart(toolset) } : {}),
+      ...(tool !== undefined ? { tool: sanitizeNamePart(tool) } : {}),
       success: outcome.kind === 'success',
       outcome: outcome.kind,
       client: 'cli',
@@ -251,7 +236,7 @@ async function reportToolsCommandTelemetry(
       duration,
     },
     // Metadata must describe the target project, consistent with the opt-out resolution.
-    { configDir: cliOptions.configDir }
+    { report, configDir: cliOptions.configDir }
   );
   if (outcome.kind === 'error') {
     await sendTelemetryError(outcome.error, 'tools-command', { cliOptions });

--- a/code/core/src/cli/tools/register.ts
+++ b/code/core/src/cli/tools/register.ts
@@ -7,14 +7,9 @@ import type { CLIOptions } from 'storybook/internal/types';
 
 import { Option, type Command } from 'commander';
 
-import type { ToolsetTelemetry } from '../../shared/open-service/toolset-definition.ts';
 import { resolveStorybookConfigDir } from './config-dir.ts';
 import { runToolsCommand, type ToolsRunResult } from './run.ts';
-import {
-  reportToolsCommandEvent,
-  sanitizeNamePart,
-  type MethodReport,
-} from './sdk/command-telemetry.ts';
+import { reportToolsCommandEvent, sanitizeNamePart } from './sdk/command-telemetry.ts';
 import { isJsonToolsRun, TOOLS_OPTION_SPECS, type ToolsOutputFlags } from './tool-tokens.ts';
 
 /** `handleCommandFailure` from `bin/core.ts`, passed in to avoid an import cycle. */
@@ -120,10 +115,6 @@ export function registerToolsPassthrough(
               // keep-alive the loop can drain mid-await and Node exits silently with code 0.
               const keepAlive = setInterval(() => {}, 60_000);
               const start = Date.now();
-              let report: MethodReport | undefined;
-              const methodTelemetry: ToolsetTelemetry = async (event, payload) => {
-                report = { event, payload };
-              };
               let result: ToolsRunResult;
               try {
                 if (options.attach && options.noAttach) {
@@ -135,18 +126,15 @@ export function registerToolsPassthrough(
                     attachMode: 'auto',
                   };
                 } else {
-                  result = await runToolsCommand(
-                    {
-                      toolset,
-                      tool,
-                      tokens,
-                      target: { cwd: options.cwd, configDir: options.configDir },
-                      port: options.port,
-                      attach: options.noAttach ? false : options.attach,
-                      flags,
-                    },
-                    { methodTelemetry }
-                  );
+                  result = await runToolsCommand({
+                    toolset,
+                    tool,
+                    tokens,
+                    target: { cwd: options.cwd, configDir: options.configDir },
+                    port: options.port,
+                    attach: options.noAttach ? false : options.attach,
+                    flags,
+                  });
                 }
               } finally {
                 clearInterval(keepAlive);
@@ -158,10 +146,7 @@ export function registerToolsPassthrough(
                 // The tool has executed either way, so a failed `--output` write must not lose the
                 // event. Reporting after printing keeps a slow telemetry endpoint from ever
                 // delaying the user's result.
-                await reportToolsCommandTelemetry(
-                  { toolset, tool, result, duration, report },
-                  cliOptions
-                );
+                await reportToolsCommandTelemetry({ toolset, tool, result, duration }, cliOptions);
               }
             }
           ).catch(handleCommandFailure(options.logfile));
@@ -196,7 +181,7 @@ function pickCliOptions(options: ToolsPassthroughOptions): CLIOptions {
 
 /**
  * Fire the `tools-command` event, once per executed tool, modeled on the `ai-command` event
- * (storybookjs/storybook#35131). The handler's own report, collected during the run, is merged
+ * (storybookjs/storybook#35131). The handler's own report, returned on its outcome, is merged
  * into the same record. Help lookups are excluded so they cannot skew success rates. Unexpected
  * failures additionally go through the standard sanitized error path; `failure` outcomes (the
  * tool ran and reported bad news) do not.
@@ -207,11 +192,10 @@ async function reportToolsCommandTelemetry(
     tool: string | undefined;
     result: ToolsRunResult;
     duration: number;
-    report: MethodReport | undefined;
   },
   cliOptions: CLIOptions
 ): Promise<void> {
-  const { toolset, tool, result, duration, report } = run;
+  const { toolset, tool, result, duration } = run;
   const { outcome } = result;
   if (outcome.kind === 'help') {
     return;
@@ -236,7 +220,7 @@ async function reportToolsCommandTelemetry(
       duration,
     },
     // Metadata must describe the target project, consistent with the opt-out resolution.
-    { report, configDir: cliOptions.configDir }
+    { report: result.report, configDir: cliOptions.configDir }
   );
   if (outcome.kind === 'error') {
     await sendTelemetryError(outcome.error, 'tools-command', { cliOptions });

--- a/code/core/src/cli/tools/run.test.ts
+++ b/code/core/src/cli/tools/run.test.ts
@@ -779,7 +779,7 @@ describe('usage report', () => {
     expect(result.report).toEqual({
       toolset: 'docs',
       tool: 'list',
-      event: 'tool:listAllDocumentation',
+      event: 'tool:docs_list',
       payload: expect.objectContaining({ componentCount: expect.any(Number) }),
     });
   });
@@ -789,9 +789,7 @@ describe('usage report', () => {
 
     const result = await run(['docs', 'list'], deps, { attach: true });
 
-    expect(result.report).toEqual(
-      expect.objectContaining({ toolset: 'docs', tool: 'list', event: 'tool:listAllDocumentation' })
-    );
+    expect(result.report).toEqual(expect.objectContaining({ toolset: 'docs', tool: 'list' }));
   });
 });
 

--- a/code/core/src/cli/tools/run.test.ts
+++ b/code/core/src/cli/tools/run.test.ts
@@ -21,6 +21,7 @@ import {
 import type { DocsAccess } from '../../shared/open-service/toolsets/docs/access.ts';
 import type { StorybookInstanceRecord } from './instances/types.ts';
 import { runToolsCommand, type ToolsInvocation, type ToolsRunDeps } from './run.ts';
+import { invokeToolsetMethod } from '../../shared/open-service/toolset-definition.ts';
 import { parseToolsetMethodId } from '../../shared/open-service/toolset-names.ts';
 import { toCatalogEntry } from './sdk/catalog.ts';
 import {
@@ -127,10 +128,9 @@ function makeLocalTools(runtimeOverrides: Partial<ToolsRuntime> = {}): LocalTool
           issues: validation.issues,
         });
       }
-      return method.handler(validation.value, {
+      return invokeToolsetMethod(toolset, methodName, validation.value, {
         ...ctx,
         ...(options.origin ? { origin: options.origin } : {}),
-        ...(options.telemetry ? { telemetry: options.telemetry } : {}),
       });
     },
     close: async () => {},
@@ -178,7 +178,6 @@ function makeAttachedTools(runtimeOverrides: Partial<ToolsRuntime> = {}): Attach
       const callCtx: ToolsetCtx = {
         ...ctx,
         ...(options?.origin !== undefined ? { origin: options.origin } : {}),
-        ...(options?.telemetry ? { telemetry: options.telemetry } : {}),
       };
       const { toolsetId, methodName } = parseToolsetMethodId(ref);
       const toolset = local.runtime.toolsets.find((candidate) => candidate.id === toolsetId);
@@ -194,7 +193,7 @@ function makeAttachedTools(runtimeOverrides: Partial<ToolsRuntime> = {}): Attach
           issues: validation.issues,
         });
       }
-      return method.handler(validation.value, callCtx);
+      return invokeToolsetMethod(toolset, methodName, validation.value, callCtx);
     },
   };
 }
@@ -216,10 +215,9 @@ describe('local tools', () => {
 
     // Parity claim: the CLI must print byte-for-byte what MCP clients receive. The MCP adapter
     // itself lives in addon-mcp (core tests cannot reach it); its own suite asserts it renders
-    // handler markdown verbatim as text blocks, so comparing against the handler's markdown under
-    // an MCP context is the same contract expressed from this side of the package boundary.
-    const mcpCtx: ToolsetCtx = { transport: 'mcp', getService: () => ({}) as never };
-    const mcpOutcome = await getToolset('docs').methods.list.handler({}, mcpCtx);
+    // handler markdown verbatim as text blocks, so comparing against the handler's markdown is
+    // the same contract expressed from this side of the package boundary.
+    const mcpOutcome = await getToolset('docs').methods.list.handler({});
     expect(result.exitCode).toBe(0);
     expect(result.outcome).toEqual({ kind: 'success' });
     expect(result.output).toContain('Button');
@@ -772,31 +770,27 @@ describe('outcome mapping', () => {
   });
 });
 
-describe('telemetry sink', () => {
-  it('forwards per-method events with the handler’s counters', async () => {
-    const methodTelemetry = vi.fn(async () => {});
-    const { deps } = makeDeps({ methodTelemetry });
+describe('usage report', () => {
+  it('carries the handler report out of a local run', async () => {
+    const { deps } = makeDeps();
 
-    await run(['docs', 'list'], deps);
+    const result = await run(['docs', 'list'], deps);
 
-    expect(methodTelemetry).toHaveBeenCalledWith(
-      'tool:listAllDocumentation',
-      expect.objectContaining({ componentCount: expect.any(Number) })
-    );
+    expect(result.report).toEqual({
+      toolset: 'docs',
+      tool: 'list',
+      event: 'tool:listAllDocumentation',
+      counters: expect.objectContaining({ componentCount: expect.any(Number) }),
+    });
   });
 
-  it('forwards per-method events on attached dispatch', async () => {
-    const methodTelemetry = vi.fn(async () => {});
-    const { deps } = makeDeps({
-      methodTelemetry,
-      createTools: vi.fn(async () => makeAttachedTools()),
-    });
+  it('carries the handler report out of an attached run', async () => {
+    const { deps } = makeDeps({ createTools: vi.fn(async () => makeAttachedTools()) });
 
-    await run(['docs', 'list'], deps, { attach: true });
+    const result = await run(['docs', 'list'], deps, { attach: true });
 
-    expect(methodTelemetry).toHaveBeenCalledWith(
-      'tool:listAllDocumentation',
-      expect.objectContaining({ componentCount: expect.any(Number) })
+    expect(result.report).toEqual(
+      expect.objectContaining({ toolset: 'docs', tool: 'list', event: 'tool:listAllDocumentation' })
     );
   });
 });

--- a/code/core/src/cli/tools/run.test.ts
+++ b/code/core/src/cli/tools/run.test.ts
@@ -226,26 +226,6 @@ describe('local tools', () => {
     expect(result.output).toBe(mcpOutcome.markdown);
   });
 
-  it('stamps tools-command dimensions onto per-method telemetry for a local host', async () => {
-    const methodTelemetry = vi.fn(async () => {});
-    const { deps } = makeDeps({ methodTelemetry });
-
-    const result = await run(['docs', 'list'], deps);
-
-    expect(result.outcome).toEqual({ kind: 'success' });
-    expect(methodTelemetry).toHaveBeenCalledWith(
-      'tool:listAllDocumentation',
-      expect.objectContaining({
-        toolset: 'docs',
-        client: 'cli',
-        requestedMode: 'local',
-        resolvedMode: 'local',
-        attachMode: 'local',
-        host: 'in-process',
-      })
-    );
-  });
-
   it('round-trips the show-story --storyId flag through token parsing to the handler', async () => {
     const { deps } = makeDeps();
 
@@ -793,7 +773,7 @@ describe('outcome mapping', () => {
 });
 
 describe('telemetry sink', () => {
-  it('forwards per-method events with the toolset’s telemetry group', async () => {
+  it('forwards per-method events with the handler’s counters', async () => {
     const methodTelemetry = vi.fn(async () => {});
     const { deps } = makeDeps({ methodTelemetry });
 
@@ -801,7 +781,7 @@ describe('telemetry sink', () => {
 
     expect(methodTelemetry).toHaveBeenCalledWith(
       'tool:listAllDocumentation',
-      expect.objectContaining({ toolset: 'docs' })
+      expect.objectContaining({ componentCount: expect.any(Number) })
     );
   });
 
@@ -816,7 +796,7 @@ describe('telemetry sink', () => {
 
     expect(methodTelemetry).toHaveBeenCalledWith(
       'tool:listAllDocumentation',
-      expect.objectContaining({ toolset: 'docs' })
+      expect.objectContaining({ componentCount: expect.any(Number) })
     );
   });
 });

--- a/code/core/src/cli/tools/run.test.ts
+++ b/code/core/src/cli/tools/run.test.ts
@@ -780,7 +780,7 @@ describe('usage report', () => {
       toolset: 'docs',
       tool: 'list',
       event: 'tool:listAllDocumentation',
-      counters: expect.objectContaining({ componentCount: expect.any(Number) }),
+      payload: expect.objectContaining({ componentCount: expect.any(Number) }),
     });
   });
 

--- a/code/core/src/cli/tools/run.ts
+++ b/code/core/src/cli/tools/run.ts
@@ -8,8 +8,6 @@ import {
   createTools,
   formatMultiInstanceNotice,
   isAttachGateError,
-  toolsCommandDimensions,
-  wrapMethodTelemetry,
   ToolsRuntimeError,
   type CreateToolsDeps,
   type CreateToolsOptions,
@@ -107,7 +105,7 @@ const CLI_CLIENT_INFO: ToolsClientInfo = {
 export type ToolsRunDeps = {
   createTools?: (options?: CreateToolsOptions, deps?: CreateToolsDeps) => Promise<Tools>;
   discoverInstance?: typeof discoverRunningInstance;
-  /** Sink for the per-method toolset telemetry events; absent when telemetry is disabled. */
+  /** Receives the handler's usage report for the run; absent when telemetry is disabled. */
   methodTelemetry?: ToolsetTelemetry;
 };
 
@@ -231,25 +229,11 @@ export async function runToolsCommand(
   }
 
   try {
-    const methodTelemetry =
-      tools.mode === 'local' && deps.methodTelemetry
-        ? wrapMethodTelemetry(
-            deps.methodTelemetry,
-            toolsCommandDimensions({
-              clientInfo: tools.clientInfo,
-              requestedMode: tools.requestedMode,
-              resolvedMode: tools.mode,
-              host: tools.host,
-              fallbackReason: tools.fallbackReason,
-            })
-          )
-        : deps.methodTelemetry;
-    const dispatchDeps: ToolsRunDeps = { ...deps, methodTelemetry };
     const dispatched = await dispatchTools(
       tools,
       { ...normalized, target },
       parsed,
-      dispatchDeps,
+      deps,
       requestedMode,
       result
     );

--- a/code/core/src/cli/tools/run.ts
+++ b/code/core/src/cli/tools/run.ts
@@ -1,6 +1,6 @@
 import { versions } from 'storybook/internal/common';
 
-import type { ToolsetTelemetry } from '../../shared/open-service/toolset-definition.ts';
+import type { ToolsetMethodReport } from '../../shared/open-service/toolset-definition.ts';
 import { parseToolsetMethodId, toCliMethodName } from '../../shared/open-service/toolset-names.ts';
 import type { StorybookInstanceRecord } from './instances/types.ts';
 import {
@@ -78,6 +78,8 @@ export type ToolsRunResult = {
   multiInstanceNotice?: string;
   /** True when the attached host chose among several matching instances; drives telemetry. */
   multipleMatches?: boolean;
+  /** The handler's usage report, from the outcome of a run that reached the handler. */
+  report?: ToolsetMethodReport;
 };
 
 export type ToolsInvocation = {
@@ -105,8 +107,6 @@ const CLI_CLIENT_INFO: ToolsClientInfo = {
 export type ToolsRunDeps = {
   createTools?: (options?: CreateToolsOptions, deps?: CreateToolsDeps) => Promise<Tools>;
   discoverInstance?: typeof discoverRunningInstance;
-  /** Receives the handler's usage report for the run; absent when telemetry is disabled. */
-  methodTelemetry?: ToolsetTelemetry;
 };
 
 /** `find-by-component` -> `findByComponent`, accepting an already-camelCase spelling unchanged. */
@@ -338,7 +338,6 @@ async function dispatchTools(
   try {
     const outcome = await tools.call(method.ref, parsed.args, {
       ...(tools.storybook.url ? { origin: tools.storybook.url } : {}),
-      ...(deps.methodTelemetry ? { telemetry: deps.methodTelemetry } : {}),
     });
     const output = parsed.json
       ? JSON.stringify(outcome.data, null, 2)
@@ -347,6 +346,7 @@ async function dispatchTools(
       exitCode: outcome.ok ? 0 : 1,
       output,
       outcome: { kind: outcome.ok ? 'success' : 'failure' },
+      ...(outcome.telemetry ? { report: outcome.telemetry } : {}),
     });
   } catch (error) {
     if (isInvalidInputError(error)) {

--- a/code/core/src/cli/tools/sdk/child-client.test.ts
+++ b/code/core/src/cli/tools/sdk/child-client.test.ts
@@ -261,7 +261,7 @@ describe('spawnChildHost', () => {
     const report = {
       toolset: 'docs',
       tool: 'list',
-      event: 'tool:listAllDocumentation',
+      event: 'tool:docs_list',
       payload: { componentCount: 3 },
     };
     child.send.mockImplementation((message: { type: string; id?: string }) => {
@@ -294,7 +294,7 @@ describe('spawnChildHost', () => {
         {
           toolset: 'docs',
           tool: 'list',
-          event: 'tool:listAllDocumentation',
+          event: 'tool:docs_list',
           componentCount: 3,
           success: true,
           outcome: 'success',
@@ -346,7 +346,7 @@ describe('spawnChildHost', () => {
         expect.anything(),
       ],
     ]);
-    expect(vi.mocked(telemetry).mock.calls[0][1]).not.toHaveProperty('event');
+    expect(vi.mocked(telemetry).mock.calls[0][1]).not.toHaveProperty('componentCount');
   });
 
   it('sends a cancel envelope keyed by the call id when the signal aborts', async () => {

--- a/code/core/src/cli/tools/sdk/child-client.test.ts
+++ b/code/core/src/cli/tools/sdk/child-client.test.ts
@@ -268,7 +268,7 @@ describe('spawnChildHost', () => {
             type: 'telemetry',
             id: message.id,
             event: 'tool:listAllDocumentation',
-            payload: { toolset: 'docs' },
+            payload: { componentCount: 3 },
           });
           child.emit('message', {
             type: 'result',
@@ -288,29 +288,34 @@ describe('spawnChildHost', () => {
       markdown: 'ok',
     });
     expect(tools.requestedMode).toBe('auto');
-    expect(sink).toHaveBeenCalledWith(
-      'tool:listAllDocumentation',
-      expect.objectContaining({
-        toolset: 'docs',
-        client: 'sdk',
-        requestedMode: 'auto',
-        resolvedMode: 'attached',
-        attachMode: 'attached',
-        host: 'child',
-      })
-    );
-    expect(telemetry).toHaveBeenCalledWith(
-      'tools-command',
-      expect.objectContaining({
-        command: 'docs list',
-        success: true,
-        outcome: 'success',
-        client: 'sdk',
-        requestedMode: 'auto',
-        host: 'child',
-      }),
-      expect.anything()
-    );
+    expect(sink).toHaveBeenCalledWith('tool:listAllDocumentation', {
+      componentCount: 3,
+      client: 'sdk',
+      requestedMode: 'auto',
+      resolvedMode: 'attached',
+      attachMode: 'attached',
+      host: 'child',
+    });
+    expect(vi.mocked(telemetry).mock.calls).toEqual([
+      [
+        'tools-command',
+        {
+          toolset: 'docs',
+          tool: 'list',
+          event: 'tool:listAllDocumentation',
+          componentCount: 3,
+          success: true,
+          outcome: 'success',
+          client: 'sdk',
+          requestedMode: 'auto',
+          resolvedMode: 'attached',
+          attachMode: 'attached',
+          host: 'child',
+          duration: expect.any(Number),
+        },
+        expect.anything(),
+      ],
+    ]);
   });
 
   it('does not reject the call when a forwarded telemetry sink fails', async () => {
@@ -324,7 +329,7 @@ describe('spawnChildHost', () => {
             type: 'telemetry',
             id: message.id,
             event: 'tool:listAllDocumentation',
-            payload: { toolset: 'docs' },
+            payload: { componentCount: 3 },
           });
           child.emit('message', {
             type: 'result',
@@ -358,7 +363,7 @@ describe('spawnChildHost', () => {
             type: 'telemetry',
             id: message.id,
             event: 'tool:listAllDocumentation',
-            payload: { toolset: 'docs' },
+            payload: { componentCount: 3 },
           });
           child.emit('message', {
             type: 'result',
@@ -382,7 +387,7 @@ describe('spawnChildHost', () => {
     expect(sink).toHaveBeenCalledWith(
       'tool:listAllDocumentation',
       expect.objectContaining({
-        toolset: 'docs',
+        componentCount: 3,
         client: 'sdk',
         requestedMode: 'attached',
         resolvedMode: 'attached',

--- a/code/core/src/cli/tools/sdk/child-client.test.ts
+++ b/code/core/src/cli/tools/sdk/child-client.test.ts
@@ -310,6 +310,45 @@ describe('spawnChildHost', () => {
     ]);
   });
 
+  it('ignores the telemetry envelope an older child host sends before its result', async () => {
+    child.send.mockImplementation((message: { type: string; id?: string }) => {
+      if (message.type === 'init') {
+        queueMicrotask(() => child.emit('message', HELLO));
+      }
+      if (message.type === 'call') {
+        queueMicrotask(() => {
+          child.emit('message', {
+            type: 'telemetry',
+            id: message.id,
+            event: 'tool:listAllDocumentation',
+            payload: { componentCount: 3 },
+          });
+          child.emit('message', {
+            type: 'result',
+            id: message.id,
+            value: { ok: true, data: { ran: true }, markdown: 'ok' },
+          });
+        });
+      }
+      return true;
+    });
+    const tools = await spawn();
+
+    await expect(tools.call('docs.list', {})).resolves.toEqual({
+      ok: true,
+      data: { ran: true },
+      markdown: 'ok',
+    });
+    expect(vi.mocked(telemetry).mock.calls).toEqual([
+      [
+        'tools-command',
+        expect.objectContaining({ toolset: 'docs', tool: 'list', success: true }),
+        expect.anything(),
+      ],
+    ]);
+    expect(vi.mocked(telemetry).mock.calls[0][1]).not.toHaveProperty('event');
+  });
+
   it('sends a cancel envelope keyed by the call id when the signal aborts', async () => {
     child.send.mockImplementation((message: { type: string; id?: string }) => {
       if (message.type === 'init') {

--- a/code/core/src/cli/tools/sdk/child-client.test.ts
+++ b/code/core/src/cli/tools/sdk/child-client.test.ts
@@ -262,7 +262,7 @@ describe('spawnChildHost', () => {
       toolset: 'docs',
       tool: 'list',
       event: 'tool:listAllDocumentation',
-      counters: { componentCount: 3 },
+      payload: { componentCount: 3 },
     };
     child.send.mockImplementation((message: { type: string; id?: string }) => {
       if (message.type === 'init') {

--- a/code/core/src/cli/tools/sdk/child-client.test.ts
+++ b/code/core/src/cli/tools/sdk/child-client.test.ts
@@ -257,45 +257,37 @@ describe('spawnChildHost', () => {
     );
   });
 
-  it('forwards child method telemetry to the call sink without resolving the waiter', async () => {
+  it('reports the invocation from the report the child outcome carries', async () => {
+    const report = {
+      toolset: 'docs',
+      tool: 'list',
+      event: 'tool:listAllDocumentation',
+      counters: { componentCount: 3 },
+    };
     child.send.mockImplementation((message: { type: string; id?: string }) => {
       if (message.type === 'init') {
         queueMicrotask(() => child.emit('message', HELLO));
       }
       if (message.type === 'call') {
-        queueMicrotask(() => {
-          child.emit('message', {
-            type: 'telemetry',
-            id: message.id,
-            event: 'tool:listAllDocumentation',
-            payload: { componentCount: 3 },
-          });
+        queueMicrotask(() =>
           child.emit('message', {
             type: 'result',
             id: message.id,
-            value: { ok: true, data: { ran: true }, markdown: 'ok' },
-          });
-        });
+            value: { ok: true, data: { ran: true }, markdown: 'ok', telemetry: report },
+          })
+        );
       }
       return true;
     });
-    const sink = vi.fn(async () => {});
     const tools = await spawn(OPTIONS, 'auto');
 
-    await expect(tools.call('docs.list', {}, { telemetry: sink })).resolves.toEqual({
+    await expect(tools.call('docs.list', {})).resolves.toEqual({
       ok: true,
       data: { ran: true },
       markdown: 'ok',
+      telemetry: report,
     });
     expect(tools.requestedMode).toBe('auto');
-    expect(sink).toHaveBeenCalledWith('tool:listAllDocumentation', {
-      componentCount: 3,
-      client: 'sdk',
-      requestedMode: 'auto',
-      resolvedMode: 'attached',
-      attachMode: 'attached',
-      host: 'child',
-    });
     expect(vi.mocked(telemetry).mock.calls).toEqual([
       [
         'tools-command',
@@ -316,85 +308,6 @@ describe('spawnChildHost', () => {
         expect.anything(),
       ],
     ]);
-  });
-
-  it('does not reject the call when a forwarded telemetry sink fails', async () => {
-    child.send.mockImplementation((message: { type: string; id?: string }) => {
-      if (message.type === 'init') {
-        queueMicrotask(() => child.emit('message', HELLO));
-      }
-      if (message.type === 'call') {
-        queueMicrotask(() => {
-          child.emit('message', {
-            type: 'telemetry',
-            id: message.id,
-            event: 'tool:listAllDocumentation',
-            payload: { componentCount: 3 },
-          });
-          child.emit('message', {
-            type: 'result',
-            id: message.id,
-            value: { ok: true, data: { ran: true }, markdown: 'ok' },
-          });
-        });
-      }
-      return true;
-    });
-    const sink = vi.fn(async () => {
-      throw new Error('telemetry down');
-    });
-    const tools = await spawn();
-
-    await expect(tools.call('docs.list', {}, { telemetry: sink })).resolves.toEqual({
-      ok: true,
-      data: { ran: true },
-      markdown: 'ok',
-    });
-  });
-
-  it('does not reject the call when a forwarded telemetry sink throws synchronously', async () => {
-    child.send.mockImplementation((message: { type: string; id?: string }) => {
-      if (message.type === 'init') {
-        queueMicrotask(() => child.emit('message', HELLO));
-      }
-      if (message.type === 'call') {
-        queueMicrotask(() => {
-          child.emit('message', {
-            type: 'telemetry',
-            id: message.id,
-            event: 'tool:listAllDocumentation',
-            payload: { componentCount: 3 },
-          });
-          child.emit('message', {
-            type: 'result',
-            id: message.id,
-            value: { ok: true, data: { ran: true }, markdown: 'ok' },
-          });
-        });
-      }
-      return true;
-    });
-    const sink = vi.fn(() => {
-      throw new Error('telemetry down');
-    });
-    const tools = await spawn();
-
-    await expect(tools.call('docs.list', {}, { telemetry: sink })).resolves.toEqual({
-      ok: true,
-      data: { ran: true },
-      markdown: 'ok',
-    });
-    expect(sink).toHaveBeenCalledWith(
-      'tool:listAllDocumentation',
-      expect.objectContaining({
-        componentCount: 3,
-        client: 'sdk',
-        requestedMode: 'attached',
-        resolvedMode: 'attached',
-        attachMode: 'attached',
-        host: 'child',
-      })
-    );
   });
 
   it('sends a cancel envelope keyed by the call id when the signal aborts', async () => {

--- a/code/core/src/cli/tools/sdk/child-client.ts
+++ b/code/core/src/cli/tools/sdk/child-client.ts
@@ -6,21 +6,14 @@ import {
   deserializeError,
   type SerializedError,
 } from '../../../shared/open-service/service-error-serialization.ts';
-import type {
-  AnyToolsetOutcome,
-  ToolsetTelemetry,
-} from '../../../shared/open-service/toolset-definition.ts';
+import type { InvokedToolsetOutcome } from '../../../shared/open-service/toolset-definition.ts';
 import {
   CHILD_HOST_PROTOCOL_VERSION,
   isChildMessage,
   type ChildHelloMessage,
   type ParentMessage,
 } from './child-protocol.ts';
-import {
-  reportSdkInvocation,
-  resolveCallTelemetry,
-  toolsCommandDimensions,
-} from './command-telemetry.ts';
+import { reportSdkInvocation } from './command-telemetry.ts';
 import {
   AttachUnavailableError,
   EnvironmentMismatchError,
@@ -140,7 +133,6 @@ export async function spawnChildHost(
     string,
     { resolve: (value: unknown) => void; reject: (error: unknown) => void }
   >();
-  const pendingTelemetry = new Map<string, ToolsetTelemetry>();
   let closed = false;
   let nextId = 0;
 
@@ -181,14 +173,6 @@ export async function spawnChildHost(
 
   child.on('message', (raw: unknown) => {
     if (!isChildMessage(raw) || raw.type === 'hello') {
-      return;
-    }
-    if (raw.type === 'telemetry') {
-      void Promise.resolve()
-        .then(() => pendingTelemetry.get(raw.id)?.(raw.event, raw.payload))
-        .catch(() => {
-          // Method telemetry is never part of the call result.
-        });
       return;
     }
     const waiter = pending.get(raw.id);
@@ -273,13 +257,6 @@ export async function spawnChildHost(
     }
   };
 
-  const dimensions = toolsCommandDimensions({
-    clientInfo: args.clientInfo,
-    requestedMode: args.requestedMode,
-    resolvedMode,
-    host: 'child',
-  });
-
   return {
     mode: resolvedMode,
     host: 'child',
@@ -295,14 +272,10 @@ export async function spawnChildHost(
       ref: string,
       input: Record<string, unknown> = {},
       options: ToolsCallOptions = {}
-    ): Promise<AnyToolsetOutcome> {
+    ): Promise<InvokedToolsetOutcome> {
       assertOpen();
       options.signal?.throwIfAborted();
       const id = String(++nextId);
-      const telemetry = resolveCallTelemetry(options, dimensions);
-      if (telemetry.sink) {
-        pendingTelemetry.set(id, telemetry.sink);
-      }
       let onAbort: (() => void) | undefined;
       const aborted = options.signal
         ? new Promise<never>((_, reject) => {
@@ -322,7 +295,7 @@ export async function spawnChildHost(
         const work = request({ type: 'call', id, ref, input });
         const outcome = (await (aborted
           ? Promise.race([work, aborted])
-          : work)) as AnyToolsetOutcome;
+          : work)) as InvokedToolsetOutcome;
         await reportSdkInvocation({
           ref,
           clientInfo: args.clientInfo,
@@ -330,7 +303,7 @@ export async function spawnChildHost(
           resolvedMode,
           host: 'child',
           result: outcome,
-          report: telemetry.report(),
+          report: outcome.telemetry,
           duration: Date.now() - start,
           configDir: hello.storybook.configDir,
         });
@@ -343,13 +316,11 @@ export async function spawnChildHost(
           resolvedMode,
           host: 'child',
           result: { error },
-          report: telemetry.report(),
           duration: Date.now() - start,
           configDir: hello.storybook.configDir,
         });
         throw error;
       } finally {
-        pendingTelemetry.delete(id);
         if (onAbort) {
           options.signal?.removeEventListener('abort', onAbort);
         }

--- a/code/core/src/cli/tools/sdk/child-client.ts
+++ b/code/core/src/cli/tools/sdk/child-client.ts
@@ -172,7 +172,10 @@ export async function spawnChildHost(
   void disconnected.catch(() => {});
 
   child.on('message', (raw: unknown) => {
-    if (!isChildMessage(raw) || raw.type === 'hello') {
+    // Only a result or an error settles a call. A child host from an older Storybook still sends a
+    // per-call `telemetry` envelope first; treating it as the reply would reject the call and drop
+    // the result that follows.
+    if (!isChildMessage(raw) || (raw.type !== 'result' && raw.type !== 'error')) {
       return;
     }
     const waiter = pending.get(raw.id);

--- a/code/core/src/cli/tools/sdk/child-client.ts
+++ b/code/core/src/cli/tools/sdk/child-client.ts
@@ -299,12 +299,9 @@ export async function spawnChildHost(
       assertOpen();
       options.signal?.throwIfAborted();
       const id = String(++nextId);
-      const telemetry = resolveCallTelemetry(options, dimensions, {
-        clientInfo: args.clientInfo,
-        configDir: hello.storybook.configDir,
-      });
-      if (telemetry) {
-        pendingTelemetry.set(id, telemetry);
+      const telemetry = resolveCallTelemetry(options, dimensions);
+      if (telemetry.sink) {
+        pendingTelemetry.set(id, telemetry.sink);
       }
       let onAbort: (() => void) | undefined;
       const aborted = options.signal
@@ -333,6 +330,7 @@ export async function spawnChildHost(
           resolvedMode,
           host: 'child',
           result: outcome,
+          report: telemetry.report(),
           duration: Date.now() - start,
           configDir: hello.storybook.configDir,
         });
@@ -345,6 +343,7 @@ export async function spawnChildHost(
           resolvedMode,
           host: 'child',
           result: { error },
+          report: telemetry.report(),
           duration: Date.now() - start,
           configDir: hello.storybook.configDir,
         });

--- a/code/core/src/cli/tools/sdk/child-host.test.ts
+++ b/code/core/src/cli/tools/sdk/child-host.test.ts
@@ -17,10 +17,7 @@ describe('runChildHost', () => {
     async (
       _ref: string,
       _input?: Record<string, unknown>,
-      options?: {
-        signal?: AbortSignal;
-        telemetry?: (event: string, payload: Record<string, unknown>) => Promise<void>;
-      }
+      options?: { signal?: AbortSignal }
     ): Promise<AnyToolsetOutcome> => {
       if (options?.signal?.aborted) {
         throw new Error('aborted');
@@ -169,11 +166,14 @@ describe('runChildHost', () => {
     exit.mockRestore();
   });
 
-  it('forwards method telemetry over IPC keyed by the call id', async () => {
-    call.mockImplementation(async (_ref, _input, options) => {
-      await options?.telemetry?.('tool:listAllDocumentation', { toolset: 'docs' });
-      return { ok: true, data: { ran: true }, markdown: 'ok' };
-    });
+  it('sends the outcome, report included, as the call result', async () => {
+    const outcome = {
+      ok: true as const,
+      data: { ran: true },
+      markdown: 'ok',
+      telemetry: { event: 'tool:listAllDocumentation', counters: { componentCount: 3 } },
+    };
+    call.mockResolvedValue(outcome);
     await runChildHost({
       send,
       subscribe: (handler) => {
@@ -186,15 +186,7 @@ describe('runChildHost', () => {
 
     handlers[0]({ type: 'call', id: 'call-7', ref: 'docs.list', input: {} });
     await vi.waitFor(() =>
-      expect(send).toHaveBeenCalledWith({
-        type: 'telemetry',
-        id: 'call-7',
-        event: 'tool:listAllDocumentation',
-        payload: { toolset: 'docs' },
-      })
-    );
-    await vi.waitFor(() =>
-      expect(send).toHaveBeenCalledWith(expect.objectContaining({ type: 'result', id: 'call-7' }))
+      expect(send).toHaveBeenCalledWith({ type: 'result', id: 'call-7', value: outcome })
     );
   });
 

--- a/code/core/src/cli/tools/sdk/child-host.test.ts
+++ b/code/core/src/cli/tools/sdk/child-host.test.ts
@@ -171,7 +171,7 @@ describe('runChildHost', () => {
       ok: true as const,
       data: { ran: true },
       markdown: 'ok',
-      telemetry: { event: 'tool:listAllDocumentation', counters: { componentCount: 3 } },
+      telemetry: { event: 'tool:listAllDocumentation', payload: { componentCount: 3 } },
     };
     call.mockResolvedValue(outcome);
     await runChildHost({

--- a/code/core/src/cli/tools/sdk/child-host.test.ts
+++ b/code/core/src/cli/tools/sdk/child-host.test.ts
@@ -171,7 +171,7 @@ describe('runChildHost', () => {
       ok: true as const,
       data: { ran: true },
       markdown: 'ok',
-      telemetry: { event: 'tool:listAllDocumentation', payload: { componentCount: 3 } },
+      telemetry: { payload: { componentCount: 3 } },
     };
     call.mockResolvedValue(outcome);
     await runChildHost({

--- a/code/core/src/cli/tools/sdk/child-host.ts
+++ b/code/core/src/cli/tools/sdk/child-host.ts
@@ -59,12 +59,7 @@ export async function runChildHost({
         controllers.set(message.id, controller);
         try {
           await reply(message.id, tools, () =>
-            tools!.call(message.ref, message.input, {
-              signal: controller.signal,
-              telemetry: async (event, payload) => {
-                send({ type: 'telemetry', id: message.id, event, payload });
-              },
-            })
+            tools!.call(message.ref, message.input, { signal: controller.signal })
           );
         } finally {
           controllers.delete(message.id);

--- a/code/core/src/cli/tools/sdk/child-protocol.ts
+++ b/code/core/src/cli/tools/sdk/child-protocol.ts
@@ -27,18 +27,7 @@ export type ChildErrorMessage = {
   error: SerializedError;
 };
 
-export type ChildTelemetryMessage = {
-  type: 'telemetry';
-  id: string;
-  event: string;
-  payload: Record<string, unknown>;
-};
-
-export type ChildMessage =
-  | ChildHelloMessage
-  | ChildResultMessage
-  | ChildErrorMessage
-  | ChildTelemetryMessage;
+export type ChildMessage = ChildHelloMessage | ChildResultMessage | ChildErrorMessage;
 
 export type ParentInitMessage = {
   type: 'init';

--- a/code/core/src/cli/tools/sdk/command-telemetry.test.ts
+++ b/code/core/src/cli/tools/sdk/command-telemetry.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
-  commandNameFromRef,
+  commandPartsFromRef,
   shouldReportSdkInvocation,
   toolsCommandDimensions,
   wrapMethodTelemetry,
@@ -41,14 +41,24 @@ describe('toolsCommandDimensions', () => {
   });
 });
 
-describe('commandNameFromRef', () => {
-  it('turns a dotted method id into the CLI spelling', () => {
-    expect(commandNameFromRef('docs.list')).toBe('docs list');
-    expect(commandNameFromRef('stories.findByComponent')).toBe('stories find-by-component');
+describe('commandPartsFromRef', () => {
+  it('splits a dotted method id into the CLI spelling of both parts', () => {
+    expect(commandPartsFromRef('docs.list')).toEqual({ toolset: 'docs', tool: 'list' });
+    expect(commandPartsFromRef('stories.findByComponent')).toEqual({
+      toolset: 'stories',
+      tool: 'find-by-component',
+    });
   });
 
   it('collapses a malformed reference', () => {
-    expect(commandNameFromRef('not-a-ref')).toBe('(invalid)');
+    expect(commandPartsFromRef('not-a-ref')).toEqual({ toolset: '(invalid)', tool: '(invalid)' });
+  });
+
+  it('collapses a part that is not a name-shaped token', () => {
+    expect(commandPartsFromRef('my project.list')).toEqual({
+      toolset: '(invalid)',
+      tool: 'list',
+    });
   });
 });
 
@@ -63,7 +73,7 @@ describe('wrapMethodTelemetry', () => {
       host: 'child',
     });
 
-    await wrapped('tool:listAllDocumentation', { toolset: 'docs' });
+    await wrapped('tool:listAllDocumentation', { componentCount: 3 });
 
     expect(sink).toHaveBeenCalledWith('tool:listAllDocumentation', {
       client: 'sdk',
@@ -71,7 +81,7 @@ describe('wrapMethodTelemetry', () => {
       resolvedMode: 'attached',
       attachMode: 'attached',
       host: 'child',
-      toolset: 'docs',
+      componentCount: 3,
     });
   });
 });

--- a/code/core/src/cli/tools/sdk/command-telemetry.test.ts
+++ b/code/core/src/cli/tools/sdk/command-telemetry.test.ts
@@ -87,7 +87,7 @@ describe('reportToolsCommandEvent', () => {
         report: {
           toolset: 'stories',
           tool: 'find-by-component',
-          event: 'tool:getStoriesByComponent',
+          event: 'tool:stories_findByComponent',
           payload: { componentCount: 2, success: 'not a record field' },
         },
         configDir: '/repo/.storybook',
@@ -99,7 +99,7 @@ describe('reportToolsCommandEvent', () => {
       {
         toolset: 'stories',
         tool: 'find-by-component',
-        event: 'tool:getStoriesByComponent',
+        event: 'tool:stories_findByComponent',
         componentCount: 2,
         success: true,
         outcome: 'success',

--- a/code/core/src/cli/tools/sdk/command-telemetry.test.ts
+++ b/code/core/src/cli/tools/sdk/command-telemetry.test.ts
@@ -1,11 +1,15 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { telemetry } from 'storybook/internal/telemetry';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   commandPartsFromRef,
+  reportToolsCommandEvent,
   shouldReportSdkInvocation,
   toolsCommandDimensions,
-  wrapMethodTelemetry,
 } from './command-telemetry.ts';
+
+vi.mock('storybook/internal/telemetry', { spy: true });
 
 describe('toolsCommandDimensions', () => {
   it('uses resolvedMode for attachMode when a host exists', () => {
@@ -62,27 +66,85 @@ describe('commandPartsFromRef', () => {
   });
 });
 
-describe('wrapMethodTelemetry', () => {
-  it('merges host dimensions under the method payload', async () => {
-    const sink = vi.fn(async () => {});
-    const wrapped = wrapMethodTelemetry(sink, {
-      client: 'sdk',
+describe('reportToolsCommandEvent', () => {
+  beforeEach(() => {
+    vi.mocked(telemetry).mockReset();
+    vi.mocked(telemetry).mockResolvedValue(undefined);
+  });
+
+  it('merges the report under the record and names the tool by the report', async () => {
+    await reportToolsCommandEvent(
+      {
+        toolset: 'stories',
+        tool: 'findByComponent',
+        success: true,
+        outcome: 'success',
+        client: 'cli',
+        requestedMode: 'auto',
+        attachMode: 'local',
+      },
+      {
+        report: {
+          toolset: 'stories',
+          tool: 'find-by-component',
+          event: 'tool:getStoriesByComponent',
+          counters: { componentCount: 2, success: 'not a record field' },
+        },
+        configDir: '/repo/.storybook',
+      }
+    );
+
+    expect(telemetry).toHaveBeenCalledWith(
+      'tools-command',
+      {
+        toolset: 'stories',
+        tool: 'find-by-component',
+        event: 'tool:getStoriesByComponent',
+        componentCount: 2,
+        success: true,
+        outcome: 'success',
+        client: 'cli',
+        requestedMode: 'auto',
+        attachMode: 'local',
+      },
+      { configDir: '/repo/.storybook' }
+    );
+  });
+
+  it('sends the record alone when the run produced no report', async () => {
+    await reportToolsCommandEvent({
+      success: false,
+      outcome: 'intercept',
+      client: 'cli',
       requestedMode: 'auto',
-      resolvedMode: 'attached',
-      attachMode: 'attached',
-      host: 'child',
+      attachMode: 'auto',
     });
 
-    await wrapped('tool:listAllDocumentation', { componentCount: 3 });
+    expect(telemetry).toHaveBeenCalledWith(
+      'tools-command',
+      {
+        success: false,
+        outcome: 'intercept',
+        client: 'cli',
+        requestedMode: 'auto',
+        attachMode: 'auto',
+      },
+      { configDir: undefined }
+    );
+  });
 
-    expect(sink).toHaveBeenCalledWith('tool:listAllDocumentation', {
-      client: 'sdk',
-      requestedMode: 'auto',
-      resolvedMode: 'attached',
-      attachMode: 'attached',
-      host: 'child',
-      componentCount: 3,
-    });
+  it('never lets a telemetry failure escape', async () => {
+    vi.mocked(telemetry).mockRejectedValue(new Error('offline'));
+
+    await expect(
+      reportToolsCommandEvent({
+        success: true,
+        outcome: 'success',
+        client: 'sdk',
+        requestedMode: 'local',
+        attachMode: 'local',
+      })
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/code/core/src/cli/tools/sdk/command-telemetry.test.ts
+++ b/code/core/src/cli/tools/sdk/command-telemetry.test.ts
@@ -88,7 +88,7 @@ describe('reportToolsCommandEvent', () => {
           toolset: 'stories',
           tool: 'find-by-component',
           event: 'tool:getStoriesByComponent',
-          counters: { componentCount: 2, success: 'not a record field' },
+          payload: { componentCount: 2, success: 'not a record field' },
         },
         configDir: '/repo/.storybook',
       }

--- a/code/core/src/cli/tools/sdk/command-telemetry.ts
+++ b/code/core/src/cli/tools/sdk/command-telemetry.ts
@@ -30,6 +30,12 @@ export type ToolsCommandTelemetryPayload = ToolsCommandDimensions & {
   duration?: number;
 };
 
+/** The record as sent: the run's fields plus the handler's event name and counters, when it ran. */
+export type ToolsCommandTelemetryRecord = ToolsCommandTelemetryPayload & {
+  event?: string;
+  [counter: string]: unknown;
+};
+
 // Names are a fixed vocabulary of short identifiers; anything else is arbitrary agent input (a
 // typo'd path, a stray flag value) that must not be sent verbatim.
 export function sanitizeNamePart(part: string): string {
@@ -72,7 +78,7 @@ export async function reportToolsCommandEvent(
   options: { report?: ToolsetMethodReport; configDir?: string } = {}
 ): Promise<void> {
   const { report, configDir } = options;
-  const payload = report
+  const payload: ToolsCommandTelemetryRecord = report
     ? {
         ...report.counters,
         ...record,

--- a/code/core/src/cli/tools/sdk/command-telemetry.ts
+++ b/code/core/src/cli/tools/sdk/command-telemetry.ts
@@ -33,7 +33,7 @@ export type ToolsCommandTelemetryPayload = ToolsCommandDimensions & {
 /** The record as sent: the run's fields plus the handler's event name and payload, when it ran. */
 export type ToolsCommandTelemetryRecord = ToolsCommandTelemetryPayload & {
   event?: string;
-  [counter: string]: unknown;
+  [field: string]: unknown;
 };
 
 // Names are a fixed vocabulary of short identifiers; anything else is arbitrary agent input (a

--- a/code/core/src/cli/tools/sdk/command-telemetry.ts
+++ b/code/core/src/cli/tools/sdk/command-telemetry.ts
@@ -1,12 +1,12 @@
 import { telemetry } from 'storybook/internal/telemetry';
 
-import type { ToolsetTelemetry } from '../../../shared/open-service/toolset-definition.ts';
+import type { ToolsetMethodReport } from '../../../shared/open-service/toolset-definition.ts';
 import {
   parseToolsetMethodId,
   toCliMethodName,
 } from '../../../shared/open-service/toolset-names.ts';
 import { attachGateReasonFromError, type ToolsAttachGateReason } from './errors.ts';
-import type { ToolsCallOptions, ToolsClientInfo, ToolsHostKind, ToolsMode } from './types.ts';
+import type { ToolsClientInfo, ToolsHostKind, ToolsMode } from './types.ts';
 
 export type ToolsCommandOutcomeKind = 'success' | 'failure' | 'intercept' | 'error' | 'attach-gate';
 
@@ -28,14 +28,6 @@ export type ToolsCommandTelemetryPayload = ToolsCommandDimensions & {
   interceptReason?: string;
   multipleMatches?: boolean;
   duration?: number;
-};
-
-export type MethodReport = { event: string; payload: Record<string, unknown> };
-
-// `sink` is absent only in a child host process, where the report travels over IPC to the parent.
-export type CallTelemetry = {
-  sink?: ToolsetTelemetry;
-  report(): MethodReport | undefined;
 };
 
 // Names are a fixed vocabulary of short identifiers; anything else is arbitrary agent input (a
@@ -73,49 +65,24 @@ export function commandPartsFromRef(ref: string): { toolset: string; tool: strin
   }
 }
 
-export function wrapMethodTelemetry(
-  sink: ToolsetTelemetry,
-  dimensions: ToolsCommandDimensions
-): ToolsetTelemetry {
-  return async (event, payload) => {
-    await sink(event, { ...dimensions, ...payload });
-  };
-}
-
-// The caller's own sink, when given, still receives the report with the host dimensions.
-export function resolveCallTelemetry(
-  options: ToolsCallOptions,
-  dimensions: ToolsCommandDimensions
-): CallTelemetry {
-  if (process.env.STORYBOOK_TOOLS_CHILD_HOST === 'true') {
-    return { sink: options.telemetry, report: () => undefined };
-  }
-  let report: MethodReport | undefined;
-  const forward = options.telemetry
-    ? wrapMethodTelemetry(options.telemetry, dimensions)
-    : undefined;
-  return {
-    sink: async (event, payload) => {
-      report = { event, payload };
-      await forward?.(event, payload);
-    },
-    report: () => report,
-  };
-}
-
-// The handler's report is merged under the record: its `event` name and its counters, with the
-// record's own fields winning.
+// The record describes the run and wins over the handler's counters; the report names the method
+// and wins over whatever the caller parsed, so a record always carries the registered spelling.
 export async function reportToolsCommandEvent(
   record: ToolsCommandTelemetryPayload,
-  options: { report?: MethodReport; configDir?: string } = {}
+  options: { report?: ToolsetMethodReport; configDir?: string } = {}
 ): Promise<void> {
   const { report, configDir } = options;
+  const payload = report
+    ? {
+        ...report.counters,
+        ...record,
+        event: report.event,
+        toolset: report.toolset,
+        tool: report.tool,
+      }
+    : record;
   try {
-    await telemetry(
-      'tools-command',
-      { ...report?.payload, ...(report ? { event: report.event } : {}), ...record },
-      { configDir }
-    );
+    await telemetry('tools-command', payload, { configDir });
   } catch {
     // Telemetry is never part of the tool's result contract.
   }
@@ -157,7 +124,7 @@ export async function reportSdkInvocation(args: {
   host: ToolsHostKind;
   fallbackReason?: ToolsAttachGateReason;
   result: { ok: boolean } | { error: unknown };
-  report?: MethodReport;
+  report?: ToolsetMethodReport;
   duration: number;
   configDir?: string;
 }): Promise<void> {

--- a/code/core/src/cli/tools/sdk/command-telemetry.ts
+++ b/code/core/src/cli/tools/sdk/command-telemetry.ts
@@ -30,7 +30,7 @@ export type ToolsCommandTelemetryPayload = ToolsCommandDimensions & {
   duration?: number;
 };
 
-/** The record as sent: the run's fields plus the handler's event name and counters, when it ran. */
+/** The record as sent: the run's fields plus the handler's event name and payload, when it ran. */
 export type ToolsCommandTelemetryRecord = ToolsCommandTelemetryPayload & {
   event?: string;
   [counter: string]: unknown;
@@ -71,7 +71,7 @@ export function commandPartsFromRef(ref: string): { toolset: string; tool: strin
   }
 }
 
-// The record describes the run and wins over the handler's counters; the report names the method
+// The record describes the run and wins over the handler's payload; the report names the method
 // and wins over whatever the caller parsed, so a record always carries the registered spelling.
 export async function reportToolsCommandEvent(
   record: ToolsCommandTelemetryPayload,
@@ -80,7 +80,7 @@ export async function reportToolsCommandEvent(
   const { report, configDir } = options;
   const payload: ToolsCommandTelemetryRecord = report
     ? {
-        ...report.counters,
+        ...report.payload,
         ...record,
         event: report.event,
         toolset: report.toolset,

--- a/code/core/src/cli/tools/sdk/command-telemetry.ts
+++ b/code/core/src/cli/tools/sdk/command-telemetry.ts
@@ -19,13 +19,30 @@ export type ToolsCommandDimensions = {
   attachGate?: ToolsAttachGateReason;
 };
 
+// One record per CLI or SDK invocation; `toolset` and `tool` are absent when no part was parsed.
 export type ToolsCommandTelemetryPayload = ToolsCommandDimensions & {
-  command: string;
+  toolset?: string;
+  tool?: string;
   success: boolean;
   outcome: ToolsCommandOutcomeKind;
   interceptReason?: string;
+  multipleMatches?: boolean;
   duration?: number;
 };
+
+export type MethodReport = { event: string; payload: Record<string, unknown> };
+
+// `sink` is absent only in a child host process, where the report travels over IPC to the parent.
+export type CallTelemetry = {
+  sink?: ToolsetTelemetry;
+  report(): MethodReport | undefined;
+};
+
+// Names are a fixed vocabulary of short identifiers; anything else is arbitrary agent input (a
+// typo'd path, a stray flag value) that must not be sent verbatim.
+export function sanitizeNamePart(part: string): string {
+  return /^[\w-]{1,64}$/.test(part) ? part : '(invalid)';
+}
 
 export function toolsCommandDimensions(args: {
   clientInfo: Pick<Required<ToolsClientInfo>, 'kind'>;
@@ -44,12 +61,15 @@ export function toolsCommandDimensions(args: {
   };
 }
 
-export function commandNameFromRef(ref: string): string {
+export function commandPartsFromRef(ref: string): { toolset: string; tool: string } {
   try {
     const { toolsetId, methodName } = parseToolsetMethodId(ref);
-    return `${toolsetId} ${toCliMethodName(methodName)}`;
+    return {
+      toolset: sanitizeNamePart(toolsetId),
+      tool: sanitizeNamePart(toCliMethodName(methodName)),
+    };
   } catch {
-    return '(invalid)';
+    return { toolset: '(invalid)', tool: '(invalid)' };
   }
 }
 
@@ -62,35 +82,40 @@ export function wrapMethodTelemetry(
   };
 }
 
-export function defaultMethodTelemetrySink(configDir?: string): ToolsetTelemetry {
-  return async (event, payload) => {
-    await telemetry('tools-command', { event, ...payload }, { configDir });
+// The caller's own sink, when given, still receives the report with the host dimensions.
+export function resolveCallTelemetry(
+  options: ToolsCallOptions,
+  dimensions: ToolsCommandDimensions
+): CallTelemetry {
+  if (process.env.STORYBOOK_TOOLS_CHILD_HOST === 'true') {
+    return { sink: options.telemetry, report: () => undefined };
+  }
+  let report: MethodReport | undefined;
+  const forward = options.telemetry
+    ? wrapMethodTelemetry(options.telemetry, dimensions)
+    : undefined;
+  return {
+    sink: async (event, payload) => {
+      report = { event, payload };
+      await forward?.(event, payload);
+    },
+    report: () => report,
   };
 }
 
-export function resolveCallTelemetry(
-  options: ToolsCallOptions,
-  dimensions: ToolsCommandDimensions,
-  args: { clientInfo: Pick<Required<ToolsClientInfo>, 'kind'>; configDir?: string }
-): ToolsetTelemetry | undefined {
-  const isChildHost = process.env.STORYBOOK_TOOLS_CHILD_HOST === 'true';
-  const sink =
-    options.telemetry ??
-    (!isChildHost && shouldReportSdkInvocation(args.clientInfo.kind)
-      ? defaultMethodTelemetrySink(args.configDir)
-      : undefined);
-  if (!sink) {
-    return undefined;
-  }
-  return isChildHost ? sink : wrapMethodTelemetry(sink, dimensions);
-}
-
+// The handler's report is merged under the record: its `event` name and its counters, with the
+// record's own fields winning.
 export async function reportToolsCommandEvent(
-  payload: ToolsCommandTelemetryPayload,
-  options?: { configDir?: string }
+  record: ToolsCommandTelemetryPayload,
+  options: { report?: MethodReport; configDir?: string } = {}
 ): Promise<void> {
+  const { report, configDir } = options;
   try {
-    await telemetry('tools-command', payload, options);
+    await telemetry(
+      'tools-command',
+      { ...report?.payload, ...(report ? { event: report.event } : {}), ...record },
+      { configDir }
+    );
   } catch {
     // Telemetry is never part of the tool's result contract.
   }
@@ -112,7 +137,6 @@ export async function reportSdkAttachGate(args: {
   const attachGate = attachGateReasonFromError(args.error);
   await reportToolsCommandEvent(
     {
-      command: '(none)',
       success: false,
       outcome: 'attach-gate',
       ...toolsCommandDimensions({
@@ -133,6 +157,7 @@ export async function reportSdkInvocation(args: {
   host: ToolsHostKind;
   fallbackReason?: ToolsAttachGateReason;
   result: { ok: boolean } | { error: unknown };
+  report?: MethodReport;
   duration: number;
   configDir?: string;
 }): Promise<void> {
@@ -140,30 +165,32 @@ export async function reportSdkInvocation(args: {
     return;
   }
   const dimensions = toolsCommandDimensions(args);
+  const invoked = commandPartsFromRef(args.ref);
+  const options = { report: args.report, configDir: args.configDir };
   if (!('ok' in args.result)) {
     const attachGate = attachGateReasonFromError(args.result.error);
     await reportToolsCommandEvent(
       {
-        command: commandNameFromRef(args.ref),
+        ...invoked,
         success: false,
         outcome: attachGate ? 'attach-gate' : 'error',
         duration: args.duration,
         ...dimensions,
         ...(attachGate ? { attachGate } : {}),
       },
-      { configDir: args.configDir }
+      options
     );
     return;
   }
   const success = args.result.ok;
   await reportToolsCommandEvent(
     {
-      command: commandNameFromRef(args.ref),
+      ...invoked,
       success,
       outcome: success ? 'success' : 'failure',
       duration: args.duration,
       ...dimensions,
     },
-    { configDir: args.configDir }
+    options
   );
 }

--- a/code/core/src/cli/tools/sdk/create-tools.test.ts
+++ b/code/core/src/cli/tools/sdk/create-tools.test.ts
@@ -63,7 +63,7 @@ const echo = defineToolset({
         ok: true as const,
         data: {},
         markdown: '',
-        telemetry: { event: 'tool:count', counters: { itemCount: 2 } },
+        telemetry: { event: 'tool:count', payload: { itemCount: 2 } },
       }),
     },
     slow: {
@@ -574,7 +574,7 @@ describe('createTools', () => {
                   ok: true as const,
                   data: { origin: ctx.origin },
                   markdown: ctx.origin ?? '',
-                  telemetry: { event: 'tool:ping', counters: { pingCount: 1 } },
+                  telemetry: { event: 'tool:ping', payload: { pingCount: 1 } },
                 }),
               },
             },
@@ -591,7 +591,7 @@ describe('createTools', () => {
       toolset: 'probe',
       tool: 'ping',
       event: 'tool:ping',
-      counters: { pingCount: 1 },
+      payload: { pingCount: 1 },
     });
     expect(invocationPayloads()).toEqual([
       expect.objectContaining({ toolset: 'probe', tool: 'ping', event: 'tool:ping', pingCount: 1 }),

--- a/code/core/src/cli/tools/sdk/create-tools.test.ts
+++ b/code/core/src/cli/tools/sdk/create-tools.test.ts
@@ -59,19 +59,12 @@ const echo = defineToolset({
       title: 'Report a count',
       description: 'Reports usage, then succeeds.',
       input: v.object({}),
-      handler: async (_input, ctx) => {
-        await ctx.telemetry?.('tool:count', { itemCount: 2 });
-        return { ok: true as const, data: {}, markdown: '' };
-      },
-    },
-    explode: {
-      title: 'Report, then throw',
-      description: 'Reports usage, then fails unexpectedly.',
-      input: v.object({}),
-      handler: async (_input, ctx) => {
-        await ctx.telemetry?.('tool:explode', { itemCount: 1 });
-        throw new Error('boom');
-      },
+      handler: async () => ({
+        ok: true as const,
+        data: {},
+        markdown: '',
+        telemetry: { event: 'tool:count', counters: { itemCount: 2 } },
+      }),
     },
     slow: {
       title: 'Delay',
@@ -565,8 +558,7 @@ describe('createTools', () => {
     await expect(spawnFailed).rejects.toThrow('Could not resolve the `storybook` package');
   });
 
-  it('applies per-call origin and telemetry to the method context', async () => {
-    const sink = vi.fn(async () => {});
+  it('applies the per-call origin and returns the named report on the outcome', async () => {
     vi.mocked(bootstrapToolsRuntime).mockResolvedValue(
       makeRuntime({
         toolsets: [
@@ -578,14 +570,12 @@ describe('createTools', () => {
                 title: 'Ping',
                 description: 'ping',
                 input: v.object({}),
-                handler: async (_input, ctx) => {
-                  await ctx.telemetry?.('tool:ping', { pingCount: 1 });
-                  return {
-                    ok: true as const,
-                    data: { origin: ctx.origin },
-                    markdown: ctx.origin ?? '',
-                  };
-                },
+                handler: async (_input, ctx) => ({
+                  ok: true as const,
+                  data: { origin: ctx.origin },
+                  markdown: ctx.origin ?? '',
+                  telemetry: { event: 'tool:ping', counters: { pingCount: 1 } },
+                }),
               },
             },
           }),
@@ -594,20 +584,14 @@ describe('createTools', () => {
     );
     const tools = await createTools({ mode: 'local' });
 
-    const outcome = await tools.call(
-      'probe.ping',
-      {},
-      { origin: 'http://localhost:9', telemetry: sink }
-    );
+    const outcome = await tools.call('probe.ping', {}, { origin: 'http://localhost:9' });
 
     expect(outcome).toMatchObject({ data: { origin: 'http://localhost:9' } });
-    expect(sink).toHaveBeenCalledWith('tool:ping', {
-      pingCount: 1,
-      client: 'sdk',
-      requestedMode: 'local',
-      resolvedMode: 'local',
-      attachMode: 'local',
-      host: 'in-process',
+    expect(outcome.telemetry).toEqual({
+      toolset: 'probe',
+      tool: 'ping',
+      event: 'tool:ping',
+      counters: { pingCount: 1 },
     });
     expect(invocationPayloads()).toEqual([
       expect.objectContaining({ toolset: 'probe', tool: 'ping', event: 'tool:ping', pingCount: 1 }),
@@ -666,7 +650,6 @@ describe('describe', () => {
       ['echo.live', true],
       ['echo.sibling', false],
       ['echo.counted', false],
-      ['echo.explode', false],
       ['echo.slow', false],
     ]);
   });
@@ -906,23 +889,6 @@ describe('tools-command telemetry', () => {
         host: 'in-process',
         duration: expect.any(Number),
       },
-    ]);
-  });
-
-  it('keeps the handler report on the record when the handler throws', async () => {
-    const tools = await createTools({ mode: 'local' });
-
-    await expect(tools.call('echo.explode')).rejects.toThrow('boom');
-
-    expect(invocationPayloads()).toEqual([
-      expect.objectContaining({
-        toolset: 'echo',
-        tool: 'explode',
-        event: 'tool:explode',
-        itemCount: 1,
-        success: false,
-        outcome: 'error',
-      }),
     ]);
   });
 

--- a/code/core/src/cli/tools/sdk/create-tools.test.ts
+++ b/code/core/src/cli/tools/sdk/create-tools.test.ts
@@ -63,7 +63,7 @@ const echo = defineToolset({
         ok: true as const,
         data: {},
         markdown: '',
-        telemetry: { event: 'tool:count', payload: { itemCount: 2 } },
+        telemetry: { payload: { itemCount: 2 } },
       }),
     },
     slow: {
@@ -574,7 +574,7 @@ describe('createTools', () => {
                   ok: true as const,
                   data: { origin: ctx.origin },
                   markdown: ctx.origin ?? '',
-                  telemetry: { event: 'tool:ping', payload: { pingCount: 1 } },
+                  telemetry: { payload: { pingCount: 1 } },
                 }),
               },
             },
@@ -590,11 +590,11 @@ describe('createTools', () => {
     expect(outcome.telemetry).toEqual({
       toolset: 'probe',
       tool: 'ping',
-      event: 'tool:ping',
+      event: 'tool:probe_ping',
       payload: { pingCount: 1 },
     });
     expect(invocationPayloads()).toEqual([
-      expect.objectContaining({ toolset: 'probe', tool: 'ping', event: 'tool:ping', pingCount: 1 }),
+      expect.objectContaining({ toolset: 'probe', tool: 'ping', pingCount: 1 }),
     ]);
   });
 
@@ -878,7 +878,7 @@ describe('tools-command telemetry', () => {
       {
         toolset: 'echo',
         tool: 'counted',
-        event: 'tool:count',
+        event: 'tool:echo_counted',
         itemCount: 2,
         success: true,
         outcome: 'success',

--- a/code/core/src/cli/tools/sdk/create-tools.test.ts
+++ b/code/core/src/cli/tools/sdk/create-tools.test.ts
@@ -55,6 +55,24 @@ const echo = defineToolset({
       input: v.object({}),
       handler: async () => ({ ok: true as const, data: {}, markdown: '' }),
     },
+    counted: {
+      title: 'Report a count',
+      description: 'Reports usage, then succeeds.',
+      input: v.object({}),
+      handler: async (_input, ctx) => {
+        await ctx.telemetry?.('tool:count', { itemCount: 2 });
+        return { ok: true as const, data: {}, markdown: '' };
+      },
+    },
+    explode: {
+      title: 'Report, then throw',
+      description: 'Reports usage, then fails unexpectedly.',
+      input: v.object({}),
+      handler: async (_input, ctx) => {
+        await ctx.telemetry?.('tool:explode', { itemCount: 1 });
+        throw new Error('boom');
+      },
+    },
     slow: {
       title: 'Delay',
       description: 'Resolves after a tick unless aborted.',
@@ -561,7 +579,7 @@ describe('createTools', () => {
                 description: 'ping',
                 input: v.object({}),
                 handler: async (_input, ctx) => {
-                  await ctx.telemetry?.('tool:ping', { toolset: 'probe' });
+                  await ctx.telemetry?.('tool:ping', { pingCount: 1 });
                   return {
                     ok: true as const,
                     data: { origin: ctx.origin },
@@ -583,17 +601,17 @@ describe('createTools', () => {
     );
 
     expect(outcome).toMatchObject({ data: { origin: 'http://localhost:9' } });
-    expect(sink).toHaveBeenCalledWith(
-      'tool:ping',
-      expect.objectContaining({
-        toolset: 'probe',
-        client: 'sdk',
-        requestedMode: 'local',
-        resolvedMode: 'local',
-        attachMode: 'local',
-        host: 'in-process',
-      })
-    );
+    expect(sink).toHaveBeenCalledWith('tool:ping', {
+      pingCount: 1,
+      client: 'sdk',
+      requestedMode: 'local',
+      resolvedMode: 'local',
+      attachMode: 'local',
+      host: 'in-process',
+    });
+    expect(invocationPayloads()).toEqual([
+      expect.objectContaining({ toolset: 'probe', tool: 'ping', event: 'tool:ping', pingCount: 1 }),
+    ]);
   });
 
   it('wraps a configuration that cannot be loaded', async () => {
@@ -647,6 +665,8 @@ describe('describe', () => {
       ['echo.bad', false],
       ['echo.live', true],
       ['echo.sibling', false],
+      ['echo.counted', false],
+      ['echo.explode', false],
       ['echo.slow', false],
     ]);
   });
@@ -840,10 +860,7 @@ describe('call', () => {
 function invocationPayloads(): unknown[] {
   return vi
     .mocked(telemetry)
-    .mock.calls.filter(
-      ([eventType, payload]) =>
-        eventType === 'tools-command' && payload !== undefined && !('event' in payload)
-    )
+    .mock.calls.filter(([eventType]) => eventType === 'tools-command')
     .map(([, payload]) => payload);
 }
 
@@ -854,8 +871,9 @@ describe('tools-command telemetry', () => {
     await tools.call('echo.ok', { value: 'hello' });
 
     expect(invocationPayloads()).toEqual([
-      expect.objectContaining({
-        command: 'echo ok',
+      {
+        toolset: 'echo',
+        tool: 'ok',
         success: true,
         outcome: 'success',
         client: 'sdk',
@@ -864,7 +882,57 @@ describe('tools-command telemetry', () => {
         attachMode: 'local',
         host: 'in-process',
         duration: expect.any(Number),
+      },
+    ]);
+  });
+
+  it('merges the handler report into the one invocation record', async () => {
+    const tools = await createTools({ mode: 'local' });
+
+    await tools.call('echo.counted');
+
+    expect(invocationPayloads()).toEqual([
+      {
+        toolset: 'echo',
+        tool: 'counted',
+        event: 'tool:count',
+        itemCount: 2,
+        success: true,
+        outcome: 'success',
+        client: 'sdk',
+        requestedMode: 'local',
+        resolvedMode: 'local',
+        attachMode: 'local',
+        host: 'in-process',
+        duration: expect.any(Number),
+      },
+    ]);
+  });
+
+  it('keeps the handler report on the record when the handler throws', async () => {
+    const tools = await createTools({ mode: 'local' });
+
+    await expect(tools.call('echo.explode')).rejects.toThrow('boom');
+
+    expect(invocationPayloads()).toEqual([
+      expect.objectContaining({
+        toolset: 'echo',
+        tool: 'explode',
+        event: 'tool:explode',
+        itemCount: 1,
+        success: false,
+        outcome: 'error',
       }),
+    ]);
+  });
+
+  it('spells the tool the way the CLI does', async () => {
+    const tools = await createTools({ mode: 'local' });
+
+    await tools.call('echo.findByComponent').catch(() => {});
+
+    expect(invocationPayloads()).toEqual([
+      expect.objectContaining({ toolset: 'echo', tool: 'find-by-component', outcome: 'error' }),
     ]);
   });
 
@@ -875,7 +943,8 @@ describe('tools-command telemetry', () => {
 
     expect(invocationPayloads()).toEqual([
       expect.objectContaining({
-        command: 'echo bad',
+        toolset: 'echo',
+        tool: 'bad',
         success: false,
         outcome: 'failure',
         client: 'sdk',
@@ -917,7 +986,8 @@ describe('tools-command telemetry', () => {
 
     expect(invocationPayloads()).toEqual([
       expect.objectContaining({
-        command: 'echo ok',
+        toolset: 'echo',
+        tool: 'ok',
         success: true,
         outcome: 'success',
         client: 'sdk',
@@ -944,15 +1014,14 @@ describe('tools-command telemetry', () => {
     );
 
     expect(invocationPayloads()).toEqual([
-      expect.objectContaining({
-        command: '(none)',
+      {
         success: false,
         outcome: 'attach-gate',
         client: 'sdk',
         requestedMode: 'attached',
         attachMode: 'attached',
         attachGate: 'connection-failed',
-      }),
+      },
     ]);
   });
 

--- a/code/core/src/cli/tools/sdk/create-tools.ts
+++ b/code/core/src/cli/tools/sdk/create-tools.ts
@@ -445,13 +445,10 @@ function createToolsHost(args: {
       options: ToolsCallOptions = {}
     ): Promise<AnyToolsetOutcome> {
       assertOpen();
-      const telemetry = resolveCallTelemetry(options, dimensions, {
-        clientInfo,
-        configDir: runtime.configDir,
-      });
+      const telemetry = resolveCallTelemetry(options, dimensions);
       const callOptions: ToolsCallOptions = {
         ...options,
-        ...(telemetry ? { telemetry } : {}),
+        ...(telemetry.sink ? { telemetry: telemetry.sink } : {}),
       };
       const start = Date.now();
       try {
@@ -466,6 +463,7 @@ function createToolsHost(args: {
           host,
           fallbackReason: args.fallbackReason,
           result: outcome,
+          report: telemetry.report(),
           duration: Date.now() - start,
           configDir: runtime.configDir,
         });
@@ -487,6 +485,7 @@ function createToolsHost(args: {
           host,
           fallbackReason: args.fallbackReason,
           result: { error: mapped },
+          report: telemetry.report(),
           duration: Date.now() - start,
           configDir: runtime.configDir,
         });

--- a/code/core/src/cli/tools/sdk/create-tools.ts
+++ b/code/core/src/cli/tools/sdk/create-tools.ts
@@ -4,12 +4,13 @@ import { versions } from 'storybook/internal/common';
 
 import { StorybookDevServerDisconnectedError } from '../../../server-errors.ts';
 import { formatIssues } from '../../../shared/open-service/errors.ts';
-import type {
-  AnyToolsetDefinition,
-  AnyToolsetMethod,
-  AnyToolsetOutcome,
-  ToolsetCtx,
-  ToolsetTransport,
+import {
+  invokeToolsetMethod,
+  type AnyToolsetDefinition,
+  type AnyToolsetMethod,
+  type InvokedToolsetOutcome,
+  type ToolsetCtx,
+  type ToolsetTransport,
 } from '../../../shared/open-service/toolset-definition.ts';
 import { parseToolsetMethodId } from '../../../shared/open-service/toolset-names.ts';
 import { projectPathsEqual } from '../instances/project-path.ts';
@@ -18,12 +19,7 @@ import type { AttachedBootstrapResult } from './attached-runtime.ts';
 import { toCatalogEntry } from './catalog.ts';
 import { formatAttachFallback } from './attach-messages.ts';
 import { spawnChildHost } from './child-client.ts';
-import {
-  reportSdkAttachGate,
-  reportSdkInvocation,
-  resolveCallTelemetry,
-  toolsCommandDimensions,
-} from './command-telemetry.ts';
+import { reportSdkAttachGate, reportSdkInvocation } from './command-telemetry.ts';
 import {
   AttachUnavailableError,
   SpawnFailedError,
@@ -378,11 +374,12 @@ function createToolsHost(args: {
     ref: string,
     input: Record<string, unknown>,
     options: ToolsCallOptions
-  ): Promise<AnyToolsetOutcome> => {
+  ): Promise<InvokedToolsetOutcome> => {
     options.signal?.throwIfAborted();
 
     const { toolsetId, methodName } = splitRef(ref);
-    const method = findMethod(findToolset(runtime, toolsetId), methodName);
+    const toolset = findToolset(runtime, toolsetId);
+    const method = findMethod(toolset, methodName);
 
     if (mode === 'local' && method.requiresDevServer) {
       throw new AttachUnavailableError({
@@ -403,21 +400,12 @@ function createToolsHost(args: {
 
     return raceAbort(
       options.signal,
-      method.handler(validation.value, {
+      invokeToolsetMethod(toolset, methodName, validation.value, {
         ...baseCtx,
         ...(options.origin !== undefined ? { origin: options.origin } : {}),
-        ...(options.telemetry ? { telemetry: options.telemetry } : {}),
       })
     );
   };
-
-  const dimensions = toolsCommandDimensions({
-    clientInfo,
-    requestedMode,
-    resolvedMode: mode,
-    host,
-    fallbackReason: args.fallbackReason,
-  });
 
   return {
     mode,
@@ -443,18 +431,13 @@ function createToolsHost(args: {
       ref: string,
       input: Record<string, unknown> = {},
       options: ToolsCallOptions = {}
-    ): Promise<AnyToolsetOutcome> {
+    ): Promise<InvokedToolsetOutcome> {
       assertOpen();
-      const telemetry = resolveCallTelemetry(options, dimensions);
-      const callOptions: ToolsCallOptions = {
-        ...options,
-        ...(telemetry.sink ? { telemetry: telemetry.sink } : {}),
-      };
       const start = Date.now();
       try {
         const outcome = args.disconnected
-          ? await Promise.race([invoke(ref, input, callOptions), args.disconnected])
-          : await invoke(ref, input, callOptions);
+          ? await Promise.race([invoke(ref, input, options), args.disconnected])
+          : await invoke(ref, input, options);
         await reportSdkInvocation({
           ref,
           clientInfo,
@@ -463,7 +446,7 @@ function createToolsHost(args: {
           host,
           fallbackReason: args.fallbackReason,
           result: outcome,
-          report: telemetry.report(),
+          report: outcome.telemetry,
           duration: Date.now() - start,
           configDir: runtime.configDir,
         });
@@ -485,7 +468,6 @@ function createToolsHost(args: {
           host,
           fallbackReason: args.fallbackReason,
           result: { error: mapped },
-          report: telemetry.report(),
           duration: Date.now() - start,
           configDir: runtime.configDir,
         });

--- a/code/core/src/cli/tools/sdk/index.ts
+++ b/code/core/src/cli/tools/sdk/index.ts
@@ -10,7 +10,6 @@ export {
   type ToolsAttachGateReason,
   type ToolsRuntimeErrorReason,
 } from './errors.ts';
-export { toolsCommandDimensions, wrapMethodTelemetry } from './command-telemetry.ts';
 export type { ToolsRuntime } from './local-runtime.ts';
 export type { ToolsetJsonSchema } from './json-schema.ts';
 export { formatMultiInstanceNotice } from './attach-messages.ts';

--- a/code/core/src/cli/tools/sdk/types.ts
+++ b/code/core/src/cli/tools/sdk/types.ts
@@ -1,7 +1,4 @@
-import type {
-  AnyToolsetOutcome,
-  ToolsetTelemetry,
-} from '../../../shared/open-service/toolset-definition.ts';
+import type { InvokedToolsetOutcome } from '../../../shared/open-service/toolset-definition.ts';
 import type { ToolsetMethodId } from '../../../shared/open-service/toolset-names.ts';
 import type { ToolsAttachGateReason } from './errors.ts';
 import type { ToolsetJsonSchema } from './json-schema.ts';
@@ -101,7 +98,6 @@ export type ToolsCallOptions = {
   signal?: AbortSignal;
   /** Overrides the host's Storybook origin for this call. */
   origin?: string;
-  telemetry?: ToolsetTelemetry;
 };
 
 type ToolsBase = {
@@ -133,7 +129,7 @@ type ToolsBase = {
     ref: string,
     input?: Record<string, unknown>,
     options?: ToolsCallOptions
-  ): Promise<AnyToolsetOutcome>;
+  ): Promise<InvokedToolsetOutcome>;
   close(): Promise<void>;
 };
 

--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -151,11 +151,14 @@ Adapters resolve one toolset with `getToolset(id)` or take the whole set via
 consume them today.
 
 Telemetry classification belongs in Storybook-owned telemetry calls, not on the generic toolset
-definition. A handler returns at most one usage report on its outcome, `telemetry: { event,
-payload }`, with the frozen analytics event name and its payload. `invokeToolsetMethod` — the
-one way every surface runs a method — names the report after the registration (`toolset`, and
-`tool` in CLI spelling). The CLI and SDK forward that report as their `tools-command` record and
-the MCP adapter as its `addon-mcp` event; no surface rewrites it. Third-party toolsets do not need to participate in Storybook's telemetry taxonomy.
+definition. A handler returns at most one usage report on its outcome, `telemetry: { payload }`.
+`invokeToolsetMethod` — the one way every surface runs a method — names the report after the
+registration: `toolset`, `tool` in CLI spelling, and the generated `event`
+(`tool:stories_findByComponent`). The CLI and SDK forward that report as their `tools-command`
+record. The MCP adapter forwards it as its `addon-mcp` event, but under the pre-toolset event name
+the addon keeps per tool (`tool:getStoriesByComponent`), so MCP usage data stays continuous across
+versions. Toolsets never name events themselves. Third-party toolsets do not need to participate in
+Storybook's telemetry taxonomy.
 
 Core owns `docs`, `stories`, and `review`. Addon-vitest owns the complete `test` toolset—its schemas,
 channel protocol, formatting, telemetry, and tests—and registers it beside its responder from the

--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -154,9 +154,8 @@ Telemetry classification belongs in Storybook-owned telemetry calls, not on the 
 definition. A handler returns at most one usage report on its outcome, `telemetry: { event,
 counters }`, with the frozen analytics event name and its counters. `invokeToolsetMethod` — the
 one way every surface runs a method — names the report after the registration (`toolset`, and
-`tool` in CLI spelling). The CLI and SDK forward that report as their `tools-command` record; the
-MCP adapter substitutes its own grouping for `toolset` to keep `addon-mcp` records compatible.
-Third-party toolsets do not need to participate in Storybook's telemetry taxonomy.
+`tool` in CLI spelling). The CLI and SDK forward that report as their `tools-command` record and
+the MCP adapter as its `addon-mcp` event; no surface rewrites it. Third-party toolsets do not need to participate in Storybook's telemetry taxonomy.
 
 Core owns `docs`, `stories`, and `review`. Addon-vitest owns the complete `test` toolset—its schemas,
 channel protocol, formatting, telemetry, and tests—and registers it beside its responder from the

--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -152,7 +152,7 @@ consume them today.
 
 Telemetry classification belongs in Storybook-owned telemetry calls, not on the generic toolset
 definition. A handler returns at most one usage report on its outcome, `telemetry: { event,
-counters }`, with the frozen analytics event name and its counters. `invokeToolsetMethod` — the
+payload }`, with the frozen analytics event name and its payload. `invokeToolsetMethod` — the
 one way every surface runs a method — names the report after the registration (`toolset`, and
 `tool` in CLI spelling). The CLI and SDK forward that report as their `tools-command` record and
 the MCP adapter as its `addon-mcp` event; no surface rewrites it. Third-party toolsets do not need to participate in Storybook's telemetry taxonomy.

--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -110,18 +110,18 @@ and synchronization; **toolsets** are the public agent surface for CLI and MCP a
   narrowed to it. An outcome's `data` may carry more than this declares; only the declared shape
   reaches the wire
 - `handler(input, ctx)` — the one execution: produces the data, renders the text, and owns side
-  effects and telemetry
+  effects and the usage report
 
 `handler` returns a `ToolsetOutcome<TSuccess, TFailure = TSuccess>` — a discriminated union of
-`{ ok: true, data, markdown }` and `{ ok: false, data, markdown }`, written as plain object
-literals (no factory helpers). The failure model is one line each: could not do the job →
+`{ ok: true, data, markdown }` and `{ ok: false, data, markdown }`, each with an optional
+`telemetry` usage report, written as plain object literals (no factory helpers). The failure model is one line each: could not do the job →
 **throw**; did the job and the answer is bad news (a failed test run, a not-found lookup) →
 **return `{ ok: false, data, markdown }`**. Infallible methods declare `TFailure = never`.
 
 One handler owns data and rendering because one MCP reply carries `content` (text) and
 `structuredContent` (JSON) at once and both must come from a single run — re-running a method with
-side effects would repeat them. Usage telemetry reports inline in the handler with the rendered
-text in hand, so no consumer can forget it. Adapters unwrap outcomes mechanically — text blocks
+side effects would repeat them. The usage report is part of the returned outcome, built with the
+rendered text in hand, so no consumer can forget it. Adapters unwrap outcomes mechanically — text blocks
 from `markdown`, `structuredContent` from `data`, MCP `isError` (and later CLI exit codes) from
 `ok` — and must not re-derive meaning from the data. `markdown` may be `string | string[]`:
 the CLI joins the blocks with blank lines, and its `--json` flag means "print `data`, skip
@@ -131,7 +131,7 @@ An error whose message speaks to the agent and names its own recovery declares `
 (a `StorybookError` constructor prop); adapters surface such errors verbatim by reading that
 property — never by keeping a class list, which misclassifies across bundle copies.
 
-`ctx` is `{ transport: 'cli' | 'mcp' | 'sdk', origin?, getService, telemetry? }`. `origin` is the complete
+`ctx` is `{ transport: 'cli' | 'mcp' | 'sdk', origin?, getService }`. `origin` is the complete
 Storybook UI base URL, including a deployment subpath; the MCP adapter derives it from the request.
 Descriptions that name a sibling tool must render it through `getToolName(ctx)` rather than hardcoding
 a spelling, so the same sentence reads as the derived MCP tool name, the CLI command, or the SDK
@@ -151,9 +151,12 @@ Adapters resolve one toolset with `getToolset(id)` or take the whole set via
 consume them today.
 
 Telemetry classification belongs in Storybook-owned telemetry calls, not on the generic toolset
-definition. Use `reportToolsetTelemetry` so a rejected analytics sink cannot fail a tool call; a
-handler reports once per call with an event name and counters, and the surface adapter adds its
-own grouping. Third-party toolsets do not need to participate in Storybook's telemetry taxonomy.
+definition. A handler returns at most one usage report on its outcome, `telemetry: { event,
+counters }`, with the frozen analytics event name and its counters. `invokeToolsetMethod` — the
+one way every surface runs a method — names the report after the registration (`toolset`, and
+`tool` in CLI spelling). The CLI and SDK forward that report as their `tools-command` record; the
+MCP adapter substitutes its own grouping for `toolset` to keep `addon-mcp` records compatible.
+Third-party toolsets do not need to participate in Storybook's telemetry taxonomy.
 
 Core owns `docs`, `stories`, and `review`. Addon-vitest owns the complete `test` toolset—its schemas,
 channel protocol, formatting, telemetry, and tests—and registers it beside its responder from the

--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -151,8 +151,9 @@ Adapters resolve one toolset with `getToolset(id)` or take the whole set via
 consume them today.
 
 Telemetry classification belongs in Storybook-owned telemetry calls, not on the generic toolset
-definition. Use `reportToolsetTelemetry` so a rejected analytics sink cannot fail a tool call.
-Third-party toolsets do not need to participate in Storybook's telemetry taxonomy.
+definition. Use `reportToolsetTelemetry` so a rejected analytics sink cannot fail a tool call; a
+handler reports once per call with an event name and counters, and the surface adapter adds its
+own grouping. Third-party toolsets do not need to participate in Storybook's telemetry taxonomy.
 
 Core owns `docs`, `stories`, and `review`. Addon-vitest owns the complete `test` toolset—its schemas,
 channel protocol, formatting, telemetry, and tests—and registers it beside its responder from the

--- a/code/core/src/shared/open-service/index.ts
+++ b/code/core/src/shared/open-service/index.ts
@@ -10,20 +10,22 @@ export { seedQueryState } from './query-state.ts';
 
 export {
   defineToolset,
-  reportToolsetTelemetry,
+  invokeToolsetMethod,
   resolveToolsetDescription,
 } from './toolset-definition.ts';
 export type {
   AnyToolsetDefinition,
   AnyToolsetOutcome,
+  InvokedToolsetOutcome,
   ToolsetCtx,
   ToolsetDefinition,
   ToolsetGetService,
   ToolsetMethod,
   ToolsetMethodDescription,
   ToolsetObjectOutputSchema,
+  ToolsetMethodReport,
   ToolsetOutcome,
-  ToolsetTelemetry,
+  ToolsetTelemetryReport,
   ToolsetTransport,
 } from './toolset-definition.ts';
 export { getToolName, parseToolsetMethodId, toMcpToolName } from './toolset-names.ts';

--- a/code/core/src/shared/open-service/toolset-definition.ts
+++ b/code/core/src/shared/open-service/toolset-definition.ts
@@ -26,14 +26,12 @@ export type ToolsetCtx = {
 };
 
 /**
- * A handler's usage report: the analytics event name and the payload describing what the call
- * did, counts and flags alike. It travels on the outcome, so a handler reports at most once and in the same object as its
- * data; the surface that ran the method turns it into its own telemetry record.
- *
- * Event names (`tool:previewStories`, …) are a frozen cross-version contract: keep them aligned
- * with older Storybook releases even when wire tool names or toolset ids change.
+ * A handler's usage report: the payload describing what the call did, counts and flags alike. It
+ * travels on the outcome, so a handler reports at most once and in the same object as its data.
+ * The surface that ran the method turns it into its own telemetry record and names the event; a
+ * handler never names one.
  */
-export type ToolsetTelemetryReport = { event: string; payload: Record<string, unknown> };
+export type ToolsetTelemetryReport = { payload: Record<string, unknown> };
 
 /**
  * A method description, resolved per transport.
@@ -194,10 +192,15 @@ export function resolveToolsetDescription(
 }
 
 /**
- * A handler's report completed with the CLI spelling of the invoked names (`stories`,
- * `find-by-component`), taken from where the method is registered.
+ * A handler's report completed from where the method is registered: the CLI spelling of the
+ * invoked names (`stories`, `find-by-component`) and the generated event name
+ * (`tool:stories_findByComponent`).
  */
-export type ToolsetMethodReport = ToolsetTelemetryReport & { toolset: string; tool: string };
+export type ToolsetMethodReport = ToolsetTelemetryReport & {
+  toolset: string;
+  tool: string;
+  event: string;
+};
 
 // `any` for the same reason as {@link AnyToolsetOutcome}: surfaces dispatch over every method.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -220,6 +223,11 @@ export async function invokeToolsetMethod(
   }
   return {
     ...outcome,
-    telemetry: { ...telemetry, toolset: toolset.id, tool: toCliMethodName(methodName) },
+    telemetry: {
+      ...telemetry,
+      toolset: toolset.id,
+      tool: toCliMethodName(methodName),
+      event: `tool:${toolset.id}_${methodName}`,
+    },
   };
 }

--- a/code/core/src/shared/open-service/toolset-definition.ts
+++ b/code/core/src/shared/open-service/toolset-definition.ts
@@ -26,14 +26,14 @@ export type ToolsetCtx = {
 };
 
 /**
- * A handler's usage report: the analytics event name and the counters describing what the call
- * did. It travels on the outcome, so a handler reports at most once and in the same object as its
+ * A handler's usage report: the analytics event name and the payload describing what the call
+ * did, counts and flags alike. It travels on the outcome, so a handler reports at most once and in the same object as its
  * data; the surface that ran the method turns it into its own telemetry record.
  *
  * Event names (`tool:previewStories`, …) are a frozen cross-version contract: keep them aligned
  * with older Storybook releases even when wire tool names or toolset ids change.
  */
-export type ToolsetTelemetryReport = { event: string; counters: Record<string, unknown> };
+export type ToolsetTelemetryReport = { event: string; payload: Record<string, unknown> };
 
 /**
  * A method description, resolved per transport.

--- a/code/core/src/shared/open-service/toolset-definition.ts
+++ b/code/core/src/shared/open-service/toolset-definition.ts
@@ -205,8 +205,8 @@ export type InvokedToolsetOutcome = ToolsetOutcome<any, any, ToolsetMethodReport
 
 /**
  * Runs one method the way every surface does. The report is named after the registration, never
- * by the handler, so a method cannot report a toolset that disagrees with where it lives. The CLI
- * and SDK forward the report as is; the MCP adapter substitutes its own grouping for `toolset`.
+ * by the handler, so a method cannot report a toolset that disagrees with where it lives. Every
+ * surface forwards the report as is and adds only its own fields.
  */
 export async function invokeToolsetMethod(
   toolset: AnyToolsetDefinition,

--- a/code/core/src/shared/open-service/toolset-definition.ts
+++ b/code/core/src/shared/open-service/toolset-definition.ts
@@ -220,6 +220,6 @@ export async function invokeToolsetMethod(
   }
   return {
     ...outcome,
-    telemetry: { toolset: toolset.id, tool: toCliMethodName(methodName), ...telemetry },
+    telemetry: { ...telemetry, toolset: toolset.id, tool: toCliMethodName(methodName) },
   };
 }

--- a/code/core/src/shared/open-service/toolset-definition.ts
+++ b/code/core/src/shared/open-service/toolset-definition.ts
@@ -1,5 +1,6 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 
+import { toCliMethodName } from './toolset-names.ts';
 import type { GetServiceOptions } from './types.ts';
 
 type AnySchema = StandardSchemaV1<unknown, unknown>;
@@ -14,16 +15,6 @@ export type ToolsetGetService = {
   <TInstance = unknown>(serviceId: string, options?: GetServiceOptions): TInstance;
 };
 
-/**
- * Emits one telemetry event for a toolset method.
- *
- * Adapters supply the sink so surface-specific fields (the MCP toolset grouping and session id,
- * the CLI's toolset and tool names) stay with the adapter while the event name and counters — the
- * part that describes the capability — stay in the method. Absent when the transport has telemetry
- * disabled.
- */
-export type ToolsetTelemetry = (event: string, payload: Record<string, unknown>) => Promise<void>;
-
 export type ToolsetCtx = {
   transport: ToolsetTransport;
   /**
@@ -32,8 +23,17 @@ export type ToolsetCtx = {
    */
   origin?: string;
   getService: ToolsetGetService;
-  telemetry?: ToolsetTelemetry;
 };
+
+/**
+ * A handler's usage report: the analytics event name and the counters describing what the call
+ * did. It travels on the outcome, so a handler reports at most once and in the same object as its
+ * data; the surface that ran the method turns it into its own telemetry record.
+ *
+ * Event names (`tool:previewStories`, …) are a frozen cross-version contract: keep them aligned
+ * with older Storybook releases even when wire tool names or toolset ids change.
+ */
+export type ToolsetTelemetryReport = { event: string; counters: Record<string, unknown> };
 
 /**
  * A method description, resolved per transport.
@@ -46,8 +46,8 @@ export type ToolsetCtx = {
 export type ToolsetMethodDescription = string | ((context: ToolsetCtx) => string);
 
 /**
- * The result of one method run: the tag, the structured data, and the rendered Markdown, all from a
- * single execution.
+ * The result of one method run: the tag, the structured data, the rendered Markdown, and the usage
+ * report, all from a single execution.
  *
  * The failure model in one line each: could not do the job → throw; did the job and the answer is
  * bad news → return `{ ok: false, data, markdown }`. Adapters unwrap mechanically — text blocks
@@ -61,16 +61,22 @@ export type ToolsetMethodDescription = string | ((context: ToolsetCtx) => string
  * `markdown` may be multiple strings: MCP renders each as its own text block (`stories-preview`
  * renders one block per URL), the CLI joins them with newlines.
  */
-export type ToolsetOutcome<TSuccess, TFailure = TSuccess> =
+export type ToolsetOutcome<
+  TSuccess,
+  TFailure = TSuccess,
+  TReport extends ToolsetTelemetryReport = ToolsetTelemetryReport,
+> =
   | {
       readonly ok: true;
       readonly data: TSuccess;
       readonly markdown: string | string[];
+      readonly telemetry?: TReport;
     }
   | {
       readonly ok: false;
       readonly data: TFailure;
       readonly markdown: string | string[];
+      readonly telemetry?: TReport;
     };
 
 // `any` permits heterogeneous outcome maps. Each individual method remains typed by `defineToolset`.
@@ -86,11 +92,11 @@ export type ToolsetObjectOutputSchema = StandardSchemaV1<
 /**
  * One public method: description, input schema, optional output schema, and one handler.
  *
- * The handler produces the whole {@link ToolsetOutcome} — data, side effects, telemetry, and the
- * rendered Markdown — because one MCP response carries `content` (text) and `structuredContent`
- * (JSON) at once, and both must come from a single run: re-running a method with side effects
- * would repeat them. Usage telemetry reports inline in the handler, with the rendered text in
- * hand, so no consumer can forget it.
+ * The handler produces the whole {@link ToolsetOutcome} — data, side effects, the usage report,
+ * and the rendered Markdown — because one MCP response carries `content` (text) and
+ * `structuredContent` (JSON) at once, and both must come from a single run: re-running a method
+ * with side effects would repeat them. The usage report is part of the returned object, with the
+ * rendered text in hand, so no consumer can forget it.
  */
 export type ToolsetMethod<
   TSchema extends AnySchema = AnySchema,
@@ -188,21 +194,32 @@ export function resolveToolsetDescription(
 }
 
 /**
- * Reports best-effort telemetry without allowing analytics failures to fail the tool call.
- *
- * Analytics event names (`tool:previewStories`, …) are a frozen cross-version contract: keep them
- * aligned with older Storybook releases even when MCP wire tool names or toolset ids change. A
- * handler reports the event name and its counters only; each surface adds its own grouping
- * (`toolset`) when it forwards the report.
+ * A handler's report completed with the CLI spelling of the invoked names (`stories`,
+ * `find-by-component`), taken from where the method is registered.
  */
-export async function reportToolsetTelemetry(
-  context: ToolsetCtx,
-  event: string,
-  payload: Record<string, unknown>
-): Promise<void> {
-  try {
-    await context.telemetry?.(event, payload);
-  } catch {
-    // Telemetry is never part of the tool's result contract.
+export type ToolsetMethodReport = ToolsetTelemetryReport & { toolset: string; tool: string };
+
+// `any` for the same reason as {@link AnyToolsetOutcome}: surfaces dispatch over every method.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type InvokedToolsetOutcome = ToolsetOutcome<any, any, ToolsetMethodReport>;
+
+/**
+ * Runs one method the way every surface does. The report is named after the registration, never
+ * by the handler, so a method cannot report a toolset that disagrees with where it lives. The CLI
+ * and SDK forward the report as is; the MCP adapter substitutes its own grouping for `toolset`.
+ */
+export async function invokeToolsetMethod(
+  toolset: AnyToolsetDefinition,
+  methodName: string,
+  input: unknown,
+  context: ToolsetCtx
+): Promise<InvokedToolsetOutcome> {
+  const { telemetry, ...outcome } = await toolset.methods[methodName].handler(input, context);
+  if (!telemetry) {
+    return outcome;
   }
+  return {
+    ...outcome,
+    telemetry: { toolset: toolset.id, tool: toCliMethodName(methodName), ...telemetry },
+  };
 }

--- a/code/core/src/shared/open-service/toolset-definition.ts
+++ b/code/core/src/shared/open-service/toolset-definition.ts
@@ -17,9 +17,10 @@ export type ToolsetGetService = {
 /**
  * Emits one telemetry event for a toolset method.
  *
- * Adapters supply the sink so surface-specific fields (MCP session id, client info) stay with the
- * adapter while the event name and payload — the part that describes the capability — stay in the
- * method. Absent when the transport has telemetry disabled.
+ * Adapters supply the sink so surface-specific fields (the MCP toolset grouping and session id,
+ * the CLI's toolset and tool names) stay with the adapter while the event name and counters — the
+ * part that describes the capability — stay in the method. Absent when the transport has telemetry
+ * disabled.
  */
 export type ToolsetTelemetry = (event: string, payload: Record<string, unknown>) => Promise<void>;
 
@@ -189,10 +190,10 @@ export function resolveToolsetDescription(
 /**
  * Reports best-effort telemetry without allowing analytics failures to fail the tool call.
  *
- * Analytics event names (`tool:previewStories`, …) and payload classifiers (`toolset: 'dev' |
- * 'docs' | 'test'`) are a frozen cross-version contract. Keep them aligned with older Storybook
- * releases even when MCP wire tool names or toolset ids change. The channel field is `transport`
- * (`'cli' | 'mcp' | 'sdk'`), matching the toolset API.
+ * Analytics event names (`tool:previewStories`, …) are a frozen cross-version contract: keep them
+ * aligned with older Storybook releases even when MCP wire tool names or toolset ids change. A
+ * handler reports the event name and its counters only; each surface adds its own grouping
+ * (`toolset`) when it forwards the report.
  */
 export async function reportToolsetTelemetry(
   context: ToolsetCtx,

--- a/code/core/src/shared/open-service/toolsets/docs/access-parity.test.ts
+++ b/code/core/src/shared/open-service/toolsets/docs/access-parity.test.ts
@@ -173,7 +173,7 @@ function manifestToolset() {
 }
 
 async function renderList(toolset: ReturnType<typeof createDocsToolset>, withStoryIds: boolean) {
-  return (await toolset.methods.list.handler({ withStoryIds }, ctx)).markdown;
+  return (await toolset.methods.list.handler({ withStoryIds })).markdown;
 }
 
 async function renderShow(toolset: ReturnType<typeof createDocsToolset>, id: string) {

--- a/code/core/src/shared/open-service/toolsets/docs/definition.test.ts
+++ b/code/core/src/shared/open-service/toolsets/docs/definition.test.ts
@@ -272,18 +272,12 @@ describe('docs.showStory in a composition', () => {
 });
 
 describe('usage reporting', () => {
-  /** Runs a method the way a transport does and returns the report on its outcome. */
-  async function run(
-    methodName: 'list' | 'show' | 'showStory',
-    input: unknown,
-    transport: 'cli' | 'mcp'
-  ) {
-    const ctx: ToolsetCtx = { transport, getService: () => ({}) as never };
-    return (await invokeToolsetMethod(toolset, methodName, input, ctx)).telemetry;
+  async function run(methodName: 'list' | 'show' | 'showStory', input: unknown) {
+    return (await invokeToolsetMethod(toolset, methodName, input, mcpCtx)).telemetry;
   }
 
-  it.each(['cli', 'mcp'] as const)('reports a listing on %s', async (transport) => {
-    const report = await run('list', { withStoryIds: false }, transport);
+  it('reports a listing', async () => {
+    const report = await run('list', { withStoryIds: false });
 
     expect(report).toEqual({
       toolset: 'docs',
@@ -298,8 +292,8 @@ describe('usage reporting', () => {
     });
   });
 
-  it.each(['cli', 'mcp'] as const)('reports a lookup on %s', async (transport) => {
-    const report = await run('show', { id: 'button' }, transport);
+  it('reports a lookup', async () => {
+    const report = await run('show', { id: 'button' });
 
     expect(report).toEqual({
       toolset: 'docs',
@@ -310,13 +304,13 @@ describe('usage reporting', () => {
   });
 
   it('reports a miss as not found', async () => {
-    const report = await run('show', { id: 'nope' }, 'mcp');
+    const report = await run('show', { id: 'nope' });
 
     expect(report?.counters).toMatchObject({ componentId: 'nope', found: false });
   });
 
-  it.each(['cli', 'mcp'] as const)('reports a story lookup by id on %s', async (transport) => {
-    const report = await run('showStory', { storyId: 'button--primary' }, transport);
+  it('reports a story lookup by id', async () => {
+    const report = await run('showStory', { storyId: 'button--primary' });
 
     expect(report).toEqual({
       toolset: 'docs',
@@ -332,7 +326,7 @@ describe('usage reporting', () => {
   });
 
   it('reports a story lookup by name with the resolved story id', async () => {
-    const report = await run('showStory', { componentId: 'button', storyName: 'Primary' }, 'mcp');
+    const report = await run('showStory', { componentId: 'button', storyName: 'Primary' });
 
     expect(report?.counters).toEqual({
       found: true,
@@ -343,7 +337,7 @@ describe('usage reporting', () => {
   });
 
   it('reports a missing story with the requested id', async () => {
-    const report = await run('showStory', { storyId: 'button--nope' }, 'mcp');
+    const report = await run('showStory', { storyId: 'button--nope' });
 
     expect(report?.counters).toMatchObject({
       found: false,
@@ -353,7 +347,7 @@ describe('usage reporting', () => {
   });
 
   it('reports a missing component without a story id', async () => {
-    const report = await run('showStory', { componentId: 'nope', storyName: 'Primary' }, 'mcp');
+    const report = await run('showStory', { componentId: 'nope', storyName: 'Primary' });
 
     expect(report?.counters).toMatchObject({ found: false, lookup: 'name' });
     expect(report?.counters.storyId).toBeUndefined();

--- a/code/core/src/shared/open-service/toolsets/docs/definition.test.ts
+++ b/code/core/src/shared/open-service/toolsets/docs/definition.test.ts
@@ -283,7 +283,7 @@ describe('usage reporting', () => {
       toolset: 'docs',
       tool: 'list',
       event: 'tool:listAllDocumentation',
-      counters: {
+      payload: {
         componentCount: 1,
         docsCount: 1,
         resultTokenCount: expect.any(Number),
@@ -299,14 +299,14 @@ describe('usage reporting', () => {
       toolset: 'docs',
       tool: 'show',
       event: 'tool:getDocumentation',
-      counters: { componentId: 'button', found: true, resultTokenCount: expect.any(Number) },
+      payload: { componentId: 'button', found: true, resultTokenCount: expect.any(Number) },
     });
   });
 
   it('reports a miss as not found', async () => {
     const report = await run('show', { id: 'nope' });
 
-    expect(report?.counters).toMatchObject({ componentId: 'nope', found: false });
+    expect(report?.payload).toMatchObject({ componentId: 'nope', found: false });
   });
 
   it('reports a story lookup by id', async () => {
@@ -316,7 +316,7 @@ describe('usage reporting', () => {
       toolset: 'docs',
       tool: 'show-story',
       event: 'tool:getDocumentationForStory',
-      counters: {
+      payload: {
         found: true,
         storyId: 'button--primary',
         lookup: 'storyId',
@@ -328,7 +328,7 @@ describe('usage reporting', () => {
   it('reports a story lookup by name with the resolved story id', async () => {
     const report = await run('showStory', { componentId: 'button', storyName: 'Primary' });
 
-    expect(report?.counters).toEqual({
+    expect(report?.payload).toEqual({
       found: true,
       storyId: 'button--primary',
       lookup: 'name',
@@ -339,7 +339,7 @@ describe('usage reporting', () => {
   it('reports a missing story with the requested id', async () => {
     const report = await run('showStory', { storyId: 'button--nope' });
 
-    expect(report?.counters).toMatchObject({
+    expect(report?.payload).toMatchObject({
       found: false,
       storyId: 'button--nope',
       lookup: 'storyId',
@@ -349,7 +349,7 @@ describe('usage reporting', () => {
   it('reports a missing component without a story id', async () => {
     const report = await run('showStory', { componentId: 'nope', storyName: 'Primary' });
 
-    expect(report?.counters).toMatchObject({ found: false, lookup: 'name' });
-    expect(report?.counters.storyId).toBeUndefined();
+    expect(report?.payload).toMatchObject({ found: false, lookup: 'name' });
+    expect(report?.payload.storyId).toBeUndefined();
   });
 });

--- a/code/core/src/shared/open-service/toolsets/docs/definition.test.ts
+++ b/code/core/src/shared/open-service/toolsets/docs/definition.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { ToolsetCtx } from '../../toolset-definition.ts';
+import { invokeToolsetMethod, type ToolsetCtx } from '../../toolset-definition.ts';
 import type { DocsAccess } from './access.ts';
 import { createDocsToolset } from './definition.ts';
 
@@ -49,7 +49,7 @@ const cliCtx: ToolsetCtx = { transport: 'cli', getService: () => ({}) as never }
 
 describe('docs.list', () => {
   it('returns the manifests from the access and renders the list Markdown', async () => {
-    const outcome = await toolset.methods.list.handler({ withStoryIds: false }, mcpCtx);
+    const outcome = await toolset.methods.list.handler({ withStoryIds: false });
 
     expect(outcome.ok).toBe(true);
     expect(Object.keys(outcome.data.manifests!.componentManifest.components)).toEqual(['button']);
@@ -59,7 +59,7 @@ describe('docs.list', () => {
   });
 
   it('includes story ids only when requested', async () => {
-    const outcome = await toolset.methods.list.handler({ withStoryIds: true }, mcpCtx);
+    const outcome = await toolset.methods.list.handler({ withStoryIds: true });
 
     expect(outcome.markdown).toContain('button--primary');
   });
@@ -272,83 +272,69 @@ describe('docs.showStory in a composition', () => {
 });
 
 describe('usage reporting', () => {
-  /** Runs a method the way a transport does; the handler reports usage inline. */
+  /** Runs a method the way a transport does and returns the report on its outcome. */
   async function run(
     methodName: 'list' | 'show' | 'showStory',
     input: unknown,
     transport: 'cli' | 'mcp'
   ) {
-    const events: Array<[string, Record<string, unknown>]> = [];
-    const ctx: ToolsetCtx = {
-      transport,
-      getService: () => ({}) as never,
-      telemetry: async (event, payload) => {
-        events.push([event, payload]);
-      },
-    };
-
-    await toolset.methods[methodName].handler(input as never, ctx);
-
-    return events;
+    const ctx: ToolsetCtx = { transport, getService: () => ({}) as never };
+    return (await invokeToolsetMethod(toolset, methodName, input, ctx)).telemetry;
   }
 
   it.each(['cli', 'mcp'] as const)('reports a listing on %s', async (transport) => {
-    const events = await run('list', { withStoryIds: false }, transport);
+    const report = await run('list', { withStoryIds: false }, transport);
 
-    expect(events).toEqual([
-      [
-        'tool:listAllDocumentation',
-        {
-          componentCount: 1,
-          docsCount: 1,
-          resultTokenCount: expect.any(Number),
-          sourceCount: undefined,
-        },
-      ],
-    ]);
+    expect(report).toEqual({
+      toolset: 'docs',
+      tool: 'list',
+      event: 'tool:listAllDocumentation',
+      counters: {
+        componentCount: 1,
+        docsCount: 1,
+        resultTokenCount: expect.any(Number),
+        sourceCount: undefined,
+      },
+    });
   });
 
   it.each(['cli', 'mcp'] as const)('reports a lookup on %s', async (transport) => {
-    const events = await run('show', { id: 'button' }, transport);
+    const report = await run('show', { id: 'button' }, transport);
 
-    expect(events).toEqual([
-      [
-        'tool:getDocumentation',
-        { componentId: 'button', found: true, resultTokenCount: expect.any(Number) },
-      ],
-    ]);
+    expect(report).toEqual({
+      toolset: 'docs',
+      tool: 'show',
+      event: 'tool:getDocumentation',
+      counters: { componentId: 'button', found: true, resultTokenCount: expect.any(Number) },
+    });
   });
 
   it('reports a miss as not found', async () => {
-    const [[, payload] = []] = await run('show', { id: 'nope' }, 'mcp');
+    const report = await run('show', { id: 'nope' }, 'mcp');
 
-    expect(payload).toMatchObject({ componentId: 'nope', found: false });
+    expect(report?.counters).toMatchObject({ componentId: 'nope', found: false });
   });
 
   it.each(['cli', 'mcp'] as const)('reports a story lookup by id on %s', async (transport) => {
-    const events = await run('showStory', { storyId: 'button--primary' }, transport);
+    const report = await run('showStory', { storyId: 'button--primary' }, transport);
 
-    expect(events).toEqual([
-      [
-        'tool:getDocumentationForStory',
-        {
-          found: true,
-          storyId: 'button--primary',
-          lookup: 'storyId',
-          resultTokenCount: expect.any(Number),
-        },
-      ],
-    ]);
+    expect(report).toEqual({
+      toolset: 'docs',
+      tool: 'show-story',
+      event: 'tool:getDocumentationForStory',
+      counters: {
+        found: true,
+        storyId: 'button--primary',
+        lookup: 'storyId',
+        resultTokenCount: expect.any(Number),
+      },
+    });
   });
 
   it('reports a story lookup by name with the resolved story id', async () => {
-    const [[, payload] = []] = await run(
-      'showStory',
-      { componentId: 'button', storyName: 'Primary' },
-      'mcp'
-    );
+    const report = await run('showStory', { componentId: 'button', storyName: 'Primary' }, 'mcp');
 
-    expect(payload).toEqual({
+    expect(report?.counters).toEqual({
       found: true,
       storyId: 'button--primary',
       lookup: 'name',
@@ -357,19 +343,19 @@ describe('usage reporting', () => {
   });
 
   it('reports a missing story with the requested id', async () => {
-    const [[, payload] = []] = await run('showStory', { storyId: 'button--nope' }, 'mcp');
+    const report = await run('showStory', { storyId: 'button--nope' }, 'mcp');
 
-    expect(payload).toMatchObject({ found: false, storyId: 'button--nope', lookup: 'storyId' });
+    expect(report?.counters).toMatchObject({
+      found: false,
+      storyId: 'button--nope',
+      lookup: 'storyId',
+    });
   });
 
   it('reports a missing component without a story id', async () => {
-    const [[, payload] = []] = await run(
-      'showStory',
-      { componentId: 'nope', storyName: 'Primary' },
-      'mcp'
-    );
+    const report = await run('showStory', { componentId: 'nope', storyName: 'Primary' }, 'mcp');
 
-    expect(payload).toMatchObject({ found: false, lookup: 'name' });
-    expect(payload!.storyId).toBeUndefined();
+    expect(report?.counters).toMatchObject({ found: false, lookup: 'name' });
+    expect(report?.counters.storyId).toBeUndefined();
   });
 });

--- a/code/core/src/shared/open-service/toolsets/docs/definition.test.ts
+++ b/code/core/src/shared/open-service/toolsets/docs/definition.test.ts
@@ -282,7 +282,7 @@ describe('usage reporting', () => {
     expect(report).toEqual({
       toolset: 'docs',
       tool: 'list',
-      event: 'tool:listAllDocumentation',
+      event: 'tool:docs_list',
       payload: {
         componentCount: 1,
         docsCount: 1,
@@ -298,7 +298,7 @@ describe('usage reporting', () => {
     expect(report).toEqual({
       toolset: 'docs',
       tool: 'show',
-      event: 'tool:getDocumentation',
+      event: 'tool:docs_show',
       payload: { componentId: 'button', found: true, resultTokenCount: expect.any(Number) },
     });
   });
@@ -315,7 +315,7 @@ describe('usage reporting', () => {
     expect(report).toEqual({
       toolset: 'docs',
       tool: 'show-story',
-      event: 'tool:getDocumentationForStory',
+      event: 'tool:docs_showStory',
       payload: {
         found: true,
         storyId: 'button--primary',

--- a/code/core/src/shared/open-service/toolsets/docs/definition.test.ts
+++ b/code/core/src/shared/open-service/toolsets/docs/definition.test.ts
@@ -273,7 +273,11 @@ describe('docs.showStory in a composition', () => {
 
 describe('usage reporting', () => {
   /** Runs a method the way a transport does; the handler reports usage inline. */
-  async function run(methodName: 'list' | 'show', input: unknown, transport: 'cli' | 'mcp') {
+  async function run(
+    methodName: 'list' | 'show' | 'showStory',
+    input: unknown,
+    transport: 'cli' | 'mcp'
+  ) {
     const events: Array<[string, Record<string, unknown>]> = [];
     const ctx: ToolsetCtx = {
       transport,
@@ -289,23 +293,83 @@ describe('usage reporting', () => {
   }
 
   it.each(['cli', 'mcp'] as const)('reports a listing on %s', async (transport) => {
-    const [[event, payload] = []] = await run('list', { withStoryIds: false }, transport);
+    const events = await run('list', { withStoryIds: false }, transport);
 
-    expect(event).toBe('tool:listAllDocumentation');
-    expect(payload).toMatchObject({ componentCount: 1, docsCount: 1 });
-    expect(payload!.resultTokenCount).toBeGreaterThan(0);
+    expect(events).toEqual([
+      [
+        'tool:listAllDocumentation',
+        {
+          componentCount: 1,
+          docsCount: 1,
+          resultTokenCount: expect.any(Number),
+          sourceCount: undefined,
+        },
+      ],
+    ]);
   });
 
   it.each(['cli', 'mcp'] as const)('reports a lookup on %s', async (transport) => {
-    const [[event, payload] = []] = await run('show', { id: 'button' }, transport);
+    const events = await run('show', { id: 'button' }, transport);
 
-    expect(event).toBe('tool:getDocumentation');
-    expect(payload).toMatchObject({ componentId: 'button', found: true });
+    expect(events).toEqual([
+      [
+        'tool:getDocumentation',
+        { componentId: 'button', found: true, resultTokenCount: expect.any(Number) },
+      ],
+    ]);
   });
 
   it('reports a miss as not found', async () => {
     const [[, payload] = []] = await run('show', { id: 'nope' }, 'mcp');
 
     expect(payload).toMatchObject({ componentId: 'nope', found: false });
+  });
+
+  it.each(['cli', 'mcp'] as const)('reports a story lookup by id on %s', async (transport) => {
+    const events = await run('showStory', { storyId: 'button--primary' }, transport);
+
+    expect(events).toEqual([
+      [
+        'tool:getDocumentationForStory',
+        {
+          found: true,
+          storyId: 'button--primary',
+          lookup: 'storyId',
+          resultTokenCount: expect.any(Number),
+        },
+      ],
+    ]);
+  });
+
+  it('reports a story lookup by name with the resolved story id', async () => {
+    const [[, payload] = []] = await run(
+      'showStory',
+      { componentId: 'button', storyName: 'Primary' },
+      'mcp'
+    );
+
+    expect(payload).toEqual({
+      found: true,
+      storyId: 'button--primary',
+      lookup: 'name',
+      resultTokenCount: expect.any(Number),
+    });
+  });
+
+  it('reports a missing story with the requested id', async () => {
+    const [[, payload] = []] = await run('showStory', { storyId: 'button--nope' }, 'mcp');
+
+    expect(payload).toMatchObject({ found: false, storyId: 'button--nope', lookup: 'storyId' });
+  });
+
+  it('reports a missing component without a story id', async () => {
+    const [[, payload] = []] = await run(
+      'showStory',
+      { componentId: 'nope', storyName: 'Primary' },
+      'mcp'
+    );
+
+    expect(payload).toMatchObject({ found: false, lookup: 'name' });
+    expect(payload!.storyId).toBeUndefined();
   });
 });

--- a/code/core/src/shared/open-service/toolsets/docs/definition.ts
+++ b/code/core/src/shared/open-service/toolsets/docs/definition.ts
@@ -111,6 +111,7 @@ function resolveShow({ entry, sourceError }: DocsShowOutput): ShowResolution {
 }
 
 type ComponentEntry = Extract<ResolvedDocsEntry, { kind: 'component' }>;
+type ComponentStory = NonNullable<ComponentEntry['component']['stories']>[number];
 
 /** The `showStory` counterpart of {@link ShowResolution}. */
 type ShowStoryResolution =
@@ -118,7 +119,7 @@ type ShowStoryResolution =
   | { kind: 'source-error'; message: string }
   | { kind: 'component-missing' }
   | { kind: 'story-missing'; component: ComponentEntry['component'] }
-  | { kind: 'found'; component: ComponentEntry['component']; storyName: string };
+  | { kind: 'found'; component: ComponentEntry['component']; story: ComponentStory };
 
 /** Whether a `showStory` input names a story at all: a story id, or a complete name pair. */
 function isShowStorySelector({ storyId, componentId, storyName }: DocsShowStoryOutput): boolean {
@@ -151,9 +152,7 @@ function resolveShowStory(data: DocsShowStoryOutput): ShowStoryResolution {
     storyId !== undefined
       ? component.stories?.find((candidate) => candidate.id === storyId)
       : component.stories?.find((candidate) => candidate.name === storyName);
-  return story
-    ? { kind: 'found', component, storyName: story.name }
-    : { kind: 'story-missing', component };
+  return story ? { kind: 'found', component, story } : { kind: 'story-missing', component };
 }
 
 /**
@@ -217,8 +216,11 @@ function formatAvailableStories(stories: ComponentEntry['component']['stories'])
 }
 
 /** Pure renderer for `showStory`. */
-function renderShowStory(data: DocsShowStoryOutput, ctx: ToolsetCtx): string {
-  const resolution = resolveShowStory(data);
+function renderShowStory(
+  resolution: ShowStoryResolution,
+  data: DocsShowStoryOutput,
+  ctx: ToolsetCtx
+): string {
   switch (resolution.kind) {
     case 'input-invalid':
       return `Provide either \`storyId\`, or both \`componentId\` and \`storyName\`. Story ids are listed by the ${getToolName(ctx)(DOCS_METHOD_REFS.list)} tool with \`withStoryIds: true\` and in ${getToolName(ctx)(DOCS_METHOD_REFS.show)} output.`;
@@ -235,7 +237,7 @@ function renderShowStory(data: DocsShowStoryOutput, ctx: ToolsetCtx): string {
         : `Story "${data.storyName}" not found for component "${data.componentId}". Available stories: ${availableStories}`;
     }
     case 'found':
-      return formatStoryDocumentation(resolution.component, resolution.storyName);
+      return formatStoryDocumentation(resolution.component, resolution.story.name);
     default: {
       const exhaustive: never = resolution;
       return exhaustive;
@@ -373,7 +375,6 @@ export function createDocsToolset(options: CreateDocsToolsetOptions) {
           const counted = selectReportedManifests(data);
           if (counted) {
             await reportToolsetTelemetry(ctx, 'tool:listAllDocumentation', {
-              toolset: 'docs',
               componentCount: Object.keys(counted.componentManifest.components).length,
               docsCount: Object.keys(counted.docsManifest?.docs ?? {}).length,
               resultTokenCount: estimateTokens(markdown),
@@ -398,7 +399,6 @@ export function createDocsToolset(options: CreateDocsToolsetOptions) {
           const markdown = renderShow(data, ctx);
 
           await reportToolsetTelemetry(ctx, 'tool:getDocumentation', {
-            toolset: 'docs',
             componentId: id,
             found: data.entry !== undefined,
             resultTokenCount: estimateTokens(markdown),
@@ -437,11 +437,19 @@ export function createDocsToolset(options: CreateDocsToolsetOptions) {
               ? { ...request, entry: await selected.access.resolve(resolveId) }
               : { ...request, sourceError: selected.sourceError };
 
-          const markdown = renderShowStory(data, ctx);
+          const resolution = resolveShowStory(data);
+          const markdown = renderShowStory(resolution, data, ctx);
 
-          return isDocsShowStoryError(data)
-            ? { ok: false, data, markdown }
-            : { ok: true, data, markdown };
+          await reportToolsetTelemetry(ctx, 'tool:getDocumentationForStory', {
+            found: resolution.kind === 'found',
+            storyId: resolution.kind === 'found' ? resolution.story.id : storyId,
+            lookup: storyId !== undefined ? 'storyId' : 'name',
+            resultTokenCount: estimateTokens(markdown),
+          });
+
+          return resolution.kind === 'found'
+            ? { ok: true, data, markdown }
+            : { ok: false, data, markdown };
         },
       },
     },

--- a/code/core/src/shared/open-service/toolsets/docs/definition.ts
+++ b/code/core/src/shared/open-service/toolsets/docs/definition.ts
@@ -1,11 +1,6 @@
 import * as v from 'valibot';
 
-import {
-  defineToolset,
-  reportToolsetTelemetry,
-  type ToolsetCtx,
-  type ToolsetOutcome,
-} from '../../toolset-definition.ts';
+import { defineToolset, type ToolsetCtx, type ToolsetOutcome } from '../../toolset-definition.ts';
 import { getToolName, type ToolsetMethodId } from '../../toolset-names.ts';
 import type { DocsAccess, ResolvedDocsEntry } from './access.ts';
 import {
@@ -361,7 +356,7 @@ export function createDocsToolset(options: CreateDocsToolsetOptions) {
         }),
         title: 'List All Documentation',
         description: describeList,
-        handler: async (input, ctx): Promise<ToolsetOutcome<DocsListOutput, never>> => {
+        handler: async (input): Promise<ToolsetOutcome<DocsListOutput, never>> => {
           const { withStoryIds } = input;
           const data: DocsListOutput = multiSource
             ? { withStoryIds, sources: await listSources(sources!, { withStoryIds }) }
@@ -373,16 +368,24 @@ export function createDocsToolset(options: CreateDocsToolsetOptions) {
 
           // A listing of nothing but errors is not a usage signal, so nothing is counted then.
           const counted = selectReportedManifests(data);
-          if (counted) {
-            await reportToolsetTelemetry(ctx, 'tool:listAllDocumentation', {
-              componentCount: Object.keys(counted.componentManifest.components).length,
-              docsCount: Object.keys(counted.docsManifest?.docs ?? {}).length,
-              resultTokenCount: estimateTokens(markdown),
-              sourceCount: data.sources?.length,
-            });
-          }
-
-          return { ok: true, data, markdown };
+          return {
+            ok: true,
+            data,
+            markdown,
+            ...(counted
+              ? {
+                  telemetry: {
+                    event: 'tool:listAllDocumentation',
+                    counters: {
+                      componentCount: Object.keys(counted.componentManifest.components).length,
+                      docsCount: Object.keys(counted.docsManifest?.docs ?? {}).length,
+                      resultTokenCount: estimateTokens(markdown),
+                      sourceCount: data.sources?.length,
+                    },
+                  },
+                }
+              : {}),
+          };
         },
       },
       [DOCS_METHOD_NAMES.show]: {
@@ -398,15 +401,17 @@ export function createDocsToolset(options: CreateDocsToolsetOptions) {
 
           const markdown = renderShow(data, ctx);
 
-          await reportToolsetTelemetry(ctx, 'tool:getDocumentation', {
-            componentId: id,
-            found: data.entry !== undefined,
-            resultTokenCount: estimateTokens(markdown),
-          });
-
+          const telemetry = {
+            event: 'tool:getDocumentation',
+            counters: {
+              componentId: id,
+              found: data.entry !== undefined,
+              resultTokenCount: estimateTokens(markdown),
+            },
+          };
           return isDocsShowError(data)
-            ? { ok: false, data, markdown }
-            : { ok: true, data, markdown };
+            ? { ok: false, data, markdown, telemetry }
+            : { ok: true, data, markdown, telemetry };
         },
       },
       [DOCS_METHOD_NAMES.showStory]: {
@@ -440,16 +445,18 @@ export function createDocsToolset(options: CreateDocsToolsetOptions) {
           const resolution = resolveShowStory(data);
           const markdown = renderShowStory(resolution, data, ctx);
 
-          await reportToolsetTelemetry(ctx, 'tool:getDocumentationForStory', {
-            found: resolution.kind === 'found',
-            storyId: resolution.kind === 'found' ? resolution.story.id : storyId,
-            lookup: storyId !== undefined ? 'storyId' : 'name',
-            resultTokenCount: estimateTokens(markdown),
-          });
-
+          const telemetry = {
+            event: 'tool:getDocumentationForStory',
+            counters: {
+              found: resolution.kind === 'found',
+              storyId: resolution.kind === 'found' ? resolution.story.id : storyId,
+              lookup: storyId !== undefined ? 'storyId' : 'name',
+              resultTokenCount: estimateTokens(markdown),
+            },
+          };
           return resolution.kind === 'found'
-            ? { ok: true, data, markdown }
-            : { ok: false, data, markdown };
+            ? { ok: true, data, markdown, telemetry }
+            : { ok: false, data, markdown, telemetry };
         },
       },
     },

--- a/code/core/src/shared/open-service/toolsets/docs/definition.ts
+++ b/code/core/src/shared/open-service/toolsets/docs/definition.ts
@@ -376,7 +376,7 @@ export function createDocsToolset(options: CreateDocsToolsetOptions) {
               ? {
                   telemetry: {
                     event: 'tool:listAllDocumentation',
-                    counters: {
+                    payload: {
                       componentCount: Object.keys(counted.componentManifest.components).length,
                       docsCount: Object.keys(counted.docsManifest?.docs ?? {}).length,
                       resultTokenCount: estimateTokens(markdown),
@@ -403,7 +403,7 @@ export function createDocsToolset(options: CreateDocsToolsetOptions) {
 
           const telemetry = {
             event: 'tool:getDocumentation',
-            counters: {
+            payload: {
               componentId: id,
               found: data.entry !== undefined,
               resultTokenCount: estimateTokens(markdown),
@@ -447,7 +447,7 @@ export function createDocsToolset(options: CreateDocsToolsetOptions) {
 
           const telemetry = {
             event: 'tool:getDocumentationForStory',
-            counters: {
+            payload: {
               found: resolution.kind === 'found',
               storyId: resolution.kind === 'found' ? resolution.story.id : storyId,
               lookup: storyId !== undefined ? 'storyId' : 'name',

--- a/code/core/src/shared/open-service/toolsets/docs/definition.ts
+++ b/code/core/src/shared/open-service/toolsets/docs/definition.ts
@@ -375,7 +375,6 @@ export function createDocsToolset(options: CreateDocsToolsetOptions) {
             ...(counted
               ? {
                   telemetry: {
-                    event: 'tool:listAllDocumentation',
                     payload: {
                       componentCount: Object.keys(counted.componentManifest.components).length,
                       docsCount: Object.keys(counted.docsManifest?.docs ?? {}).length,
@@ -402,7 +401,6 @@ export function createDocsToolset(options: CreateDocsToolsetOptions) {
           const markdown = renderShow(data, ctx);
 
           const telemetry = {
-            event: 'tool:getDocumentation',
             payload: {
               componentId: id,
               found: data.entry !== undefined,
@@ -446,7 +444,6 @@ export function createDocsToolset(options: CreateDocsToolsetOptions) {
           const markdown = renderShowStory(resolution, data, ctx);
 
           const telemetry = {
-            event: 'tool:getDocumentationForStory',
             payload: {
               found: resolution.kind === 'found',
               storyId: resolution.kind === 'found' ? resolution.story.id : storyId,

--- a/code/core/src/shared/open-service/toolsets/review/definition.test.ts
+++ b/code/core/src/shared/open-service/toolsets/review/definition.test.ts
@@ -5,7 +5,11 @@ import {
   OpenServiceMissingOriginError,
   OpenServiceUnknownStoryIdsError,
 } from '../../../../server-errors.ts';
-import { resolveToolsetDescription, type ToolsetCtx } from '../../toolset-definition.ts';
+import {
+  invokeToolsetMethod,
+  resolveToolsetDescription,
+  type ToolsetCtx,
+} from '../../toolset-definition.ts';
 import { reviewToolset } from './definition.ts';
 
 const reviewUrl = 'http://localhost:6006/?path=/review/';
@@ -32,7 +36,9 @@ function createReview(
   overrides: Partial<v.InferInput<typeof reviewToolset.methods.create.input>> = {},
   ctx: ToolsetCtx = cliCtx
 ) {
-  return reviewToolset.methods.create.handler(
+  return invokeToolsetMethod(
+    reviewToolset,
+    'create',
     v.parse(reviewToolset.methods.create.input, { ...input, ...overrides }),
     ctx
   );
@@ -55,6 +61,17 @@ beforeEach(() => {
 });
 
 describe('review.create', () => {
+  it('reports what the published review contains', async () => {
+    const outcome = await createReview();
+
+    expect(outcome.telemetry).toEqual({
+      toolset: 'review',
+      tool: 'create',
+      event: 'tool:displayReview',
+      counters: { collectionCount: 1, storyCount: 1, changedFileCount: 1 },
+    });
+  });
+
   it('publishes the review and returns its page URL plus what it contains', async () => {
     const outcome = await createReview();
 

--- a/code/core/src/shared/open-service/toolsets/review/definition.test.ts
+++ b/code/core/src/shared/open-service/toolsets/review/definition.test.ts
@@ -67,7 +67,7 @@ describe('review.create', () => {
     expect(outcome.telemetry).toEqual({
       toolset: 'review',
       tool: 'create',
-      event: 'tool:displayReview',
+      event: 'tool:review_create',
       payload: { collectionCount: 1, storyCount: 1, changedFileCount: 1 },
     });
   });

--- a/code/core/src/shared/open-service/toolsets/review/definition.test.ts
+++ b/code/core/src/shared/open-service/toolsets/review/definition.test.ts
@@ -68,7 +68,7 @@ describe('review.create', () => {
       toolset: 'review',
       tool: 'create',
       event: 'tool:displayReview',
-      counters: { collectionCount: 1, storyCount: 1, changedFileCount: 1 },
+      payload: { collectionCount: 1, storyCount: 1, changedFileCount: 1 },
     });
   });
 

--- a/code/core/src/shared/open-service/toolsets/review/definition.ts
+++ b/code/core/src/shared/open-service/toolsets/review/definition.ts
@@ -5,12 +5,7 @@ import {
   describeUnknownStoryIds,
   OpenServiceUnknownStoryIdsError,
 } from '../../../../server-errors.ts';
-import {
-  defineToolset,
-  reportToolsetTelemetry,
-  type ToolsetCtx,
-  type ToolsetOutcome,
-} from '../../toolset-definition.ts';
+import { defineToolset, type ToolsetCtx, type ToolsetOutcome } from '../../toolset-definition.ts';
 import { getToolName } from '../../toolset-names.ts';
 import type { ReviewService } from '../../services/review/definition.ts';
 
@@ -176,19 +171,21 @@ export const reviewToolset = defineToolset({
           0
         );
 
-        await reportToolsetTelemetry(ctx, 'tool:displayReview', {
-          collectionCount,
-          storyCount,
-          changedFileCount: review.changedFiles.length,
-        });
-
         const data: ReviewCreateOutput = {
           reviewUrl: `${ctx.origin.replace(/\/$/, '')}/?path=${REVIEW_PAGE_PATH}`,
           collectionCount,
           storyCount,
         };
 
-        return { ok: true, data, markdown: formatReviewApplied(data, ctx) };
+        return {
+          ok: true,
+          data,
+          markdown: formatReviewApplied(data, ctx),
+          telemetry: {
+            event: 'tool:displayReview',
+            counters: { collectionCount, storyCount, changedFileCount: review.changedFiles.length },
+          },
+        };
       },
     },
   },

--- a/code/core/src/shared/open-service/toolsets/review/definition.ts
+++ b/code/core/src/shared/open-service/toolsets/review/definition.ts
@@ -182,7 +182,6 @@ export const reviewToolset = defineToolset({
           data,
           markdown: formatReviewApplied(data, ctx),
           telemetry: {
-            event: 'tool:displayReview',
             payload: { collectionCount, storyCount, changedFileCount: review.changedFiles.length },
           },
         };

--- a/code/core/src/shared/open-service/toolsets/review/definition.ts
+++ b/code/core/src/shared/open-service/toolsets/review/definition.ts
@@ -183,7 +183,7 @@ export const reviewToolset = defineToolset({
           markdown: formatReviewApplied(data, ctx),
           telemetry: {
             event: 'tool:displayReview',
-            counters: { collectionCount, storyCount, changedFileCount: review.changedFiles.length },
+            payload: { collectionCount, storyCount, changedFileCount: review.changedFiles.length },
           },
         };
       },

--- a/code/core/src/shared/open-service/toolsets/review/definition.ts
+++ b/code/core/src/shared/open-service/toolsets/review/definition.ts
@@ -177,7 +177,6 @@ export const reviewToolset = defineToolset({
         );
 
         await reportToolsetTelemetry(ctx, 'tool:displayReview', {
-          toolset: 'dev',
           collectionCount,
           storyCount,
           changedFileCount: review.changedFiles.length,

--- a/code/core/src/shared/open-service/toolsets/stories/definition.test.ts
+++ b/code/core/src/shared/open-service/toolsets/stories/definition.test.ts
@@ -191,7 +191,6 @@ describe('stories.preview', () => {
     await runPreview([{ storyId: 'button--primary' }, { storyId: 'gone--story' }]);
 
     expect(telemetry).toHaveBeenCalledWith('tool:previewStories', {
-      toolset: 'dev',
       inputStoryCount: 2,
       outputStoryCount: 2,
     });
@@ -322,7 +321,6 @@ describe('stories.changed', () => {
     await runChanged();
 
     expect(telemetry).toHaveBeenCalledWith('tool:getChangedStories', {
-      toolset: 'dev',
       storyCount: 1,
       newStoryCount: 1,
       modifiedStoryCount: 0,
@@ -463,7 +461,6 @@ describe('stories.findByComponent', () => {
     await runFindByComponent({ componentPaths: [componentPath, orphanPath] });
 
     expect(telemetry).toHaveBeenCalledWith('tool:getStoriesByComponent', {
-      toolset: 'dev',
       componentCount: 2,
       matchedComponentCount: 1,
       totalMatchCount: 1,

--- a/code/core/src/shared/open-service/toolsets/stories/definition.test.ts
+++ b/code/core/src/shared/open-service/toolsets/stories/definition.test.ts
@@ -13,7 +13,11 @@ import {
   OpenServiceModuleGraphUnavailableError,
 } from '../../../../server-errors.ts';
 import { CHANGE_DETECTION_STATUS_TYPE_ID } from '../../../status-store/index.ts';
-import { resolveToolsetDescription, type ToolsetCtx } from '../../toolset-definition.ts';
+import {
+  invokeToolsetMethod,
+  resolveToolsetDescription,
+  type ToolsetCtx,
+} from '../../toolset-definition.ts';
 import { createStoriesToolset, type StoriesToolset } from './definition.ts';
 
 vi.mock('node:fs', { spy: true });
@@ -55,7 +59,6 @@ const getStatuses = vi.fn();
 const graphStatus = vi.fn();
 const changeDetectionReadiness = vi.fn();
 const storiesForFiles = vi.fn();
-const telemetry = vi.fn();
 const cwd = vi.spyOn(process, 'cwd');
 const moduleGraph = {
   queries: {
@@ -89,11 +92,16 @@ function runPreview(
   ctx: ToolsetCtx = cliCtx,
   target: StoriesToolset = toolset
 ) {
-  return target.methods.preview.handler(v.parse(target.methods.preview.input, { stories }), ctx);
+  return invokeToolsetMethod(
+    target,
+    'preview',
+    v.parse(target.methods.preview.input, { stories }),
+    ctx
+  );
 }
 
 function runChanged(ctx: ToolsetCtx = cliCtx, target: StoriesToolset = toolset) {
-  return target.methods.changed.handler(v.parse(target.methods.changed.input, {}), ctx);
+  return invokeToolsetMethod(target, 'changed', v.parse(target.methods.changed.input, {}), ctx);
 }
 
 function runFindByComponent(
@@ -101,7 +109,9 @@ function runFindByComponent(
   ctx: ToolsetCtx = cliCtx,
   target: StoriesToolset = toolset
 ) {
-  return target.methods.findByComponent.handler(
+  return invokeToolsetMethod(
+    target,
+    'findByComponent',
     v.parse(target.methods.findByComponent.input, input),
     ctx
   );
@@ -133,7 +143,6 @@ beforeEach(() => {
     transport: 'cli',
     origin: 'http://localhost:6006',
     getService: vi.fn(() => moduleGraph) as ToolsetCtx['getService'],
-    telemetry,
   };
   mcpCtx = { ...cliCtx, transport: 'mcp' };
   getIndex.mockResolvedValue(index);
@@ -188,11 +197,13 @@ describe('stories.preview', () => {
   });
 
   it('reports the story counts it resolved', async () => {
-    await runPreview([{ storyId: 'button--primary' }, { storyId: 'gone--story' }]);
+    const outcome = await runPreview([{ storyId: 'button--primary' }, { storyId: 'gone--story' }]);
 
-    expect(telemetry).toHaveBeenCalledWith('tool:previewStories', {
-      inputStoryCount: 2,
-      outputStoryCount: 2,
+    expect(outcome.telemetry).toEqual({
+      toolset: 'stories',
+      tool: 'preview',
+      event: 'tool:previewStories',
+      counters: { inputStoryCount: 2, outputStoryCount: 2 },
     });
   });
 
@@ -318,13 +329,13 @@ describe('stories.changed', () => {
   it('reports the per-status counts', async () => {
     markChanged('button--primary', 'status-value:new');
 
-    await runChanged();
+    const outcome = await runChanged();
 
-    expect(telemetry).toHaveBeenCalledWith('tool:getChangedStories', {
-      storyCount: 1,
-      newStoryCount: 1,
-      modifiedStoryCount: 0,
-      affectedStoryCount: 0,
+    expect(outcome.telemetry).toEqual({
+      toolset: 'stories',
+      tool: 'changed',
+      event: 'tool:getChangedStories',
+      counters: { storyCount: 1, newStoryCount: 1, modifiedStoryCount: 0, affectedStoryCount: 0 },
     });
   });
 
@@ -458,13 +469,13 @@ describe('stories.findByComponent', () => {
   });
 
   it('reports how many of the requested components matched', async () => {
-    await runFindByComponent({ componentPaths: [componentPath, orphanPath] });
+    const outcome = await runFindByComponent({ componentPaths: [componentPath, orphanPath] });
 
-    expect(telemetry).toHaveBeenCalledWith('tool:getStoriesByComponent', {
-      componentCount: 2,
-      matchedComponentCount: 1,
-      totalMatchCount: 1,
-      maxDistance: 3,
+    expect(outcome.telemetry).toEqual({
+      toolset: 'stories',
+      tool: 'find-by-component',
+      event: 'tool:getStoriesByComponent',
+      counters: { componentCount: 2, matchedComponentCount: 1, totalMatchCount: 1, maxDistance: 3 },
     });
   });
 

--- a/code/core/src/shared/open-service/toolsets/stories/definition.test.ts
+++ b/code/core/src/shared/open-service/toolsets/stories/definition.test.ts
@@ -202,7 +202,7 @@ describe('stories.preview', () => {
     expect(outcome.telemetry).toEqual({
       toolset: 'stories',
       tool: 'preview',
-      event: 'tool:previewStories',
+      event: 'tool:stories_preview',
       payload: { inputStoryCount: 2, outputStoryCount: 2 },
     });
   });
@@ -334,7 +334,7 @@ describe('stories.changed', () => {
     expect(outcome.telemetry).toEqual({
       toolset: 'stories',
       tool: 'changed',
-      event: 'tool:getChangedStories',
+      event: 'tool:stories_changed',
       payload: { storyCount: 1, newStoryCount: 1, modifiedStoryCount: 0, affectedStoryCount: 0 },
     });
   });
@@ -474,7 +474,7 @@ describe('stories.findByComponent', () => {
     expect(outcome.telemetry).toEqual({
       toolset: 'stories',
       tool: 'find-by-component',
-      event: 'tool:getStoriesByComponent',
+      event: 'tool:stories_findByComponent',
       payload: { componentCount: 2, matchedComponentCount: 1, totalMatchCount: 1, maxDistance: 3 },
     });
   });

--- a/code/core/src/shared/open-service/toolsets/stories/definition.test.ts
+++ b/code/core/src/shared/open-service/toolsets/stories/definition.test.ts
@@ -203,7 +203,7 @@ describe('stories.preview', () => {
       toolset: 'stories',
       tool: 'preview',
       event: 'tool:previewStories',
-      counters: { inputStoryCount: 2, outputStoryCount: 2 },
+      payload: { inputStoryCount: 2, outputStoryCount: 2 },
     });
   });
 
@@ -335,7 +335,7 @@ describe('stories.changed', () => {
       toolset: 'stories',
       tool: 'changed',
       event: 'tool:getChangedStories',
-      counters: { storyCount: 1, newStoryCount: 1, modifiedStoryCount: 0, affectedStoryCount: 0 },
+      payload: { storyCount: 1, newStoryCount: 1, modifiedStoryCount: 0, affectedStoryCount: 0 },
     });
   });
 
@@ -475,7 +475,7 @@ describe('stories.findByComponent', () => {
       toolset: 'stories',
       tool: 'find-by-component',
       event: 'tool:getStoriesByComponent',
-      counters: { componentCount: 2, matchedComponentCount: 1, totalMatchCount: 1, maxDistance: 3 },
+      payload: { componentCount: 2, matchedComponentCount: 1, totalMatchCount: 1, maxDistance: 3 },
     });
   });
 

--- a/code/core/src/shared/open-service/toolsets/stories/definition.ts
+++ b/code/core/src/shared/open-service/toolsets/stories/definition.ts
@@ -294,7 +294,6 @@ Use { absoluteStoryPath + exportName } only when you're already working in a spe
           });
 
           await reportToolsetTelemetry(ctx, 'tool:previewStories', {
-            toolset: 'dev',
             inputStoryCount: input.stories.length,
             outputStoryCount: data.stories.length,
           });
@@ -326,7 +325,6 @@ Use { absoluteStoryPath + exportName } only when you're already working in a spe
             if (isGitUnusableReadiness(changeDetection)) {
               const data = emptyChangedStories();
               await reportToolsetTelemetry(ctx, 'tool:getChangedStories', {
-                toolset: 'dev',
                 storyCount: 0,
                 newStoryCount: 0,
                 modifiedStoryCount: 0,
@@ -356,7 +354,6 @@ Use { absoluteStoryPath + exportName } only when you're already working in a spe
           };
 
           await reportToolsetTelemetry(ctx, 'tool:getChangedStories', {
-            toolset: 'dev',
             storyCount: data.stories.length,
             newStoryCount: data.counts.new,
             modifiedStoryCount: data.counts.modified,
@@ -408,7 +405,6 @@ Defaults to ${DEFAULT_MAX_DISTANCE}; raise it to widen recall, lower it to tight
             (result) => !result.pathNotFound && result.matches.length === 0
           ).length;
           await reportToolsetTelemetry(ctx, 'tool:getStoriesByComponent', {
-            toolset: 'dev',
             componentCount: input.componentPaths.length,
             matchedComponentCount: input.componentPaths.length - unmatchedCount,
             totalMatchCount: lookup.results.reduce(

--- a/code/core/src/shared/open-service/toolsets/stories/definition.ts
+++ b/code/core/src/shared/open-service/toolsets/stories/definition.ts
@@ -293,7 +293,6 @@ Use { absoluteStoryPath + exportName } only when you're already working in a spe
             data,
             markdown: formatPreviewStories(data, ctx, { reviewEnabled }),
             telemetry: {
-              event: 'tool:previewStories',
               payload: {
                 inputStoryCount: input.stories.length,
                 outputStoryCount: data.stories.length,
@@ -330,7 +329,6 @@ Use { absoluteStoryPath + exportName } only when you're already working in a spe
                 data,
                 markdown: formatChangedStories(data, ctx, { reviewEnabled }),
                 telemetry: {
-                  event: 'tool:getChangedStories',
                   payload: {
                     storyCount: 0,
                     newStoryCount: 0,
@@ -362,7 +360,6 @@ Use { absoluteStoryPath + exportName } only when you're already working in a spe
             data,
             markdown: formatChangedStories(data, ctx, { reviewEnabled }),
             telemetry: {
-              event: 'tool:getChangedStories',
               payload: {
                 storyCount: data.stories.length,
                 newStoryCount: data.counts.new,
@@ -420,7 +417,6 @@ Defaults to ${DEFAULT_MAX_DISTANCE}; raise it to widen recall, lower it to tight
             data,
             markdown: formatFindByComponent(data),
             telemetry: {
-              event: 'tool:getStoriesByComponent',
               payload: {
                 componentCount: input.componentPaths.length,
                 matchedComponentCount: input.componentPaths.length - unmatchedCount,

--- a/code/core/src/shared/open-service/toolsets/stories/definition.ts
+++ b/code/core/src/shared/open-service/toolsets/stories/definition.ts
@@ -11,12 +11,7 @@ import type {
   ModuleGraphService,
 } from '../../services/module-graph/definition.ts';
 import type { ModuleGraphIndexService } from '../../services/module-graph-index/definition.ts';
-import {
-  defineToolset,
-  reportToolsetTelemetry,
-  type ToolsetCtx,
-  type ToolsetOutcome,
-} from '../../toolset-definition.ts';
+import { defineToolset, type ToolsetCtx, type ToolsetOutcome } from '../../toolset-definition.ts';
 import { getToolName } from '../../toolset-names.ts';
 import type { StatusesByStoryIdAndTypeId } from '../../../status-store/index.ts';
 import { getChangedStories } from './changed.ts';
@@ -293,12 +288,18 @@ Use { absoluteStoryPath + exportName } only when you're already working in a spe
             stories: input.stories,
           });
 
-          await reportToolsetTelemetry(ctx, 'tool:previewStories', {
-            inputStoryCount: input.stories.length,
-            outputStoryCount: data.stories.length,
-          });
-
-          return { ok: true, data, markdown: formatPreviewStories(data, ctx, { reviewEnabled }) };
+          return {
+            ok: true,
+            data,
+            markdown: formatPreviewStories(data, ctx, { reviewEnabled }),
+            telemetry: {
+              event: 'tool:previewStories',
+              counters: {
+                inputStoryCount: input.stories.length,
+                outputStoryCount: data.stories.length,
+              },
+            },
+          };
         },
       },
       changed: {
@@ -324,16 +325,19 @@ Use { absoluteStoryPath + exportName } only when you're already working in a spe
           if (changeDetection.status !== 'ready') {
             if (isGitUnusableReadiness(changeDetection)) {
               const data = emptyChangedStories();
-              await reportToolsetTelemetry(ctx, 'tool:getChangedStories', {
-                storyCount: 0,
-                newStoryCount: 0,
-                modifiedStoryCount: 0,
-                affectedStoryCount: 0,
-              });
               return {
                 ok: true,
                 data,
                 markdown: formatChangedStories(data, ctx, { reviewEnabled }),
+                telemetry: {
+                  event: 'tool:getChangedStories',
+                  counters: {
+                    storyCount: 0,
+                    newStoryCount: 0,
+                    modifiedStoryCount: 0,
+                    affectedStoryCount: 0,
+                  },
+                },
               };
             }
             throw new OpenServiceModuleGraphUnavailableError({
@@ -353,14 +357,20 @@ Use { absoluteStoryPath + exportName } only when you're already working in a spe
             unreachableFiles: await detectUnreachableFiles({ git, moduleGraph }),
           };
 
-          await reportToolsetTelemetry(ctx, 'tool:getChangedStories', {
-            storyCount: data.stories.length,
-            newStoryCount: data.counts.new,
-            modifiedStoryCount: data.counts.modified,
-            affectedStoryCount: data.counts.affected,
-          });
-
-          return { ok: true, data, markdown: formatChangedStories(data, ctx, { reviewEnabled }) };
+          return {
+            ok: true,
+            data,
+            markdown: formatChangedStories(data, ctx, { reviewEnabled }),
+            telemetry: {
+              event: 'tool:getChangedStories',
+              counters: {
+                storyCount: data.stories.length,
+                newStoryCount: data.counts.new,
+                modifiedStoryCount: data.counts.modified,
+                affectedStoryCount: data.counts.affected,
+              },
+            },
+          };
         },
       },
       findByComponent: {
@@ -404,18 +414,24 @@ Defaults to ${DEFAULT_MAX_DISTANCE}; raise it to widen recall, lower it to tight
           const unmatchedCount = lookup.results.filter(
             (result) => !result.pathNotFound && result.matches.length === 0
           ).length;
-          await reportToolsetTelemetry(ctx, 'tool:getStoriesByComponent', {
-            componentCount: input.componentPaths.length,
-            matchedComponentCount: input.componentPaths.length - unmatchedCount,
-            totalMatchCount: lookup.results.reduce(
-              (total, result) => total + result.matches.length,
-              0
-            ),
-            maxDistance,
-          });
-
           const data: FindByComponentOutput = { results: lookup.results, maxDistance };
-          return { ok: true, data, markdown: formatFindByComponent(data) };
+          return {
+            ok: true,
+            data,
+            markdown: formatFindByComponent(data),
+            telemetry: {
+              event: 'tool:getStoriesByComponent',
+              counters: {
+                componentCount: input.componentPaths.length,
+                matchedComponentCount: input.componentPaths.length - unmatchedCount,
+                totalMatchCount: lookup.results.reduce(
+                  (total, result) => total + result.matches.length,
+                  0
+                ),
+                maxDistance,
+              },
+            },
+          };
         },
       },
     },

--- a/code/core/src/shared/open-service/toolsets/stories/definition.ts
+++ b/code/core/src/shared/open-service/toolsets/stories/definition.ts
@@ -294,7 +294,7 @@ Use { absoluteStoryPath + exportName } only when you're already working in a spe
             markdown: formatPreviewStories(data, ctx, { reviewEnabled }),
             telemetry: {
               event: 'tool:previewStories',
-              counters: {
+              payload: {
                 inputStoryCount: input.stories.length,
                 outputStoryCount: data.stories.length,
               },
@@ -331,7 +331,7 @@ Use { absoluteStoryPath + exportName } only when you're already working in a spe
                 markdown: formatChangedStories(data, ctx, { reviewEnabled }),
                 telemetry: {
                   event: 'tool:getChangedStories',
-                  counters: {
+                  payload: {
                     storyCount: 0,
                     newStoryCount: 0,
                     modifiedStoryCount: 0,
@@ -363,7 +363,7 @@ Use { absoluteStoryPath + exportName } only when you're already working in a spe
             markdown: formatChangedStories(data, ctx, { reviewEnabled }),
             telemetry: {
               event: 'tool:getChangedStories',
-              counters: {
+              payload: {
                 storyCount: data.stories.length,
                 newStoryCount: data.counts.new,
                 modifiedStoryCount: data.counts.modified,
@@ -421,7 +421,7 @@ Defaults to ${DEFAULT_MAX_DISTANCE}; raise it to widen recall, lower it to tight
             markdown: formatFindByComponent(data),
             telemetry: {
               event: 'tool:getStoriesByComponent',
-              counters: {
+              payload: {
                 componentCount: input.componentPaths.length,
                 matchedComponentCount: input.componentPaths.length - unmatchedCount,
                 totalMatchCount: lookup.results.reduce(


### PR DESCRIPTION
Closes #36208

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR changes what two telemetry events contain and adds one report. It changes no tool behaviour: same output, same exit codes, same MCP tools. Ships as a 10.6.1 patch.

If you only read one section, read **Telemetry changes**. The **How** section at the end is for the code reviewer.

## Telemetry changes

### 1. `tools-command` (CLI and Node SDK): one record per call, named by toolset and tool

**Before**, one CLI call produced **two** records with nothing linking them: one from the command wrapper and one from the tool's handler. Counting rows double-counted every successful command. The handler record copied the MCP grouping, so `npx storybook tools review create` was logged as `toolset: dev`, and the CLI names were only inside a `command` string.

**After**, one CLI call produces **one** record. It carries the toolset and tool the agent invoked, in CLI spelling, plus the handler's counters.

| Field | Before | After |
| --- | --- | --- |
| `command` | `"stories changed"` (wrapper record) | **removed** |
| `toolset` | `"dev"` (handler record) | `"stories"`, `"review"`, `"docs"`, or `"test"` |
| `tool` | absent | `"changed"`, `"find-by-component"`, `"show-story"`, … |
| `event` | `"tool:getChangedStories"` (handler record) | `"tool:stories_changed"`, generated from toolset and tool |
| counters (`storyCount`, …) | handler record | unchanged, now on the same record |
| `success`, `outcome`, `duration` | wrapper record | unchanged, now on the same record |
| `client`, `requestedMode`, `resolvedMode`, `attachMode`, `host`, `attachGate`, `interceptReason`, `multipleMatches` | wrapper record | unchanged |

Example, `npx storybook tools stories changed` with four changed stories:

**Before**, record 1 (from the command wrapper):

```json
{
  "command": "stories changed",
  "success": true,
  "outcome": "success",
  "duration": 312,
  "client": "cli",
  "requestedMode": "auto",
  "resolvedMode": "local",
  "attachMode": "local",
  "host": "in-process"
}
```

**Before**, record 2 (from the tool's handler):

```json
{
  "event": "tool:getChangedStories",
  "toolset": "dev",
  "storyCount": 4,
  "newStoryCount": 1,
  "modifiedStoryCount": 3,
  "affectedStoryCount": 0,
  "client": "cli",
  "requestedMode": "auto",
  "resolvedMode": "local",
  "attachMode": "local",
  "host": "in-process"
}
```

**After**, the one record:

```json
{
  "toolset": "stories",
  "tool": "changed",
  "event": "tool:stories_changed",
  "storyCount": 4,
  "newStoryCount": 1,
  "modifiedStoryCount": 3,
  "affectedStoryCount": 0,
  "success": true,
  "outcome": "success",
  "duration": 312,
  "client": "cli",
  "requestedMode": "auto",
  "resolvedMode": "local",
  "attachMode": "local",
  "host": "in-process"
}
```

The Node SDK sends the same single record with `client: "sdk"`. When the CLI or SDK runs the tool in a project-local child process, the parent still sends exactly one record.

Calls that never reach a handler (intercepts and attach gates) still produce one record without `event` or counters:

| Case | Before | After |
| --- | --- | --- |
| unknown tool `stories nope` | `command: "stories nope"` | `toolset: "stories"`, `tool: "nope"` |
| name that is not a token, `../x list` | `command: "(invalid) list"` | `toolset: "(invalid)"`, `tool: "list"` |
| attach gate before anything was parsed | `command: "(none)"` | no `toolset`, no `tool` |
| help lookups | no record | no record |

### 2. `addon-mcp` (MCP server): `toolset` becomes the toolset name, `tool` is added

Every MCP tool call already sent one `addon-mcp` record. Its `toolset` was the MCP grouping (`dev`, `docs`, `test`). It now carries the same `toolset` and `tool` as the CLI, so one query groups usage across surfaces. `event` keeps its existing name on MCP (the only surface that does), and the payload and the session fields (`mcpSessionId`, `clientInfo`, `clientCapabilities`, `transport`) are unchanged.

| MCP tool | `toolset` before | `toolset` after | `tool` (new) | `event` (unchanged on MCP) |
| --- | --- | --- | --- | --- |
| `stories-preview` | `dev` | `stories` | `preview` | `tool:previewStories` |
| `stories-changed` | `dev` | `stories` | `changed` | `tool:getChangedStories` |
| `stories-find-by-component` | `dev` | `stories` | `find-by-component` | `tool:getStoriesByComponent` |
| `review-create` | `dev` | `review` | `create` | `tool:displayReview` |
| `docs-list` | `docs` | `docs` | `list` | `tool:listAllDocumentation` |
| `docs-show` | `docs` | `docs` | `show` | `tool:getDocumentation` |
| `docs-show-story` | none, no record | `docs` | `show-story` | `tool:getDocumentationForStory` (new) |
| `test-run` | `test` | `test` | `run` | `tool:runStoryTests` |

Not affected: the UI-instructions tool (`tool:getUIBuildingInstructions`, still `toolset: "dev"`) and `session:initialized`.

### 3. New report for `docs show-story` / `docs-show-story`

This tool reported nothing on any surface. It now reports, as `tool:docs_showStory` on the CLI and SDK and `tool:getDocumentationForStory` on MCP:

| Field | Meaning |
| --- | --- |
| `found` | whether a story was resolved |
| `storyId` | the resolved id when found, otherwise the id that was asked for; absent when only a name was given and the component was unknown |
| `lookup` | `"storyId"` or `"name"`: which input shape the agent used |
| `resultTokenCount` | size of the returned Markdown |

### Payload fields per tool, for reference (unchanged unless marked new)

| `toolset` / `tool` | `event` on CLI and SDK | `event` on MCP | Fields |
| --- | --- | --- | --- |
| `stories` / `preview` | `tool:stories_preview` | `tool:previewStories` | `inputStoryCount`, `outputStoryCount` |
| `stories` / `changed` | `tool:stories_changed` | `tool:getChangedStories` | `storyCount`, `newStoryCount`, `modifiedStoryCount`, `affectedStoryCount` |
| `stories` / `find-by-component` | `tool:stories_findByComponent` | `tool:getStoriesByComponent` | `componentCount`, `matchedComponentCount`, `totalMatchCount`, `maxDistance` |
| `review` / `create` | `tool:review_create` | `tool:displayReview` | `collectionCount`, `storyCount`, `changedFileCount` |
| `docs` / `list` | `tool:docs_list` | `tool:listAllDocumentation` | `componentCount`, `docsCount`, `resultTokenCount`, `sourceCount` |
| `docs` / `show` | `tool:docs_show` | `tool:getDocumentation` | `componentId`, `found`, `resultTokenCount` |
| `docs` / `show-story` (new) | `tool:docs_showStory` | `tool:getDocumentationForStory` | `found`, `storyId`, `lookup`, `resultTokenCount` |
| `test` / `run` | `tool:test_run` | `tool:runStoryTests` | `runA11y`, `inputStoryCount`, `matchedStoryCount`, `passingStoryCount`, `failingStoryCount`, `a11yViolationCount`, `unhandledErrorCount` |

### What this means for dashboards

- **Count CLI invocations** by counting `tools-command` rows. No more double counting.
- **Group by toolset** on either event with `toolset`; both use the same names now.
- **Queries on `command`** for 10.6.0 data lose that key. Use `toolset` and `tool` from 10.6.1 on.
- **Queries on `addon-mcp` `toolset = "dev"`** need `"stories"` or `"review"` from 10.6.1 on.
- **Join old and new MCP data** on `event`: `addon-mcp` keeps its existing names (`tool:getChangedStories`, …). CLI data from 10.6.0 carried those names on its second record; from 10.6.1 the CLI uses generated names (`tool:stories_changed`), so CLI history joins on `toolset` and `tool` from 10.6.1 on, not on `event`.

Agreed with Michael and Jeppe: one data break at 10.6.1. Event names are generated from the toolset and tool everywhere except MCP, which keeps its existing names so MCP data stays continuous.

## How

For the code reviewer. Nothing here is visible to users.

- A tool handler no longer sends telemetry through a callback. It returns its report on its outcome: `telemetry: { payload }`, next to `data` and `markdown`. Handlers never write `event`, `toolset`, or `tool`.
- `invokeToolsetMethod` in open-service is now the one way every surface runs a handler. It fills `toolset` and `tool` from where the method is registered, in CLI spelling, and generates `event` as `tool:<toolset>_<method>`, so a handler cannot report a name that disagrees with its registration and never invents an event name.
- The CLI and SDK put that report into their `tools-command` record and add the run fields. The MCP adapter puts it into the `addon-mcp` event, adds the session fields, and replaces `event` with the pre-toolset name its tool registry declares per tool (`mcpEventName`). That registry is the only place those names live.
- Deleted: `ctx.telemetry`, `reportToolsetTelemetry`, the CLI collector, the SDK per-call `telemetry` option and its sink wrapping, and the child-host `telemetry` IPC message. A child's report rides inside the outcome that already crosses IPC; the parent ignores the old message from a child on the previous release. The SDK has no external users yet, so no compatibility layer is kept for it.
- A handler that throws has no outcome and therefore no report on the error record. That partial data was never meaningful.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Run a sandbox, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. In the sandbox, run `STORYBOOK_TELEMETRY_DEBUG=1 npx storybook tools stories changed`
3. Exactly one `tools-command` event is logged, with `toolset: 'stories'`, `tool: 'changed'`, `event: 'tool:stories_changed'`, the story counters, `success`, and `duration` on the same record. There is no `command` field.
4. Run `STORYBOOK_TELEMETRY_DEBUG=1 npx storybook tools docs show-story --storyId example-button--primary`; the record carries `event: 'tool:docs_showStory'`, `found: true`, `lookup: 'storyId'`, and a `resultTokenCount`.
5. Start Storybook and call the `stories-changed` MCP tool from an MCP client; the `addon-mcp` event carries `event: 'tool:getChangedStories'`, `toolset: 'stories'`, `tool: 'changed'`, and the same counters as before.

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->






