### PR TITLE
UI: Reset the mobile about overlay when the menu drawer closes

### DIFF
--- a/code/core/src/manager/components/mobile/navigation/MobileMenuDrawer.tsx
+++ b/code/core/src/manager/components/mobile/navigation/MobileMenuDrawer.tsx
@@ -1,9 +1,10 @@
 import type { FC, ReactNode } from 'react';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { Modal } from 'storybook/internal/components';
 
 import { MOBILE_TRANSITION_DURATION } from '../../../constants.ts';
+import { useLayout } from '../../layout/LayoutProvider.tsx';
 import { MobileAbout } from '../about/MobileAbout.tsx';
 
 interface MobileMenuDrawerProps {
@@ -19,6 +20,17 @@ export const MobileMenuDrawer: FC<MobileMenuDrawerProps> = ({
   isOpen,
   onOpenChange,
 }) => {
+  const { setMobileAboutOpen } = useLayout();
+
+  // Reset the about overlay when the drawer closes, so reopening shows the menu again. Delayed
+  // until the drawer's exit transition is done, so the menu does not flash in underneath.
+  useEffect(() => {
+    if (!isOpen) {
+      const timeout = setTimeout(setMobileAboutOpen, MOBILE_TRANSITION_DURATION, false);
+      return () => clearTimeout(timeout);
+    }
+  }, [isOpen, setMobileAboutOpen]);
+
   return (
     <Modal
       ariaLabel="Menu"

--- a/code/core/src/manager/components/mobile/navigation/MobileNavigation.stories.tsx
+++ b/code/core/src/manager/components/mobile/navigation/MobileNavigation.stories.tsx
@@ -7,6 +7,7 @@ import { startCase } from 'es-toolkit/string';
 import { ManagerContext, useStorybookApi } from 'storybook/manager-api';
 import { expect, fn, screen, userEvent, waitFor } from 'storybook/test';
 
+import { MOBILE_TRANSITION_DURATION } from '../../../constants.ts';
 import { LayoutProvider, useLayout } from '../../layout/LayoutProvider.tsx';
 import { MobileNavigation } from './MobileNavigation.tsx';
 
@@ -23,7 +24,6 @@ const MockMenu = () => {
       >
         close
       </button>
-      {/* Mirrors the sidebar's cog button, which opens the about overlay on mobile. */}
       <button type="button" aria-label="About Storybook" onClick={() => setMobileAboutOpen(true)}>
         about
       </button>
@@ -96,7 +96,6 @@ const MockManagerProvider: FC<
   const value: any = useMemo(() => {
     const api = {
       getCurrentStoryData: fn(() => index.someStoryId),
-      // The about overlay's upgrade block reads the current version.
       getCurrentVersion: () => ({ version: '0.0.0' }),
       getShortcutKeys: () => ({ toggleNav: ['alt', 'S'] }),
       setMobileNavigation: (show: boolean) => setShowMobileNavigation(show),
@@ -111,7 +110,7 @@ const MockManagerProvider: FC<
       },
       api,
     };
-  }, [index, showMobileNavigation, exposeApi]);
+  }, [index, showMobileNavigation]);
 
   // Expose the live api for the shortcut story on commit, not during render.
   useEffect(() => {
@@ -274,7 +273,7 @@ export const AboutResetOnReopen: Story = {
       expect(screen.queryByLabelText('Close about section')).not.toBeInTheDocument()
     );
     // The reset is delayed until the drawer's exit transition is done.
-    await new Promise((resolve) => setTimeout(resolve, 400));
+    await new Promise((resolve) => setTimeout(resolve, MOBILE_TRANSITION_DURATION + 50));
 
     // @ts-expect-error (non strict)
     await MenuOpen.play(context);

--- a/code/core/src/manager/components/mobile/navigation/MobileNavigation.stories.tsx
+++ b/code/core/src/manager/components/mobile/navigation/MobileNavigation.stories.tsx
@@ -5,13 +5,14 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { startCase } from 'es-toolkit/string';
 import { ManagerContext, useStorybookApi } from 'storybook/manager-api';
-import { expect, fn, screen, userEvent } from 'storybook/test';
+import { expect, fn, screen, userEvent, waitFor } from 'storybook/test';
 
 import { LayoutProvider, useLayout } from '../../layout/LayoutProvider.tsx';
 import { MobileNavigation } from './MobileNavigation.tsx';
 
 const MockMenu = () => {
   const api = useStorybookApi();
+  const { setMobileAboutOpen } = useLayout();
   return (
     <div>
       menu
@@ -21,6 +22,10 @@ const MockMenu = () => {
         onClick={() => api.setMobileNavigation(false)}
       >
         close
+      </button>
+      {/* Mirrors the sidebar's cog button, which opens the about overlay on mobile. */}
+      <button type="button" aria-label="About Storybook" onClick={() => setMobileAboutOpen(true)}>
+        about
       </button>
     </div>
   );
@@ -91,6 +96,8 @@ const MockManagerProvider: FC<
   const value: any = useMemo(() => {
     const api = {
       getCurrentStoryData: fn(() => index.someStoryId),
+      // The about overlay's upgrade block reads the current version.
+      getCurrentVersion: () => ({ version: '0.0.0' }),
       getShortcutKeys: () => ({ toggleNav: ['alt', 'S'] }),
       setMobileNavigation: (show: boolean) => setShowMobileNavigation(show),
       toggleNav: (nextState?: boolean) =>
@@ -250,6 +257,32 @@ export const PanelClosed: Story = {
 export const PanelDisabled: Story = {
   args: {
     showPanel: false,
+  },
+};
+
+// Closing the drawer while the about overlay is open must reset it, so the drawer reopens on the
+// menu rather than on the overlay (regression test).
+export const AboutResetOnReopen: Story = {
+  play: async (context) => {
+    // @ts-expect-error (non strict)
+    await MenuOpen.play(context);
+    await userEvent.click(await screen.findByLabelText('About Storybook'));
+    await screen.findByLabelText('Close about section');
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() =>
+      expect(screen.queryByLabelText('Close about section')).not.toBeInTheDocument()
+    );
+    // The reset is delayed until the drawer's exit transition is done.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    // @ts-expect-error (non strict)
+    await MenuOpen.play(context);
+    // waitFor, as the reopened drawer fades in and starts fully transparent
+    await waitFor(async () =>
+      expect(await screen.findByLabelText('Close navigation menu')).toBeVisible()
+    );
+    expect(screen.queryByLabelText('Close about section')).not.toBeInTheDocument();
   },
 };
 


### PR DESCRIPTION
## What I did

On mobile, opening the about/settings overlay (cog button in the sidebar header) and then closing the drawer — by pressing Escape, tapping the underlay, or picking a story — left `isMobileAboutOpen` set in `LayoutProvider`. Reopening the sidebar then showed the about overlay again instead of the menu.

`MobileMenuDrawer` now resets the overlay state when the drawer closes. The reset is delayed by the drawer's transition duration so the menu does not flash in underneath the overlay while the drawer slides away.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories (`AboutResetOnReopen` in `MobileNavigation.stories.tsx`, run via the Storybook Vitest project)
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run the internal Storybook UI: `cd code && yarn storybook:ui`
2. Open it in a browser and narrow the window below 600px (or use a mobile device emulation)
3. Open the sidebar via the bottom bar menu button, then click the cog ("About Storybook") button in the sidebar header
4. Close the drawer while the about overlay is showing (press Escape or tap the dimmed area above the drawer)
5. Reopen the sidebar: it should show the menu, not the about overlay

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169Un4YR1Bvn5ATuAeXidrZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0169Un4YR1Bvn5ATuAeXidrZ)_