### PR TITLE
UI: Make settings pages scrollable in mobile layout

### DIFF
--- a/code/core/src/manager/components/layout/Layout.stories.tsx
+++ b/code/core/src/manager/components/layout/Layout.stories.tsx
@@ -517,6 +517,27 @@ export const MobileDocs = {
   },
 };
 
+// Pages taller than the viewport must scroll internally on mobile; the layout root hides overflow,
+// so a pages container sized by its content would leave no way to reach the rest (regression test).
+export const MobilePages: Story = {
+  ...Mobile,
+  args: {
+    managerLayoutState: { ...defaultState, viewMode: 'settings' },
+    slotPages: (
+      <div data-testid="pages" style={{ overflow: 'auto' }}>
+        <div style={{ height: 2000 }}>tall page content</div>
+      </div>
+    ),
+  },
+  play: async ({ canvas }) => {
+    const main = await canvas.findByRole('main', { name: 'Main content' });
+    expect(main.getBoundingClientRect().height).toBeLessThanOrEqual(window.innerHeight);
+
+    const pages = canvas.getByTestId('pages');
+    expect(pages.scrollHeight).toBeGreaterThan(pages.clientHeight);
+  },
+};
+
 export const MobileReview: Story = {
   ...Mobile,
   args: {

--- a/code/core/src/manager/components/layout/MainAreaContainer.tsx
+++ b/code/core/src/manager/components/layout/MainAreaContainer.tsx
@@ -14,12 +14,19 @@ interface PagesContainerProps {
 const PagesInnerContainer = styled.main(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
-  gridRowStart: 'sidebar-start',
-  gridRowEnd: '-1',
-  gridColumnStart: 'sidebar-end',
-  gridColumnEnd: '-1',
+  // On mobile the layout root is a column flexbox; fill it and let pages scroll internally
+  // instead of growing past the viewport, which is not scrollable.
+  flex: 1,
+  minHeight: 0,
   backgroundColor: theme.appContentBg,
   zIndex: 1,
+
+  [MEDIA_DESKTOP_BREAKPOINT]: {
+    gridRowStart: 'sidebar-start',
+    gridRowEnd: '-1',
+    gridColumnStart: 'sidebar-end',
+    gridColumnEnd: '-1',
+  },
 }));
 
 /**


### PR DESCRIPTION
## What I did

On mobile, the settings pages (About, Guide, Keyboard shortcuts) were not scrollable at all. The pages container (`PagesInnerContainer`) was placed with grid line names that only exist in the desktop grid layout; in the mobile column flexbox those are ignored, so the container was sized by its content and overflowed the `overflow: hidden` layout root. Content taller than the viewport was simply unreachable.

It also made the onboarding guide a trap: opening a checklist item navigates to `/settings/guide#item`, whose anchor `scrollIntoView` scrolled the hidden-overflow ancestor and could push the tab bar (with the close button) off screen, with no way to scroll back.

<a href="http://localhost:6006/?path=/settings/guide#accessibilityTests">
<img width="258" height="373" alt="image" src="https://github.com/user-attachments/assets/b052476f-a452-492a-a8bd-a62278dbc2fa" /></a>


The fix makes the pages container fill the layout root on mobile (`flex: 1; minHeight: 0`) so pages keep the viewport height and scroll internally through their own `ScrollArea`, and scopes the grid placement to the desktop breakpoint. Desktop rendering is unchanged.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories (`MobilePages` in `Layout.stories.tsx`, run via the Storybook Vitest project)
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run the internal Storybook UI: `cd code && yarn storybook:ui`
2. Open it in a browser and narrow the window below 600px (or use a mobile device emulation)
3. Open the sidebar and click "Open onboarding guide" in the checklist widget (or navigate to `/?path=/settings/guide`)
4. The guide should scroll (wheel/touch), the tab bar should stay pinned at the top, and the close button should remain reachable
5. Check the About and Keyboard shortcuts tabs also scroll when their content is taller than the viewport

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169Un4YR1Bvn5ATuAeXidrZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0169Un4YR1Bvn5ATuAeXidrZ)_