### PR TITLE
Addon-Pseudostates: Preserve :where() specificity in rewritten selectors

### DIFF
--- a/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
+++ b/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
@@ -223,6 +223,14 @@ describe('rewriteStyleSheet', () => {
     expect(selectors).not.toContain('.pseudo-focus-visible-all .textLink:where(*)');
   });
 
+  it('preserves literal ":where(*)" text inside quoted attribute values', () => {
+    const sheet = new Sheet('[data-label=":where(*)"] .item:hover { color: red }');
+    rewriteStyleSheet(sheet as any);
+    expect(sheet.cssRules[0].getSelectors()).toContain(
+      '.pseudo-hover-all [data-label=":where(*)"] .item'
+    );
+  });
+
   it('preserves the specificity of mixed pseudo-states inside and outside ":where"', () => {
     const sheet = new Sheet('.textLink:where(:focus-visible):hover { text-decoration: none }');
     rewriteStyleSheet(sheet as any);

--- a/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
+++ b/code/addons/pseudo-states/src/preview/rewriteStyleSheet.test.ts
@@ -215,6 +215,22 @@ describe('rewriteStyleSheet', () => {
     expect(sheet.cssRules[0].getSelectors()).toContain('.pseudo-hover-all :is()');
   });
 
+  it('preserves zero specificity for pseudo-states inside ":where"', () => {
+    const sheet = new Sheet('.textLink:where(:focus-visible) { text-decoration: none }');
+    rewriteStyleSheet(sheet as any);
+    const selectors = sheet.cssRules[0].getSelectors();
+    expect(selectors).toContain(':where(.pseudo-focus-visible-all) .textLink');
+    expect(selectors).not.toContain('.pseudo-focus-visible-all .textLink:where(*)');
+  });
+
+  it('preserves the specificity of mixed pseudo-states inside and outside ":where"', () => {
+    const sheet = new Sheet('.textLink:where(:focus-visible):hover { text-decoration: none }');
+    rewriteStyleSheet(sheet as any);
+    expect(sheet.cssRules[0].getSelectors()).toContain(
+      ':where(.pseudo-focus-visible-all).pseudo-hover-all .textLink'
+    );
+  });
+
   it('adds alternative selector for each pseudo selector', () => {
     const sheet = new Sheet('a:hover, a:focus { color: red }');
     rewriteStyleSheet(sheet as any);

--- a/code/addons/pseudo-states/src/preview/rewriteStyleSheet.ts
+++ b/code/addons/pseudo-states/src/preview/rewriteStyleSheet.ts
@@ -81,6 +81,38 @@ const replacePseudoStateMatches = (
 // valid even after pseudo-state selectors are expanded.
 const maximumSelectorsPerRule = 4000;
 
+const findWhereRanges = (selector: string): [number, number][] => {
+  const ranges: [number, number][] = [];
+  let start = selector.indexOf(':where(');
+
+  while (start !== -1) {
+    let depth = 1;
+    let quote: string | undefined;
+
+    for (let index = start + ':where('.length; index < selector.length; index++) {
+      const character = selector[index];
+      if (character === '\\') {
+        index++;
+      } else if (quote) {
+        if (character === quote) {
+          quote = undefined;
+        }
+      } else if (character === '"' || character === "'") {
+        quote = character;
+      } else if (character === '(') {
+        depth++;
+      } else if (character === ')' && --depth === 0) {
+        ranges.push([start, index + 1]);
+        break;
+      }
+    }
+
+    start = selector.indexOf(':where(', start + ':where('.length);
+  }
+
+  return ranges;
+};
+
 const warnings = new Set();
 const warnOnce = (message: string) => {
   if (warnings.has(message)) {
@@ -119,7 +151,13 @@ const replacePseudoStatesWithAncestorSelector = (
     return selector;
   }
 
-  const selectors = `${additionalHostSelectors ?? ''}${extracted.states.map((s) => `.pseudo-${s}-all`).join('')}`;
+  const zeroSpecificitySelectors = extracted.zeroSpecificityStates
+    .map((state) => `.pseudo-${state}-all`)
+    .join('');
+  const selectors = `${additionalHostSelectors ?? ''}${zeroSpecificitySelectors ? `:where(${zeroSpecificitySelectors})` : ''}${extracted.states
+    .filter((state) => !extracted.zeroSpecificityStates.includes(state))
+    .map((state) => `.pseudo-${state}-all`)
+    .join('')}`;
 
   // If there was a :host-context() containing only pseudo-states, we will later add a :host selector that replaces it.
   let { withoutPseudoStates } = extracted;
@@ -136,7 +174,10 @@ const replacePseudoStatesWithAncestorSelector = (
 
 const extractPseudoStates = (selector: string) => {
   const states = new Set<string>();
+  const zeroSpecificityStates = new Set<string>();
+  const nonZeroSpecificityStates = new Set<string>();
   const matches = findPseudoStates(selector);
+  const whereRanges = findWhereRanges(selector);
   let withoutPseudoStates = '';
   let cursor = 0;
 
@@ -146,15 +187,29 @@ const extractPseudoStates = (selector: string) => {
       withoutPseudoStates += '*';
     }
     states.add(match.state);
+    const target = whereRanges.some(([start, end]) => match.index >= start && match.index < end)
+      ? zeroSpecificityStates
+      : nonZeroSpecificityStates;
+    target.add(match.state);
     cursor = match.index + match.text.length;
   });
   withoutPseudoStates += selector.slice(cursor);
 
   // If a selector list was left with blank items (e.g. ", foo, , bar, "), remove the extra commas/spaces.
-  withoutPseudoStates = withoutPseudoStates.replaceAll(/([\s(]),\s+|(,\s+)+(?=\))/g, '$1') || '*';
+  withoutPseudoStates = withoutPseudoStates.replaceAll(/([\s(]),\s+|(,\s+)+(?=\))/g, '$1');
+  // Remove a vacuous `:where(*)` when another selector already provides the subject.
+  withoutPseudoStates = withoutPseudoStates.replaceAll(':where(*)', (match, offset, input) =>
+    offset > 0 && !selectorStartPattern.test(input[offset - 1]) ? '' : match
+  );
+  withoutPseudoStates ||= '*';
+
+  for (const state of nonZeroSpecificityStates) {
+    zeroSpecificityStates.delete(state);
+  }
 
   return {
     states: Array.from(states),
+    zeroSpecificityStates: Array.from(zeroSpecificityStates),
     withoutPseudoStates,
   };
 };

--- a/code/addons/pseudo-states/src/preview/rewriteStyleSheet.ts
+++ b/code/addons/pseudo-states/src/preview/rewriteStyleSheet.ts
@@ -83,31 +83,30 @@ const maximumSelectorsPerRule = 4000;
 
 const findWhereRanges = (selector: string): [number, number][] => {
   const ranges: [number, number][] = [];
-  let start = selector.indexOf(':where(');
+  const parentheses: (number | undefined)[] = [];
+  let quote: string | undefined;
 
-  while (start !== -1) {
-    let depth = 1;
-    let quote: string | undefined;
-
-    for (let index = start + ':where('.length; index < selector.length; index++) {
-      const character = selector[index];
-      if (character === '\\') {
-        index++;
-      } else if (quote) {
-        if (character === quote) {
-          quote = undefined;
-        }
-      } else if (character === '"' || character === "'") {
-        quote = character;
-      } else if (character === '(') {
-        depth++;
-      } else if (character === ')' && --depth === 0) {
+  for (let index = 0; index < selector.length; index++) {
+    const character = selector[index];
+    if (character === '\\') {
+      index++;
+    } else if (quote) {
+      if (character === quote) {
+        quote = undefined;
+      }
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (selector.startsWith(':where(', index)) {
+      parentheses.push(index);
+      index += ':where('.length - 1;
+    } else if (character === '(') {
+      parentheses.push(undefined);
+    } else if (character === ')') {
+      const start = parentheses.pop();
+      if (start !== undefined) {
         ranges.push([start, index + 1]);
-        break;
       }
     }
-
-    start = selector.indexOf(':where(', start + ':where('.length);
   }
 
   return ranges;
@@ -197,10 +196,15 @@ const extractPseudoStates = (selector: string) => {
 
   // If a selector list was left with blank items (e.g. ", foo, , bar, "), remove the extra commas/spaces.
   withoutPseudoStates = withoutPseudoStates.replaceAll(/([\s(]),\s+|(,\s+)+(?=\))/g, '$1');
-  // Remove a vacuous `:where(*)` when another selector already provides the subject.
-  withoutPseudoStates = withoutPseudoStates.replaceAll(':where(*)', (match, offset, input) =>
-    offset > 0 && !selectorStartPattern.test(input[offset - 1]) ? '' : match
+  const vacuousWhereRanges = findWhereRanges(withoutPseudoStates).filter(
+    ([start, end]) =>
+      withoutPseudoStates.slice(start, end) === ':where(*)' &&
+      start > 0 &&
+      !selectorStartPattern.test(withoutPseudoStates[start - 1])
   );
+  for (const [start, end] of vacuousWhereRanges.reverse()) {
+    withoutPseudoStates = withoutPseudoStates.slice(0, start) + withoutPseudoStates.slice(end);
+  }
   withoutPseudoStates ||= '*';
 
   for (const state of nonZeroSpecificityStates) {


### PR DESCRIPTION
Closes #31411

## What I did

Preserve zero specificity when the pseudo-states addon rewrites a state inside `:where()` into its `.pseudo-*-all` ancestor form.

- Find balanced `:where()` ranges, including nested parentheses, quoted strings, and escapes.
- Wrap generated ancestor classes for states found only inside `:where()` in their own `:where()`.
- Keep states that also occur outside `:where()` specificity-bearing.
- Remove the attached vacuous `:where(*)` left after extracting the pseudo-state.
- Add regression coverage for the reported selector and for mixed states inside and outside `:where()`.

This follows the approach explored by @irfanfandi in #35838, adapted to the index-based pseudo-state matcher now on `next`. That earlier PR is currently reported by GitHub as conflicting and not rebaseable.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Start a React Vite sandbox.
2. Add `.textLink:where(:focus-visible) { text-decoration: none }` before `.textLink { text-decoration: underline }` in an imported stylesheet.
3. Render a link with `class="textLink"` and enable the `focus-visible` pseudo-state from the toolbar.
4. Confirm the link remains underlined. The rewritten ancestor selector should be `:where(.pseudo-focus-visible-all) .textLink`, so source order still decides the tie.
5. Confirm ordinary pseudo-states outside `:where()` continue to use specificity-bearing `.pseudo-*-all` ancestor classes.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update `MIGRATION.md`

No documentation change is needed because this restores existing behavior without adding or changing an API.
