### PR TITLE
UI: Fix focus trap, indicators and tab order in the mobile about overlay

### DIFF
--- a/code/core/src/components/components/Tabs/TabPanel.tsx
+++ b/code/core/src/components/components/Tabs/TabPanel.tsx
@@ -26,10 +26,17 @@ export interface TabPanelProps extends HTMLAttributes<HTMLDivElement> {
   renderAllChildren?: boolean;
 }
 
-const Panel = styled.div({
+// When a panel has no focusable content, react-aria makes the panel itself the tab stop, so it
+// needs a focus indicator of its own.
+const Panel = styled.div(({ theme }) => ({
   overflowY: 'hidden',
   height: '100%',
-});
+
+  '&:focus-visible': {
+    outline: `2px solid ${theme.color.secondary}`,
+    outlineOffset: -2,
+  },
+}));
 
 export const TabPanel: FC<TabPanelProps> = ({
   hasScrollbar = true,

--- a/code/core/src/components/components/Tabs/TabPanel.tsx
+++ b/code/core/src/components/components/Tabs/TabPanel.tsx
@@ -26,17 +26,10 @@ export interface TabPanelProps extends HTMLAttributes<HTMLDivElement> {
   renderAllChildren?: boolean;
 }
 
-// When a panel has no focusable content, react-aria makes the panel itself the tab stop, so it
-// needs a focus indicator of its own.
-const Panel = styled.div(({ theme }) => ({
+const Panel = styled.div({
   overflowY: 'hidden',
   height: '100%',
-
-  '&:focus-visible': {
-    outline: `2px solid ${theme.color.secondary}`,
-    outlineOffset: -2,
-  },
-}));
+});
 
 export const TabPanel: FC<TabPanelProps> = ({
   hasScrollbar = true,

--- a/code/core/src/components/components/typography/link/link.tsx
+++ b/code/core/src/components/components/typography/link/link.tsx
@@ -90,6 +90,7 @@ const A = styled.a<LinkStylesProps>(
     '&:focus-visible': {
       outline: `2px solid ${theme.color.secondary}`,
       outlineOffset: 2,
+      borderRadius: theme.input.borderRadius,
       // Should ensure focus outline gets drawn above next sibling
       zIndex: '1',
     },

--- a/code/core/src/components/components/typography/link/link.tsx
+++ b/code/core/src/components/components/typography/link/link.tsx
@@ -87,6 +87,13 @@ const A = styled.a<LinkStylesProps>(
       },
     },
 
+    '&:focus-visible': {
+      outline: `2px solid ${theme.color.secondary}`,
+      outlineOffset: 2,
+      // Should ensure focus outline gets drawn above next sibling
+      zIndex: '1',
+    },
+
     svg: {
       display: 'inline-block',
       height: '1em',
@@ -176,13 +183,6 @@ const A = styled.a<LinkStylesProps>(
           padding: 0,
           fontSize: 'inherit',
           lineHeight: 'inherit',
-
-          '&:focus-visible': {
-            outline: `2px solid ${theme.color.secondary}`,
-            outlineOffset: 2,
-            // Should ensure focus outline gets drawn above next sibling
-            zIndex: '1',
-          },
         }
       : {}
 );

--- a/code/core/src/components/index.ts
+++ b/code/core/src/components/index.ts
@@ -45,6 +45,9 @@ export { ActionList } from './components/ActionList/ActionList.tsx';
 export { Collapsible } from './components/Collapsible/Collapsible.tsx';
 export { Card } from './components/Card/Card.tsx';
 export { Modal, ModalDecorator } from './components/Modal/Modal.tsx';
+// Manager code must use this copy of @react-aria/focus: a FocusScope from another module instance
+// cannot nest inside the Modal's scope, so both scopes would handle each Tab press.
+export { FocusScope } from '@react-aria/focus';
 export { Spaced } from './components/spaced/Spaced.tsx';
 export { Placeholder } from './components/placeholder/placeholder.tsx';
 export { ScrollArea } from './components/ScrollArea/ScrollArea.tsx';

--- a/code/core/src/manager/components/mobile/about/MobileAbout.tsx
+++ b/code/core/src/manager/components/mobile/about/MobileAbout.tsx
@@ -1,11 +1,9 @@
 import type { FC } from 'react';
 import React, { useEffect, useRef } from 'react';
 
-import { Button, Link, ScrollArea } from 'storybook/internal/components';
+import { ActionList, Button, FocusScope, Link, ScrollArea } from 'storybook/internal/components';
 
 import { ArrowLeftIcon, GithubIcon, ShareAltIcon, StorybookIcon } from '@storybook/icons';
-
-import { FocusScope } from '@react-aria/focus';
 
 import { useTransitionState } from 'react-transition-state';
 import { keyframes, styled } from 'storybook/theming';
@@ -54,30 +52,44 @@ export const MobileAbout: FC = () => {
               <ArrowLeftIcon />
               Back
             </CloseButton>
-            <LinkContainer>
-              <LinkLine
-                href="https://github.com/storybookjs/storybook"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <LinkLeft>
-                  <GithubIcon />
-                  <span>Github</span>
-                </LinkLeft>
-                <ShareAltIcon width={12} />
-              </LinkLine>
-              <LinkLine
-                href="https://storybook.js.org/docs/get-started/install?ref=ui"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <LinkLeft>
-                  <StorybookIcon />
-                  <span>Documentation</span>
-                </LinkLeft>
-                <ShareAltIcon width={12} />
-              </LinkLine>
-            </LinkContainer>
+            <LinkList>
+              <ActionList.Item>
+                <ActionList.Link
+                  ariaLabel={false}
+                  href="https://github.com/storybookjs/storybook"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <ActionList.Icon>
+                    <GithubIcon />
+                  </ActionList.Icon>
+                  <ActionList.Text>
+                    <span>Github</span>
+                  </ActionList.Text>
+                  <ActionList.Icon>
+                    <ShareAltIcon />
+                  </ActionList.Icon>
+                </ActionList.Link>
+              </ActionList.Item>
+              <ActionList.Item>
+                <ActionList.Link
+                  ariaLabel={false}
+                  href="https://storybook.js.org/docs/get-started/install?ref=ui"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <ActionList.Icon>
+                    <StorybookIcon />
+                  </ActionList.Icon>
+                  <ActionList.Text>
+                    <span>Documentation</span>
+                  </ActionList.Text>
+                  <ActionList.Icon>
+                    <ShareAltIcon />
+                  </ActionList.Icon>
+                </ActionList.Link>
+              </ActionList.Item>
+            </LinkList>
             <UpgradeBlock />
             <BottomText>
               Open source software maintained by{' '}
@@ -147,30 +159,9 @@ const InnerArea = styled.div({
   padding: '25px 12px 20px',
 });
 
-const LinkContainer = styled.div({});
-
-const LinkLine = styled.a(({ theme }) => ({
-  all: 'unset',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  fontSize: theme.typography.size.s2 - 1,
-  borderBottom: `1px solid ${theme.appBorderColor}`,
-  cursor: 'pointer',
-  padding: '0 10px',
-
-  '&:last-child': {
-    borderBottom: 'none',
-  },
-}));
-
-const LinkLeft = styled.div(({ theme }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  fontSize: theme.typography.size.s2 - 1,
-  height: 40,
-  gap: 5,
-}));
+const LinkList = styled(ActionList)({
+  padding: 0,
+});
 
 const BottomText = styled.div(({ theme }) => ({
   fontSize: theme.typography.size.s2 - 1,

--- a/code/core/src/manager/components/mobile/about/MobileAbout.tsx
+++ b/code/core/src/manager/components/mobile/about/MobileAbout.tsx
@@ -5,6 +5,8 @@ import { Button, Link, ScrollArea } from 'storybook/internal/components';
 
 import { ArrowLeftIcon, GithubIcon, ShareAltIcon, StorybookIcon } from '@storybook/icons';
 
+import { FocusScope } from '@react-aria/focus';
+
 import { useTransitionState } from 'react-transition-state';
 import { keyframes, styled } from 'storybook/theming';
 
@@ -37,57 +39,62 @@ export const MobileAbout: FC = () => {
       $status={state.status}
       $transitionDuration={MOBILE_TRANSITION_DURATION}
     >
-      <ScrollArea vertical offset={3} scrollbarSize={6}>
-        <InnerArea>
-          <CloseButton
-            onClick={() => setMobileAboutOpen(false)}
-            ariaLabel="Close about section"
-            tooltip="Close about section"
-            variant="ghost"
-          >
-            <ArrowLeftIcon />
-            Back
-          </CloseButton>
-          <LinkContainer>
-            <LinkLine
-              href="https://github.com/storybookjs/storybook"
-              target="_blank"
-              rel="noopener noreferrer"
+      {/* The overlay covers the menu drawer's content but stays inside its focus scope, so without
+       a scope of its own, Tab would keep cycling through the obscured menu underneath. */}
+      {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
+      <FocusScope contain restoreFocus autoFocus>
+        <ScrollArea vertical offset={3} scrollbarSize={6}>
+          <InnerArea>
+            <CloseButton
+              onClick={() => setMobileAboutOpen(false)}
+              ariaLabel="Close about section"
+              tooltip="Close about section"
+              variant="ghost"
             >
-              <LinkLeft>
-                <GithubIcon />
-                <span>Github</span>
-              </LinkLeft>
-              <ShareAltIcon width={12} />
-            </LinkLine>
-            <LinkLine
-              href="https://storybook.js.org/docs/get-started/install?ref=ui"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <LinkLeft>
-                <StorybookIcon />
-                <span>Documentation</span>
-              </LinkLeft>
-              <ShareAltIcon width={12} />
-            </LinkLine>
-          </LinkContainer>
-          <UpgradeBlock />
-          <BottomText>
-            Open source software maintained by{' '}
-            <Link href="https://chromatic.com" target="_blank" rel="noopener noreferrer">
-              Chromatic
-            </Link>{' '}
-            and the{' '}
-            <Link
-              href="https://github.com/storybookjs/storybook/graphs/contributors"
-              rel="noopener noreferrer"
-            >
-              Storybook Community
-            </Link>
-          </BottomText>
-        </InnerArea>
-      </ScrollArea>
+              <ArrowLeftIcon />
+              Back
+            </CloseButton>
+            <LinkContainer>
+              <LinkLine
+                href="https://github.com/storybookjs/storybook"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <LinkLeft>
+                  <GithubIcon />
+                  <span>Github</span>
+                </LinkLeft>
+                <ShareAltIcon width={12} />
+              </LinkLine>
+              <LinkLine
+                href="https://storybook.js.org/docs/get-started/install?ref=ui"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <LinkLeft>
+                  <StorybookIcon />
+                  <span>Documentation</span>
+                </LinkLeft>
+                <ShareAltIcon width={12} />
+              </LinkLine>
+            </LinkContainer>
+            <UpgradeBlock />
+            <BottomText>
+              Open source software maintained by{' '}
+              <Link href="https://chromatic.com" target="_blank" rel="noopener noreferrer">
+                Chromatic
+              </Link>{' '}
+              and the{' '}
+              <Link
+                href="https://github.com/storybookjs/storybook/graphs/contributors"
+                rel="noopener noreferrer"
+              >
+                Storybook Community
+              </Link>
+            </BottomText>
+          </InnerArea>
+        </ScrollArea>
+      </FocusScope>
     </Container>
   );
 };

--- a/code/core/src/manager/components/mobile/navigation/MobileNavigation.stories.tsx
+++ b/code/core/src/manager/components/mobile/navigation/MobileNavigation.stories.tsx
@@ -286,7 +286,8 @@ export const AboutResetOnReopen: Story = {
 };
 
 // The about overlay covers the menu inside the drawer, so it must trap focus: without a trap,
-// tabbing keeps cycling through the obscured menu underneath (regression test).
+// tabbing keeps cycling through the obscured menu underneath. Every stop is asserted, so both
+// escaping the overlay and skipping an element fail the test (regression test).
 export const AboutFocusTrapped: Story = {
   play: async (context) => {
     // @ts-expect-error (non strict)
@@ -296,13 +297,22 @@ export const AboutFocusTrapped: Story = {
     const backButton = await screen.findByLabelText('Close about section');
     await waitFor(() => expect(backButton).toHaveFocus());
 
-    const menuCloseButton = screen.getByLabelText('Close navigation menu');
-    const aboutOpenButton = screen.getByLabelText('About Storybook');
-    for (let i = 0; i < 12; i += 1) {
-      await userEvent.tab();
-      expect(menuCloseButton).not.toHaveFocus();
-      expect(aboutOpenButton).not.toHaveFocus();
-    }
+    await userEvent.tab();
+    await expect(screen.getByRole('link', { name: 'Github' })).toHaveFocus();
+    await userEvent.tab();
+    await expect(screen.getByRole('link', { name: 'Documentation' })).toHaveFocus();
+    await userEvent.tab();
+    await expect(screen.getByRole('switch', { name: 'npm' })).toHaveFocus();
+    await userEvent.tab();
+    await expect(screen.getByRole('switch', { name: 'yarn' })).toHaveFocus();
+    await userEvent.tab();
+    await expect(screen.getByRole('switch', { name: 'pnpm' })).toHaveFocus();
+    await userEvent.tab();
+    await expect(screen.getByRole('link', { name: 'Chromatic' })).toHaveFocus();
+    await userEvent.tab();
+    await expect(screen.getByRole('link', { name: 'Storybook Community' })).toHaveFocus();
+    await userEvent.tab();
+    await expect(backButton).toHaveFocus();
   },
 };
 

--- a/code/core/src/manager/components/mobile/navigation/MobileNavigation.stories.tsx
+++ b/code/core/src/manager/components/mobile/navigation/MobileNavigation.stories.tsx
@@ -285,6 +285,27 @@ export const AboutResetOnReopen: Story = {
   },
 };
 
+// The about overlay covers the menu inside the drawer, so it must trap focus: without a trap,
+// tabbing keeps cycling through the obscured menu underneath (regression test).
+export const AboutFocusTrapped: Story = {
+  play: async (context) => {
+    // @ts-expect-error (non strict)
+    await MenuOpen.play(context);
+    await userEvent.click(await screen.findByLabelText('About Storybook'));
+
+    const backButton = await screen.findByLabelText('Close about section');
+    await waitFor(() => expect(backButton).toHaveFocus());
+
+    const menuCloseButton = screen.getByLabelText('Close navigation menu');
+    const aboutOpenButton = screen.getByLabelText('About Storybook');
+    for (let i = 0; i < 12; i += 1) {
+      await userEvent.tab();
+      expect(menuCloseButton).not.toHaveFocus();
+      expect(aboutOpenButton).not.toHaveFocus();
+    }
+  },
+};
+
 export const ReactNodeRenderLabel: Story = {
   decorators: [
     (storyFn) => {

--- a/code/core/src/manager/components/mobile/navigation/MobileNavigation.stories.tsx
+++ b/code/core/src/manager/components/mobile/navigation/MobileNavigation.stories.tsx
@@ -301,12 +301,16 @@ export const AboutFocusTrapped: Story = {
     await expect(screen.getByRole('link', { name: 'Github' })).toHaveFocus();
     await userEvent.tab();
     await expect(screen.getByRole('link', { name: 'Documentation' })).toHaveFocus();
+    // The package manager tabs are a single stop with a roving tabindex.
     await userEvent.tab();
-    await expect(screen.getByRole('switch', { name: 'npm' })).toHaveFocus();
+    await expect(screen.getByRole('tab', { name: 'npm' })).toHaveFocus();
+    await userEvent.keyboard('{ArrowRight}');
+    await expect(screen.getByRole('tab', { name: 'yarn' })).toHaveFocus();
+    await userEvent.keyboard('{ArrowLeft}');
+    await expect(screen.getByRole('tab', { name: 'npm' })).toHaveFocus();
+    // The code block has no focusable content, so the panel itself is the next stop.
     await userEvent.tab();
-    await expect(screen.getByRole('switch', { name: 'yarn' })).toHaveFocus();
-    await userEvent.tab();
-    await expect(screen.getByRole('switch', { name: 'pnpm' })).toHaveFocus();
+    await expect(screen.getByRole('tabpanel')).toHaveFocus();
     await userEvent.tab();
     await expect(screen.getByRole('link', { name: 'Chromatic' })).toHaveFocus();
     await userEvent.tab();

--- a/code/core/src/manager/components/mobile/navigation/MobileNavigation.stories.tsx
+++ b/code/core/src/manager/components/mobile/navigation/MobileNavigation.stories.tsx
@@ -308,9 +308,8 @@ export const AboutFocusTrapped: Story = {
     await expect(screen.getByRole('tab', { name: 'yarn' })).toHaveFocus();
     await userEvent.keyboard('{ArrowLeft}');
     await expect(screen.getByRole('tab', { name: 'npm' })).toHaveFocus();
-    // The code block has no focusable content, so the panel itself is the next stop.
     await userEvent.tab();
-    await expect(screen.getByRole('tabpanel')).toHaveFocus();
+    await expect(screen.getByRole('button', { name: 'Copy command' })).toHaveFocus();
     await userEvent.tab();
     await expect(screen.getByRole('link', { name: 'Chromatic' })).toHaveFocus();
     await userEvent.tab();

--- a/code/core/src/manager/components/upgrade/UpgradeBlock.tsx
+++ b/code/core/src/manager/components/upgrade/UpgradeBlock.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import React, { useState } from 'react';
 
-import { Link } from 'storybook/internal/components';
+import { Link, ToggleButton } from 'storybook/internal/components';
 
 import { useStorybookApi } from 'storybook/manager-api';
 import { styled } from 'storybook/theming';
@@ -21,15 +21,33 @@ export const UpgradeBlock: FC<UpgradeBlockProps> = ({ onNavigateToWhatsNew }) =>
       <strong>You are on Storybook {api.getCurrentVersion().version}</strong>
       <p>Run the following script to check for updates and upgrade to the latest version.</p>
       <Tabs>
-        <ButtonTab active={activeTab === 'npm'} onClick={() => setActiveTab('npm')}>
+        <ToggleButton
+          ariaLabel={false}
+          variant="ghost"
+          size="small"
+          pressed={activeTab === 'npm'}
+          onClick={() => setActiveTab('npm')}
+        >
           npm
-        </ButtonTab>
-        <ButtonTab active={activeTab === 'yarn'} onClick={() => setActiveTab('yarn')}>
+        </ToggleButton>
+        <ToggleButton
+          ariaLabel={false}
+          variant="ghost"
+          size="small"
+          pressed={activeTab === 'yarn'}
+          onClick={() => setActiveTab('yarn')}
+        >
           yarn
-        </ButtonTab>
-        <ButtonTab active={activeTab === 'pnpm'} onClick={() => setActiveTab('pnpm')}>
+        </ToggleButton>
+        <ToggleButton
+          ariaLabel={false}
+          variant="ghost"
+          size="small"
+          pressed={activeTab === 'pnpm'}
+          onClick={() => setActiveTab('pnpm')}
+        >
           pnpm
-        </ButtonTab>
+        </ToggleButton>
       </Tabs>
       <Code>
         {activeTab === 'npm'
@@ -60,23 +78,11 @@ const Container = styled.div(({ theme }) => ({
 const Tabs = styled.div({
   display: 'flex',
   gap: 2,
+  marginBottom: 5,
 });
 
 const Code = styled.pre(({ theme }) => ({
   background: theme.base === 'light' ? 'rgba(0, 0, 0, 0.05)' : theme.appBorderColor,
   fontSize: theme.typography.size.s2 - 1,
   margin: '4px 0 16px',
-}));
-
-const ButtonTab = styled.button<{ active: boolean }>(({ theme, active }) => ({
-  all: 'unset',
-  alignItems: 'center',
-  gap: 10,
-  color: theme.color.defaultText,
-  fontSize: theme.typography.size.s2 - 1,
-  borderBottom: '2px solid transparent',
-  borderBottomColor: active ? theme.color.secondary : 'none',
-  padding: '0 10px 5px',
-  marginBottom: '5px',
-  cursor: 'pointer',
 }));

--- a/code/core/src/manager/components/upgrade/UpgradeBlock.tsx
+++ b/code/core/src/manager/components/upgrade/UpgradeBlock.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
-import React, { useState } from 'react';
+import React from 'react';
 
-import { Link, ToggleButton } from 'storybook/internal/components';
+import { Link, TabList, TabPanel, useTabsState } from 'storybook/internal/components';
 
 import { useStorybookApi } from 'storybook/manager-api';
 import { styled } from 'storybook/theming';
@@ -14,46 +14,21 @@ interface UpgradeBlockProps {
 
 export const UpgradeBlock: FC<UpgradeBlockProps> = ({ onNavigateToWhatsNew }) => {
   const api = useStorybookApi();
-  const [activeTab, setActiveTab] = useState<'npm' | 'yarn' | 'pnpm'>('npm');
+  const tabsState = useTabsState({
+    defaultSelected: 'npm',
+    tabs: [
+      { id: 'npm', title: 'npm', children: <Code>npx storybook@latest upgrade</Code> },
+      { id: 'yarn', title: 'yarn', children: <Code>yarn dlx storybook@latest upgrade</Code> },
+      { id: 'pnpm', title: 'pnpm', children: <Code>pnpm dlx storybook@latest upgrade</Code> },
+    ],
+  });
 
   return (
     <Container>
       <strong>You are on Storybook {api.getCurrentVersion().version}</strong>
       <p>Run the following script to check for updates and upgrade to the latest version.</p>
-      <Tabs>
-        <ToggleButton
-          ariaLabel={false}
-          variant="ghost"
-          size="small"
-          pressed={activeTab === 'npm'}
-          onClick={() => setActiveTab('npm')}
-        >
-          npm
-        </ToggleButton>
-        <ToggleButton
-          ariaLabel={false}
-          variant="ghost"
-          size="small"
-          pressed={activeTab === 'yarn'}
-          onClick={() => setActiveTab('yarn')}
-        >
-          yarn
-        </ToggleButton>
-        <ToggleButton
-          ariaLabel={false}
-          variant="ghost"
-          size="small"
-          pressed={activeTab === 'pnpm'}
-          onClick={() => setActiveTab('pnpm')}
-        >
-          pnpm
-        </ToggleButton>
-      </Tabs>
-      <Code>
-        {activeTab === 'npm'
-          ? 'npx storybook@latest upgrade'
-          : `${activeTab} dlx storybook@latest upgrade`}
-      </Code>
+      <TabList state={tabsState} />
+      <TabPanel state={tabsState} hasScrollbar={false} />
       {onNavigateToWhatsNew && (
         <Link onClick={onNavigateToWhatsNew}>See what's new in Storybook</Link>
       )}
@@ -74,12 +49,6 @@ const Container = styled.div(({ theme }) => ({
     maxWidth: 400,
   },
 }));
-
-const Tabs = styled.div({
-  display: 'flex',
-  gap: 2,
-  marginBottom: 5,
-});
 
 const Code = styled.pre(({ theme }) => ({
   background: theme.base === 'light' ? 'rgba(0, 0, 0, 0.05)' : theme.appBorderColor,

--- a/code/core/src/manager/components/upgrade/UpgradeBlock.tsx
+++ b/code/core/src/manager/components/upgrade/UpgradeBlock.tsx
@@ -21,6 +21,7 @@ const UpgradeSnippet: FC<{ command: string }> = ({ command }) => {
     childrenOnCopy: <CheckIcon />,
     content: command,
     ariaLabel: 'Copy command',
+    ariaLabelOnCopy: 'Command copied',
   });
 
   return (

--- a/code/core/src/manager/components/upgrade/UpgradeBlock.tsx
+++ b/code/core/src/manager/components/upgrade/UpgradeBlock.tsx
@@ -1,25 +1,58 @@
 import type { FC } from 'react';
 import React from 'react';
 
-import { Link, TabList, TabPanel, useTabsState } from 'storybook/internal/components';
+import { Button, Link, TabList, TabPanel, useTabsState } from 'storybook/internal/components';
+
+import { CheckIcon, CopyIcon } from '@storybook/icons';
 
 import { useStorybookApi } from 'storybook/manager-api';
 import { styled } from 'storybook/theming';
 
+import { useCopyButton } from '../../../shared/useCopyButton.ts';
 import { MEDIA_DESKTOP_BREAKPOINT } from '../../constants.ts';
 
 interface UpgradeBlockProps {
   onNavigateToWhatsNew?: () => void;
 }
 
+const UpgradeSnippet: FC<{ command: string }> = ({ command }) => {
+  const { children, buttonProps } = useCopyButton({
+    children: <CopyIcon />,
+    childrenOnCopy: <CheckIcon />,
+    content: command,
+    ariaLabel: 'Copy command',
+  });
+
+  return (
+    <Code>
+      {command}
+      <Button variant="ghost" padding="small" size="small" {...buttonProps}>
+        {children}
+      </Button>
+    </Code>
+  );
+};
+
 export const UpgradeBlock: FC<UpgradeBlockProps> = ({ onNavigateToWhatsNew }) => {
   const api = useStorybookApi();
   const tabsState = useTabsState({
     defaultSelected: 'npm',
     tabs: [
-      { id: 'npm', title: 'npm', children: <Code>npx storybook@latest upgrade</Code> },
-      { id: 'yarn', title: 'yarn', children: <Code>yarn dlx storybook@latest upgrade</Code> },
-      { id: 'pnpm', title: 'pnpm', children: <Code>pnpm dlx storybook@latest upgrade</Code> },
+      {
+        id: 'npm',
+        title: 'npm',
+        children: <UpgradeSnippet command="npx storybook@latest upgrade" />,
+      },
+      {
+        id: 'yarn',
+        title: 'yarn',
+        children: <UpgradeSnippet command="yarn dlx storybook@latest upgrade" />,
+      },
+      {
+        id: 'pnpm',
+        title: 'pnpm',
+        children: <UpgradeSnippet command="pnpm dlx storybook@latest upgrade" />,
+      },
     ],
   });
 
@@ -51,6 +84,10 @@ const Container = styled.div(({ theme }) => ({
 }));
 
 const Code = styled.pre(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 8,
   background: theme.base === 'light' ? 'rgba(0, 0, 0, 0.05)' : theme.appBorderColor,
   fontSize: theme.typography.size.s2 - 1,
   margin: '4px 0 16px',

--- a/code/core/src/manager/globals/exports.ts
+++ b/code/core/src/manager/globals/exports.ts
@@ -520,6 +520,7 @@ export default {
     'EmptyTabContent',
     'ErrorFormatter',
     'FlexBar',
+    'FocusScope',
     'Form',
     'H1',
     'H2',


### PR DESCRIPTION
## What I did

Three keyboard-accessibility fixes for the about/settings overlay opened from the cog button in the mobile menu drawer:

**1. Focus trap.** The overlay covers the sidebar visually, but stayed inside the drawer's focus scope: Tab kept cycling through the obscured sidebar underneath. The overlay content is now wrapped in its own react-aria `FocusScope` (`contain` + `autoFocus` + `restoreFocus`), nested inside the drawer modal's scope: opening moves focus to the Back button, Tab cycles only through the overlay, and closing returns focus to the cog button.

**2. Focus indicators.** The Github/Documentation rows and the npm/yarn/pnpm package-manager tabs were hand-rolled `styled.a`/`styled.button` elements with `all: unset`, which strips the focus outline entirely, and the DS `Link` anchor form had no focus-visible outline either — it was impossible to see what was focused. They now use design-system components:
- the link rows are built on `ActionList` (`ActionList.Link`), same as the desktop cog menu;
- the package-manager tabs compose the DS `TabList`/`TabPanel` (via `useTabsState`): real `tablist`/`tab`/`tabpanel` semantics with arrow-key navigation and a single Tab stop, the DS tab focus ring, and the underline-tab look — the old tabs conveyed the selection through border color alone and each was a separate Tab stop;
- the upgrade command snippet gets a copy button (shared `useCopyButton` hook), which is both a usability win and gives each tab panel focusable content, so react-aria never has to make the bare panel a tab stop;
- the `Link` component's anchor form gets the same `:focus-visible` outline its button form already had (this benefits every `Link` in the UI).

**3. Tab order skipped every other element.** The built manager carries two copies of `@react-aria/focus`: one inside the `storybook/internal/components` bundle (used by `Modal`) and one bundled into the manager chunk (used by the overlay's direct import). Focus scopes from separate module copies cannot nest — each copy has its own scope tree and active-scope state — so *both* `contain` scopes advanced focus on every Tab press, stepping by two and skipping alternate elements. `FocusScope` is now re-exported from `storybook/internal/components` and the manager imports it from there, so both scopes come from the same instance and nest correctly. (`manager/globals/exports.ts` is regenerated accordingly.)

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories (`AboutFocusTrapped` in `MobileNavigation.stories.tsx` asserts every stop of the Tab cycle in order — including arrow-key navigation within the tablist — so escaping the overlay, skipping an element, or broken tab semantics fail the test; run via the Storybook Vitest project)
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Note: the Vitest browser environment builds everything from source with a single `@react-aria/focus` copy, so the double-stepping only manifests against the built manager — verify it manually per below.

#### Manual testing

1. Run the internal Storybook UI: `cd code && yarn storybook:ui`
2. Open it in a browser and narrow the window below 600px (or use a mobile device emulation)
3. Open the sidebar via the bottom bar menu button, then click the cog ("About Storybook") button in the sidebar header
4. Press Tab repeatedly: focus starts on "Back" and moves through every stop in order — Github, Documentation, the package-manager tablist (arrow keys switch npm/yarn/pnpm), the snippet's copy button, Chromatic, Storybook Community — then wraps to "Back"; nothing in the sidebar underneath is reached and no stop is skipped
5. Every focused element shows a visible indicator
6. Click the copy button: the clipboard receives the command for the selected package manager and the button briefly shows a checkmark
7. Click "Back": focus returns to the cog button

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169Un4YR1Bvn5ATuAeXidrZ