### PR TITLE
Manager: Rework keyboard shortcut handling and Escape layering

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -12,14 +12,17 @@
   - [Next.js: Require v15 and up](#nextjs-require-v15-and-up)
   - [Next.js: most Node.js built-in polyfills removed from `@storybook/nextjs`](#nextjs-most-nodejs-built-in-polyfills-removed-from-storybooknextjs)
   - [Angular: requires Angular 21 or higher](#angular-requires-angular-21-or-higher)
-  - [`@storybook/nextjs` is deprecated](#nextjs-storybooknextjs-is-deprecated)
+  - [Next.js: `@storybook/nextjs` is deprecated](#nextjs-storybooknextjs-is-deprecated)
   - [Create React App support removed](#create-react-app-support-removed)
   - [`@storybook/angular-vite`: legacy animation modules are no longer auto-converted](#storybookangular-vite-legacy-animation-modules-are-no-longer-auto-converted)
   - [Internal WebSocket heartbeat controls removed](#internal-websocket-heartbeat-controls-removed)
   - [Internal toolset telemetry now returns with the outcome](#internal-toolset-telemetry-now-returns-with-the-outcome)
-
 - [From version 10.5.x to 10.6.0](#from-version-105x-to-1060)
   - [Vue 3: `vue-docgen-api` is deprecated](#vue-3-vue-docgen-api-is-deprecated)
+  - [Angular Vite: a new `propsTable` framework option](#angular-vite-a-new-propstable-framework-option)
+  - [MCP tool names follow toolset.method](#mcp-tool-names-follow-toolsetmethod)
+  - [Angular Vite defaults to server-side docgen](#angular-vite-defaults-to-server-side-docgen)
+  - [Angular Vite: tsconfig paths now take priority over `node_modules` in production builds too](#angular-vite-tsconfig-paths-now-take-priority-over-node_modules-in-production-builds-too)
   - [Experimental Playwright CT integration removed](#experimental-playwright-ct-integration-removed)
   - [`@storybook/csf-plugin` removed](#storybookcsf-plugin-removed)
 - [From version 10.4.0 to 10.5.0](#from-version-1040-to-1050)
@@ -74,7 +77,6 @@
   - [Core Changes and Removals](#core-changes-and-removals)
     - [Dropped support for legacy packages](#dropped-support-for-legacy-packages)
     - [Dropped support](#dropped-support)
-      - [Vite 5 and Vite 6](#vite-requires-vite-63-or-higher)
       - [Vite 4](#vite-4)
       - [TypeScript \< 4.9](#typescript--49)
       - [Node.js \< 20](#nodejs--20)
@@ -813,16 +815,16 @@ To drop a single member the default keeps, tag it `@ignore`.
 
 Storybook's MCP tools are now named from their toolset and method (`stories.preview` → `stories-preview`). Update agent prompts, skills, and hard-coded tool allowlists:
 
-| Previous name | New name |
-| --- | --- |
-| `preview-stories` | `stories-preview` |
-| `get-changed-stories` | `stories-changed` |
-| `get-stories-by-component` | `stories-find-by-component` |
-| `display-review` | `review-create` |
-| `run-story-tests` | `test-run` |
-| `list-all-documentation` | `docs-list` |
-| `get-documentation` | `docs-show` |
-| `get-documentation-for-story` | `docs-show-story` |
+| Previous name                 | New name                    |
+| ----------------------------- | --------------------------- |
+| `preview-stories`             | `stories-preview`           |
+| `get-changed-stories`         | `stories-changed`           |
+| `get-stories-by-component`    | `stories-find-by-component` |
+| `display-review`              | `review-create`             |
+| `run-story-tests`             | `test-run`                  |
+| `list-all-documentation`      | `docs-list`                 |
+| `get-documentation`           | `docs-show`                 |
+| `get-documentation-for-story` | `docs-show-story`           |
 
 `get-storybook-story-instructions` is unchanged (it is not backed by a toolset method).
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,6 +5,7 @@
   - [Yarn PnP support removed](#yarn-pnp-support-removed)
   - [Top-level `setConfig` layout and UI options removed](#top-level-setconfig-layout-and-ui-options-removed)
   - [Sidebar label rendering: renderAriaLabel and a context argument](#sidebar-label-rendering-renderarialabel-and-a-context-argument)
+  - [Escape is no longer a configurable shortcut](#escape-is-no-longer-a-configurable-shortcut)
   - [Vitest Addon: requires Vitest 4.0 or higher](#vitest-addon-requires-vitest-40-or-higher)
   - [Vite: `publicDir` is handled by Storybook's `staticDirs`](#vite-publicdir-is-handled-by-storybooks-staticdirs)
   - [Vite: requires Vite 6.3 or higher](#vite-requires-vite-63-or-higher)
@@ -603,6 +604,10 @@ option exists in both places, keep the nested value because it was authoritative
 `sidebar.renderLabel` now receives a third `context` argument, `{ isMobile: boolean; location: 'sidebar' | 'bottom-bar' }`, so labels can adapt to where they render (the sidebar tree vs. the mobile bottom bar). Existing two-argument functions keep working - the parameter is optional.
 
 `sidebar.renderAriaLabel` was added alongside it and must return a plain string; it feeds accessible names for tree entries and the mobile bottom bar's current-page announcement. When `renderLabel` returns a React element, the bottom bar now falls back to the entry name for its concatenated announcement instead of stringifying the element.
+
+### Escape is no longer a configurable shortcut
+
+The `escape` entry was removed from the manager's configurable shortcuts: `api.getShortcutKeys()` no longer includes it, and the types no longer accept `api.setShortcut('escape', ...)`. Escape still exits fullscreen, but as fixed behavior layered under overlay dismissal (a popover, menu, or modal that consumes Escape closes without also exiting fullscreen), so it cannot be rebound or shadowed from the shortcuts settings page.
 
 ### Vitest Addon: requires Vitest 4.0 or higher
 

--- a/code/core/src/components/components/Select/Select.tsx
+++ b/code/core/src/components/components/Select/Select.tsx
@@ -460,6 +460,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
 
         if (e.key === 'Escape') {
           handleClose();
+          e.stopPropagation();
         } else if (e.key === 'ArrowDown') {
           moveActiveOptionDown();
         } else if (e.key === 'ArrowUp') {

--- a/code/core/src/manager-api/lib/shortcut.test.ts
+++ b/code/core/src/manager-api/lib/shortcut.test.ts
@@ -210,7 +210,8 @@ describe('shortcut', () => {
       expect(keyToSymbol('Enter')).toBe('');
       expect(keyToSymbol('Backspace')).toBe('');
       expect(keyToSymbol('Esc')).toBe('');
-      expect(keyToSymbol('escape')).toBe('');
+      // 'escape' falls through to the uppercase default; nothing binds it as a shortcut anymore.
+      expect(keyToSymbol('escape')).toBe('ESCAPE');
       expect(keyToSymbol(' ')).toBe('SPACE');
       expect(keyToSymbol('ArrowUp')).toBe('↑');
       expect(keyToSymbol('ArrowDown')).toBe('↓');

--- a/code/core/src/manager-api/lib/shortcut.ts
+++ b/code/core/src/manager-api/lib/shortcut.ts
@@ -150,9 +150,6 @@ export const keyToSymbol = (key: string): string => {
   if (key === 'Enter' || key === 'Backspace' || key === 'Esc') {
     return '';
   }
-  if (key === 'escape') {
-    return '';
-  }
   if (key === ' ') {
     return 'SPACE';
   }

--- a/code/core/src/manager-api/modules/shortcuts.ts
+++ b/code/core/src/manager-api/modules/shortcuts.ts
@@ -260,9 +260,9 @@ export const init: ModuleFn = ({ store, fullAPI, provider }) => {
         if (isSidebarShortcutBlocked && ['focusNav', 'search', 'toggleNav'].includes(feature)) {
           return false;
         }
-        // Bindings persisted from a previous session whose addon didn't re-register must not
+        // Bindings persisted by a previous page load whose addon didn't re-register must not
         // match: acting on them would crash, and matching alone would swallow the key.
-        if (feature in addonsShortcuts || !(feature in defaultShortcuts)) {
+        if (!(feature in defaultShortcuts)) {
           return feature in addonsShortcuts;
         }
         return true;

--- a/code/core/src/manager-api/modules/shortcuts.ts
+++ b/code/core/src/manager-api/modules/shortcuts.ts
@@ -85,8 +85,9 @@ export interface SubAPI {
    * Handles a keydown event.
    *
    * @param event The event to handle.
+   * @returns The matched shortcut action name, or undefined if no shortcut was matched.
    */
-  handleKeydownEvent(event: KeyboardEventLike): void;
+  handleKeydownEvent(event: KeyboardEventLike): API_Action | undefined;
   /**
    * Handles a shortcut feature.
    *
@@ -114,7 +115,6 @@ export interface API_Shortcuts {
   nextStory: API_KeyCollection;
   shortcutsPage: API_KeyCollection;
   aboutPage: API_KeyCollection;
-  escape: API_KeyCollection;
   collapseAll: API_KeyCollection;
   expandAll: API_KeyCollection;
   remount: API_KeyCollection;
@@ -134,6 +134,12 @@ interface API_AddonShortcut {
   defaultShortcut: API_KeyCollection;
   actionName: string;
   showInMenu?: boolean;
+  /**
+   * When provided and returning false, the shortcut does not match key events (they propagate
+   * to the rest of the UI, e.g. react-aria keyboard navigation). Use this for modal shortcuts
+   * like plain arrow keys that must only apply while the addon's mode is active.
+   */
+  isActive?: () => boolean;
   action: (...args: any[]) => any;
 }
 type API_AddonShortcuts = Record<string, API_AddonShortcut>;
@@ -156,7 +162,6 @@ export const defaultShortcuts: API_Shortcuts = Object.freeze({
   nextStory: ['alt', 'ArrowRight'],
   shortcutsPage: [controlOrMetaKey(), 'shift', ','],
   aboutPage: [controlOrMetaKey(), ','],
-  escape: ['escape'], // This one is not customizable
   collapseAll: [controlOrMetaKey(), 'shift', 'ArrowUp'],
   expandAll: [controlOrMetaKey(), 'shift', 'ArrowDown'],
   remount: ['alt', 'R'],
@@ -244,15 +249,36 @@ export const init: ModuleFn = ({ store, fullAPI, provider }) => {
 
     // Listening to shortcut events
     handleKeydownEvent(event) {
+      // A feature that would not run must report "no match": the capture listener stops
+      // propagation for matched shortcuts, so reporting a match here would swallow the key
+      // for the rest of the UI without performing any action.
+      if (!store.getState().ui.enableShortcuts) {
+        return undefined;
+      }
       const shortcut = eventToShortcut(event);
       const shortcuts = api.getShortcutKeys();
       const actions = keys(shortcuts);
-      const matchedFeature = actions.find((feature: API_Action) =>
-        shortcutMatchesShortcut(shortcut!, shortcuts[feature])
-      );
+      const isSidebarShortcutBlocked = fullAPI.getNavAvailability() === 'unavailable';
+      const matchedFeature = actions.find((feature: API_Action) => {
+        if (!shortcutMatchesShortcut(shortcut!, shortcuts[feature])) {
+          return false;
+        }
+        if (isSidebarShortcutBlocked && ['focusNav', 'search', 'toggleNav'].includes(feature)) {
+          return false;
+        }
+        // Addon shortcuts can be scoped to a mode (e.g. review navigation on bare arrow
+        // keys); when inactive they must not swallow keys others rely on. Bindings persisted
+        // from a previous session whose addon didn't re-register are skipped the same way.
+        const addonShortcut = addonsShortcuts[feature];
+        if (feature in addonsShortcuts || !(feature in defaultShortcuts)) {
+          return !!addonShortcut && (addonShortcut.isActive?.() ?? true);
+        }
+        return true;
+      });
       if (matchedFeature) {
         api.handleShortcutFeature(matchedFeature, event);
       }
+      return matchedFeature;
     },
 
     // warning: event might not have a full prototype chain because it may originate from the channel
@@ -279,16 +305,6 @@ export const init: ModuleFn = ({ store, fullAPI, provider }) => {
         event.preventDefault();
       }
       switch (feature) {
-        case 'escape': {
-          if (fullAPI.getIsFullscreen()) {
-            fullAPI.toggleFullscreen(false);
-          } else if (isDesktopViewport() && fullAPI.getIsNavShown()) {
-            // On mobile toggleNav opens the drawer, so Escape must not reach it — only the desktop nav.
-            fullAPI.toggleNav(true);
-          }
-          break;
-        }
-
         // Handled by @react-aria/interactions and useLandmarkIndicator
         case 'goToNextLandmark':
         case 'goToPreviousLandmark':
@@ -518,16 +534,57 @@ export const init: ModuleFn = ({ store, fullAPI, provider }) => {
   };
 
   const initModule = () => {
-    // Listen for keydown events in the manager
-    document.addEventListener('keydown', (event: KeyboardEvent) => {
-      if (!shouldSkipShortcut(event)) {
-        api.handleKeydownEvent(event);
+    // Listen for keydown events in the manager.
+    // Capture phase ensures we run before React Aria (and other component libraries) can
+    // call stopPropagation(), which would prevent bubbling-phase listeners from firing.
+    // When a shortcut is matched we also stop propagation so React Aria cannot re-dispatch
+    // the same event (which it does for ArrowUp/Down) and cause double-firing or
+    // unintended tree navigation as a side effect.
+    // Landmark-navigation shortcuts (F6 / Shift+F6) are intentionally excluded: Storybook's
+    // handler is a no-op for them and React Aria must be allowed to handle them.
+    document.addEventListener(
+      'keydown',
+      (event: KeyboardEvent) => {
+        if (!shouldSkipShortcut(event)) {
+          const matched = api.handleKeydownEvent(event);
+          if (matched && matched !== 'goToNextLandmark' && matched !== 'goToPreviousLandmark') {
+            event.stopPropagation();
+          }
+        }
+      },
+      { capture: true }
+    );
+
+    // Escape is deliberately not part of the shortcut map: react-aria overlays (menus,
+    // popovers, modals) handle it at the element level and stop propagation when they consume
+    // it, so this bubble-phase listener only sees presses nothing else claimed. Those exit
+    // fullscreen. Running at the capture phase instead would close overlays and exit
+    // fullscreen with a single press.
+    window.addEventListener('keydown', (event: KeyboardEvent) => {
+      if (
+        event.key === 'Escape' &&
+        !event.defaultPrevented &&
+        !shouldSkipShortcut(event) &&
+        store.getState().ui.enableShortcuts &&
+        fullAPI.getIsFullscreen()
+      ) {
+        event.preventDefault();
+        fullAPI.toggleFullscreen(false);
       }
     });
 
     // Also listen to keydown events sent over the channel
     provider.channel?.on(PREVIEW_KEYDOWN, (data: { event: KeyboardEventLike }) => {
       api.handleKeydownEvent(data.event);
+      // The preview only forwards keydowns when focus is outside inputs, so Escape pressed
+      // while interacting with the story exits fullscreen just like it does in the manager.
+      if (
+        data.event.key === 'Escape' &&
+        store.getState().ui.enableShortcuts &&
+        fullAPI.getIsFullscreen()
+      ) {
+        fullAPI.toggleFullscreen(false);
+      }
     });
   };
 

--- a/code/core/src/manager-api/modules/shortcuts.ts
+++ b/code/core/src/manager-api/modules/shortcuts.ts
@@ -9,6 +9,7 @@ import { global } from '@storybook/global';
 
 import copy from 'copy-to-clipboard';
 
+import { logger } from 'storybook/internal/client-logger';
 import type { KeyboardEventLike } from '../lib/shortcut.ts';
 import { eventToShortcut, shortcutMatchesShortcut } from '../lib/shortcut.ts';
 import type { ModuleFn } from '../lib/types.tsx';
@@ -519,7 +520,11 @@ export const init: ModuleFn = ({ store, fullAPI, provider }) => {
           break;
         }
         default:
-          addonsShortcuts[feature].action();
+          if (feature in addonsShortcuts) {
+            addonsShortcuts[feature].action();
+          } else {
+            logger.warn(`api.handleShortcutFeature called with unknown feature: ${feature}.`);
+          }
           break;
       }
     },

--- a/code/core/src/manager-api/modules/shortcuts.ts
+++ b/code/core/src/manager-api/modules/shortcuts.ts
@@ -252,16 +252,19 @@ export const init: ModuleFn = ({ store, fullAPI, provider }) => {
       const shortcut = eventToShortcut(event);
       const shortcuts = api.getShortcutKeys();
       const actions = keys(shortcuts);
-      const isSidebarShortcutBlocked = fullAPI.getNavAvailability() === 'unavailable';
       const matchedFeature = actions.find((feature: API_Action) => {
         if (!shortcutMatchesShortcut(shortcut!, shortcuts[feature])) {
           return false;
         }
+
+        // Don't register sidebar shortcuts when it's hidden.
+        const isSidebarShortcutBlocked = fullAPI.getNavAvailability() === 'unavailable';
         if (isSidebarShortcutBlocked && ['focusNav', 'search', 'toggleNav'].includes(feature)) {
           return false;
         }
-        // Bindings persisted by a previous page load whose addon didn't re-register must not
-        // match: acting on them would crash, and matching alone would swallow the key.
+
+        // Orphaned bindings persisted to localStorage by an old addon or SB version must not
+        // match or they would swallow a keyboard shortcut (due to stopPropagation()).
         if (!(feature in defaultShortcuts)) {
           return feature in addonsShortcuts;
         }

--- a/code/core/src/manager-api/modules/shortcuts.ts
+++ b/code/core/src/manager-api/modules/shortcuts.ts
@@ -87,14 +87,14 @@ export interface SubAPI {
    * @param event The event to handle.
    * @returns The matched shortcut action name, or undefined if no shortcut was matched.
    */
-  handleKeydownEvent(event: KeyboardEventLike): API_Action | undefined;
+  handleKeydownEvent(event: KeyboardEventLike): API_MatchableAction | undefined;
   /**
    * Handles a shortcut feature.
    *
    * @param feature The feature to handle.
    * @param event The event to handle.
    */
-  handleShortcutFeature(feature: API_Action, event: KeyboardEventLike): void;
+  handleShortcutFeature(feature: API_MatchableAction, event: KeyboardEventLike): void;
 }
 
 export type API_KeyCollection = string[];
@@ -128,6 +128,13 @@ export interface API_Shortcuts {
 }
 
 export type API_Action = keyof API_Shortcuts;
+
+/**
+ * A built-in shortcut action, or the id of a shortcut registered through `setAddonShortcut`
+ * (`` `${addon}-${actionName}` ``). `(string & {})` admits those addon ids while preserving
+ * autocompletion for the built-in names.
+ */
+export type API_MatchableAction = API_Action | (string & {});
 
 interface API_AddonShortcut {
   label: string;

--- a/code/core/src/manager-api/modules/shortcuts.ts
+++ b/code/core/src/manager-api/modules/shortcuts.ts
@@ -134,12 +134,6 @@ interface API_AddonShortcut {
   defaultShortcut: API_KeyCollection;
   actionName: string;
   showInMenu?: boolean;
-  /**
-   * When provided and returning false, the shortcut does not match key events (they propagate
-   * to the rest of the UI, e.g. react-aria keyboard navigation). Use this for modal shortcuts
-   * like plain arrow keys that must only apply while the addon's mode is active.
-   */
-  isActive?: () => boolean;
   action: (...args: any[]) => any;
 }
 type API_AddonShortcuts = Record<string, API_AddonShortcut>;
@@ -266,12 +260,10 @@ export const init: ModuleFn = ({ store, fullAPI, provider }) => {
         if (isSidebarShortcutBlocked && ['focusNav', 'search', 'toggleNav'].includes(feature)) {
           return false;
         }
-        // Addon shortcuts can be scoped to a mode (e.g. review navigation on bare arrow
-        // keys); when inactive they must not swallow keys others rely on. Bindings persisted
-        // from a previous session whose addon didn't re-register are skipped the same way.
-        const addonShortcut = addonsShortcuts[feature];
+        // Bindings persisted from a previous session whose addon didn't re-register must not
+        // match: acting on them would crash, and matching alone would swallow the key.
         if (feature in addonsShortcuts || !(feature in defaultShortcuts)) {
-          return !!addonShortcut && (addonShortcut.isActive?.() ?? true);
+          return feature in addonsShortcuts;
         }
         return true;
       });

--- a/code/core/src/manager-api/modules/shortcuts.ts
+++ b/code/core/src/manager-api/modules/shortcuts.ts
@@ -130,9 +130,8 @@ export interface API_Shortcuts {
 export type API_Action = keyof API_Shortcuts;
 
 /**
- * A built-in shortcut action, or the id of a shortcut registered through `setAddonShortcut`
- * (`` `${addon}-${actionName}` ``). `(string & {})` admits those addon ids while preserving
- * autocompletion for the built-in names.
+ * Matchable shortcut actions include built-in and addon-defined actions. We use this type to
+ * get autocompletion on built-in actions, but allow arbitrary strings for addon-defined ones.
  */
 export type API_MatchableAction = API_Action | (string & {});
 

--- a/code/core/src/manager-api/tests/shortcut.test.js
+++ b/code/core/src/manager-api/tests/shortcut.test.js
@@ -82,9 +82,9 @@ describe('keyToSymbol', () => {
     const result = keyToSymbol(' ');
     expect(result).toEqual('SPACE');
   });
-  it('escape returns esc', () => {
+  it('escape returns ESCAPE', () => {
     const result = keyToSymbol('escape');
-    expect(result).toEqual('');
+    expect(result).toEqual('ESCAPE');
   });
   it('ArrowUp returns ↑​​​', () => {
     const result = keyToSymbol('ArrowUp');

--- a/code/core/src/manager-api/tests/shortcuts.test.js
+++ b/code/core/src/manager-api/tests/shortcuts.test.js
@@ -289,3 +289,95 @@ describe('shortcuts api', () => {
     ).toEqual(['G']);
   });
 });
+
+describe('addon shortcut activity gating', () => {
+  const initWithUi = () => {
+    const store = createMockStore();
+    const fullAPI = { getNavAvailability: () => 'shown' };
+    const { api, state } = initShortcuts({ store, provider: {}, fullAPI });
+    store.setState({ ...state, ui: { enableShortcuts: true }, storyId: 'a', refId: undefined });
+    return api;
+  };
+
+  it('inactive addon shortcuts do not match key events', async () => {
+    const api = initWithUi();
+    const action = vi.fn();
+    await api.setAddonShortcut('review', {
+      label: 'Next collection',
+      defaultShortcut: ['ArrowDown'],
+      actionName: 'nextCollection',
+      isActive: () => false,
+      action,
+    });
+
+    const matched = api.handleKeydownEvent({ key: 'ArrowDown' });
+    expect(matched).toBeUndefined();
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('active addon shortcuts match and fire', async () => {
+    const api = initWithUi();
+    const action = vi.fn();
+    await api.setAddonShortcut('review', {
+      label: 'Next collection',
+      defaultShortcut: ['ArrowDown'],
+      actionName: 'nextCollection',
+      isActive: () => true,
+      action,
+    });
+
+    const matched = api.handleKeydownEvent({ key: 'ArrowDown' });
+    expect(matched).toBe('review-nextCollection');
+    expect(action).toHaveBeenCalled();
+  });
+
+  it('addon shortcuts without isActive still match (default behavior)', async () => {
+    const api = initWithUi();
+    const action = vi.fn();
+    await api.setAddonShortcut('my-addon', {
+      label: 'Do it',
+      defaultShortcut: ['O'],
+      actionName: 'doIt',
+      action,
+    });
+
+    expect(api.handleKeydownEvent({ key: 'O', code: 'KeyO' })).toBe('my-addon-doIt');
+    expect(action).toHaveBeenCalled();
+  });
+
+  it('persisted addon bindings whose addon did not re-register are ignored', () => {
+    const store = createMockStore();
+    const fullAPI = { getNavAvailability: () => 'shown' };
+    const { api, state } = initShortcuts({ store, provider: {}, fullAPI });
+    store.setState({
+      ...state,
+      ui: { enableShortcuts: true },
+      shortcuts: { ...state.shortcuts, 'stale-addon-gone': ['ArrowUp'] },
+    });
+
+    expect(() => api.handleKeydownEvent({ key: 'ArrowUp' })).not.toThrow();
+    expect(api.handleKeydownEvent({ key: 'ArrowUp' })).toBeUndefined();
+  });
+});
+
+describe('keydown match gating', () => {
+  it('reports no match when shortcuts are disabled, so the key is not swallowed', () => {
+    const store = createMockStore();
+    const fullAPI = { getNavAvailability: () => 'shown', toggleFullscreen: vi.fn() };
+    const { api, state } = initShortcuts({ store, provider: {}, fullAPI });
+    store.setState({ ...state, ui: { enableShortcuts: false }, storyId: 'a' });
+
+    expect(api.handleKeydownEvent({ key: 'F', altKey: true })).toBeUndefined();
+    expect(fullAPI.toggleFullscreen).not.toHaveBeenCalled();
+  });
+
+  it('reports no match for sidebar shortcuts while the nav is unavailable', () => {
+    const store = createMockStore();
+    const fullAPI = { getNavAvailability: () => 'unavailable', toggleFullscreen: vi.fn() };
+    const { api, state } = initShortcuts({ store, provider: {}, fullAPI });
+    store.setState({ ...state, ui: { enableShortcuts: true }, storyId: 'a' });
+
+    expect(api.handleKeydownEvent({ key: 'S', code: 'KeyS', altKey: true })).toBeUndefined();
+    expect(api.handleKeydownEvent({ key: 'F', altKey: true })).toBe('fullScreen');
+  });
+});

--- a/code/core/src/manager-api/tests/shortcuts.test.js
+++ b/code/core/src/manager-api/tests/shortcuts.test.js
@@ -290,7 +290,7 @@ describe('shortcuts api', () => {
   });
 });
 
-describe('addon shortcut activity gating', () => {
+describe('addon shortcut matching', () => {
   const initWithUi = () => {
     const store = createMockStore();
     const fullAPI = { getNavAvailability: () => 'shown' };
@@ -299,39 +299,7 @@ describe('addon shortcut activity gating', () => {
     return api;
   };
 
-  it('inactive addon shortcuts do not match key events', async () => {
-    const api = initWithUi();
-    const action = vi.fn();
-    await api.setAddonShortcut('review', {
-      label: 'Next collection',
-      defaultShortcut: ['ArrowDown'],
-      actionName: 'nextCollection',
-      isActive: () => false,
-      action,
-    });
-
-    const matched = api.handleKeydownEvent({ key: 'ArrowDown' });
-    expect(matched).toBeUndefined();
-    expect(action).not.toHaveBeenCalled();
-  });
-
-  it('active addon shortcuts match and fire', async () => {
-    const api = initWithUi();
-    const action = vi.fn();
-    await api.setAddonShortcut('review', {
-      label: 'Next collection',
-      defaultShortcut: ['ArrowDown'],
-      actionName: 'nextCollection',
-      isActive: () => true,
-      action,
-    });
-
-    const matched = api.handleKeydownEvent({ key: 'ArrowDown' });
-    expect(matched).toBe('review-nextCollection');
-    expect(action).toHaveBeenCalled();
-  });
-
-  it('addon shortcuts without isActive still match (default behavior)', async () => {
+  it('addon shortcuts match and fire', async () => {
     const api = initWithUi();
     const action = vi.fn();
     await api.setAddonShortcut('my-addon', {

--- a/code/core/src/manager-api/tests/shortcuts.test.js
+++ b/code/core/src/manager-api/tests/shortcuts.test.js
@@ -1,6 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
+// @vitest-environment happy-dom
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { logger } from 'storybook/internal/client-logger';
 
 import { init as initShortcuts } from '../modules/shortcuts';
+
+vi.mock('storybook/internal/client-logger');
 
 function createMockStore() {
   let state = {};
@@ -326,6 +331,15 @@ describe('addon shortcut matching', () => {
     expect(() => api.handleKeydownEvent({ key: 'ArrowUp' })).not.toThrow();
     expect(api.handleKeydownEvent({ key: 'ArrowUp' })).toBeUndefined();
   });
+
+  it('handleShortcutFeature warns instead of throwing for a feature id with no registered action', () => {
+    const api = initWithUi();
+
+    expect(() => api.handleShortcutFeature('stale-addon-gone', {})).not.toThrow();
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.stringContaining('stale-addon-gone')
+    );
+  });
 });
 
 describe('keydown match gating', () => {
@@ -360,5 +374,73 @@ describe('keydown match gating', () => {
     });
 
     expect(api.handleKeydownEvent({ key: 'Escape' })).toBeUndefined();
+  });
+});
+
+describe('keydown listeners registered by init', () => {
+  let fullAPI;
+
+  const dispatch = (eventInit) => {
+    const event = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...eventInit });
+    vi.spyOn(event, 'stopPropagation');
+    document.body.dispatchEvent(event);
+    return event;
+  };
+
+  beforeAll(() => {
+    const store = createMockStore();
+    fullAPI = {
+      getNavAvailability: () => 'shown',
+      toggleFullscreen: vi.fn(),
+      getIsFullscreen: vi.fn().mockReturnValue(false),
+    };
+    const { state, init } = initShortcuts({ store, provider: {}, fullAPI });
+    store.setState({
+      ...state,
+      ui: { enableShortcuts: true },
+      storyId: 'a',
+      shortcuts: { ...state.shortcuts, 'stale-addon-gone': ['alt', 'shift', 'Q'] },
+    });
+    init();
+  });
+
+  it('stops propagation of a matched shortcut at the capture phase and runs its action', () => {
+    const event = dispatch({ key: 'F', code: 'KeyF', altKey: true });
+
+    expect(fullAPI.toggleFullscreen).toHaveBeenCalled();
+    expect(event.stopPropagation).toHaveBeenCalled();
+  });
+
+  it('lets landmark navigation keys through to react-aria', () => {
+    const event = dispatch({ key: 'F6', code: 'F6' });
+
+    expect(event.stopPropagation).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('leaves events untouched when they only match an orphaned persisted addon binding', () => {
+    const event = dispatch({ key: 'Q', code: 'KeyQ', altKey: true, shiftKey: true });
+
+    expect(event.stopPropagation).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('exits fullscreen on a bubbled Escape that no overlay consumed', () => {
+    fullAPI.getIsFullscreen.mockReturnValue(true);
+
+    const event = dispatch({ key: 'Escape' });
+
+    expect(fullAPI.toggleFullscreen).toHaveBeenCalledWith(false);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('does not exit fullscreen when an overlay already consumed Escape', () => {
+    fullAPI.getIsFullscreen.mockReturnValue(true);
+
+    const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+    event.preventDefault();
+    document.body.dispatchEvent(event);
+
+    expect(fullAPI.toggleFullscreen).not.toHaveBeenCalled();
   });
 });

--- a/code/core/src/manager-api/tests/shortcuts.test.js
+++ b/code/core/src/manager-api/tests/shortcuts.test.js
@@ -348,4 +348,17 @@ describe('keydown match gating', () => {
     expect(api.handleKeydownEvent({ key: 'S', code: 'KeyS', altKey: true })).toBeUndefined();
     expect(api.handleKeydownEvent({ key: 'F', altKey: true })).toBe('fullScreen');
   });
+
+  it('reports no match for an escape binding persisted by an older Storybook, so overlays receive the key', () => {
+    const store = createMockStore();
+    const fullAPI = { getNavAvailability: () => 'shown' };
+    const { api, state } = initShortcuts({ store, provider: {}, fullAPI });
+    store.setState({
+      ...state,
+      ui: { enableShortcuts: true },
+      shortcuts: { ...state.shortcuts, escape: ['escape'] },
+    });
+
+    expect(api.handleKeydownEvent({ key: 'Escape' })).toBeUndefined();
+  });
 });

--- a/code/core/src/manager/settings/defaultShortcuts.tsx
+++ b/code/core/src/manager/settings/defaultShortcuts.tsx
@@ -16,7 +16,6 @@ export const defaultShortcuts: State['shortcuts'] = {
   nextStory: ['alt', 'ArrowRight'],
   shortcutsPage: ['ctrl', 'shift', ','],
   aboutPage: [','],
-  escape: ['escape'],
   collapseAll: ['ctrl', 'shift', 'ArrowUp'],
   expandAll: ['ctrl', 'shift', 'ArrowDown'],
   remount: ['alt', 'R'],

--- a/code/core/src/manager/settings/shortcuts.tsx
+++ b/code/core/src/manager/settings/shortcuts.tsx
@@ -146,16 +146,13 @@ export type Feature = keyof typeof shortcutLabels;
 
 type ConfiguredShortcut = { shortcut: API_KeyCollection; error: boolean; hardcoded?: boolean };
 
-// Shortcuts that cannot be configured
-const fixedShortcuts = ['escape'];
-
 // Shortcuts that cannot be changed by the user (imposed by third-party libraries).
 const hardcodedShortcuts = ['goToPreviousLandmark', 'goToNextLandmark'];
 function toShortcutState(
   shortcutKeys: ShortcutsScreenProps['shortcutKeys']
 ): Record<Feature, ConfiguredShortcut> {
   const state: Record<string, ConfiguredShortcut> = {};
-  for (const key of Object.keys(shortcutKeys).filter((k) => !fixedShortcuts.includes(k))) {
+  for (const key of Object.keys(shortcutKeys)) {
     state[key] = {
       shortcut: shortcutKeys[key as Feature],
       error: false,
@@ -216,13 +213,19 @@ class ShortcutsScreen extends Component<ShortcutsScreenProps, ShortcutsScreenSta
       Array.isArray(key) ? key.at(-1) : key
     ) as string[];
 
+    // Escape stays reserved: overlays across the manager close on it, and a persisted
+    // binding would swallow every Escape press at the document level before they see it.
+    const isReservedKey = normalizedShortcut.length === 1 && normalizedShortcut[0] === 'escape';
+
     // Check we don't match any other shortcuts
-    const error = !!Object.entries(shortcutKeys).find(
-      ([feature, { shortcut: existingShortcut }]) =>
-        feature !== activeFeature &&
-        existingShortcut &&
-        shortcutMatchesShortcut(normalizedShortcut, existingShortcut)
-    );
+    const error =
+      isReservedKey ||
+      !!Object.entries(shortcutKeys).find(
+        ([feature, { shortcut: existingShortcut }]) =>
+          feature !== activeFeature &&
+          existingShortcut &&
+          shortcutMatchesShortcut(normalizedShortcut, existingShortcut)
+      );
 
     return this.setState({
       shortcutKeys: { ...shortcutKeys, [activeFeature]: { shortcut: normalizedShortcut, error } },


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Part of the Sidebar 2.0 stack (#33422): reworks how the manager handles keyboard shortcuts so they coexist with react-aria's own key handling, and gives Escape a fixed, layered role instead of a configurable binding.

- Shortcut matching moves to a **capture-phase document listener**: react-aria re-dispatches some keys it handles (ArrowUp/Down), which double-fired shortcuts and triggered unintended tree navigation. Matched shortcuts stop propagation; landmark keys (F6/Shift+F6) are exempt because react-aria must receive them.
- Matching reports "no match" when `enableShortcuts` is off or when sidebar features (`focusNav`, `search`, `toggleNav`) are blocked by nav availability — otherwise the capture listener would swallow those keys manager-wide while doing nothing.
- Addon shortcut bindings persisted from a previous session whose addon didn't re-register are skipped instead of crashing — and since matched shortcuts now stop propagation, skipping them also keeps those keys from being swallowed.
- **Escape leaves the configurable shortcut map** (MIGRATION note included). As a recordable binding it fundamentally conflicts with overlays: react-aria menus, popovers, and modals consume Escape at the element level, and a document-capture match would close an overlay *and* exit fullscreen in a single press. The shortcuts module now owns fixed Escape behavior on a bubble-phase window listener — overlays that consume the key stop its propagation and win — plus a `PREVIEW_KEYDOWN` branch so Escape pressed inside the preview iframe still exits fullscreen. The settings recorder rejects a bare Escape so a persisted binding can't shadow overlay dismissal, and `Select`'s own Escape handling stops propagation for the same layering.
- The fullscreen toolbar button keeps advertising the `fullScreen` binding in both states.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. `cd code && yarn storybook:ui`
2. Enter fullscreen (alt+F or the toolbar button), click into the story canvas so focus is inside the iframe, press Escape → fullscreen exits.
3. Open any popover (e.g. the sidebar ⚙ menu), press Escape → only the popover closes; press Escape again in fullscreen → fullscreen exits.
4. On the shortcuts settings page, focus a shortcut input and press Escape → it is rejected as a binding (error state) instead of being recorded.
5. Set `enableShortcuts: false` in `manager.tsx`, reload, and confirm keys like `F`, `A`, `/` type normally into inputs and reach the UI (nothing is silently swallowed).

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSk2g5RrcpxacMMUTRv9HK