### PR TITLE
UI: Fix stacked modals being inert and Escape closing both

### DIFF
--- a/code/core/src/components/components/Modal/Modal.stories.tsx
+++ b/code/core/src/components/components/Modal/Modal.stories.tsx
@@ -1031,6 +1031,90 @@ export const WithPortalSelector = meta.story({
   },
 });
 
+// A modal opened while another modal is open (e.g. from within the mobile menu drawer) must stay
+// interactive: the parent modal's aria hiding must not make the new modal inert (regression test).
+export const StackedModals = meta.story({
+  args: {
+    children: undefined,
+  },
+  render: (args) => {
+    const [isOuterOpen, setOuterOpen] = useState(false);
+    const [isInnerOpen, setInnerOpen] = useState(false);
+
+    return (
+      <>
+        <Modal {...args} ariaLabel="Outer modal" open={isOuterOpen} onOpenChange={setOuterOpen}>
+          <Modal.Content>
+            <Modal.Header>
+              <Modal.Title>Outer Modal</Modal.Title>
+            </Modal.Header>
+            <Modal.Col>
+              <Button ariaLabel={false} onClick={() => setInnerOpen(true)}>
+                Open Inner Modal
+              </Button>
+              <Modal
+                {...args}
+                ariaLabel="Inner modal"
+                open={isInnerOpen}
+                onOpenChange={setInnerOpen}
+              >
+                <Modal.Content>
+                  <Modal.Header>
+                    <Modal.Title>Inner Modal</Modal.Title>
+                  </Modal.Header>
+                  <Modal.Col>
+                    <input type="text" aria-label="Inner input" />
+                  </Modal.Col>
+                </Modal.Content>
+              </Modal>
+            </Modal.Col>
+          </Modal.Content>
+        </Modal>
+        <Button ariaLabel={false} onClick={() => setOuterOpen(true)}>
+          Open Outer Modal
+        </Button>
+      </>
+    );
+  },
+  play: async ({ canvas, step }) => {
+    const dialogByLabel = (label: string) =>
+      document.querySelector(`[role="dialog"][aria-label="${label}"]`);
+
+    await step('Open outer modal', async () => {
+      await userEvent.click(canvas.getByText('Open Outer Modal'));
+      await waitFor(() => expect(dialogByLabel('Outer modal')).toBeInTheDocument());
+    });
+
+    await step('Open inner modal on top; only the outer modal becomes inert', async () => {
+      await userEvent.click(await screen.findByText('Open Inner Modal'));
+      await waitFor(() => expect(dialogByLabel('Inner modal')).toBeInTheDocument());
+      expect(dialogByLabel('Inner modal')).not.toHaveAttribute('inert');
+      await waitFor(() => expect(dialogByLabel('Outer modal')).toHaveAttribute('inert'));
+    });
+
+    await step('The inner modal is interactive', async () => {
+      const input = screen.getByLabelText('Inner input');
+      await userEvent.click(input);
+      await userEvent.type(input, 'abc');
+      expect(input).toHaveValue('abc');
+      expect(dialogByLabel('Inner modal')).toBeInTheDocument();
+    });
+
+    await step('Escape closes only the inner modal', async () => {
+      await userEvent.keyboard('{Escape}');
+      await waitFor(() => expect(dialogByLabel('Inner modal')).not.toBeInTheDocument());
+      expect(dialogByLabel('Outer modal')).toBeInTheDocument();
+      await waitFor(() => expect(dialogByLabel('Outer modal')).not.toHaveAttribute('inert'));
+      await waitFor(() => expect(screen.getByText('Open Inner Modal')).toHaveFocus());
+    });
+
+    await step('Escape closes the outer modal', async () => {
+      await userEvent.keyboard('{Escape}');
+      await waitFor(() => expect(dialogByLabel('Outer modal')).not.toBeInTheDocument());
+    });
+  },
+});
+
 export const WithContainerAndPortalSelector = meta.story({
   args: {
     children: <SampleModalContent />,

--- a/code/core/src/components/components/Modal/Modal.tsx
+++ b/code/core/src/components/components/Modal/Modal.tsx
@@ -1,4 +1,11 @@
-import React, { type HTMLAttributes, createContext, useEffect, useRef, useState } from 'react';
+import React, {
+  type HTMLAttributes,
+  createContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import { deprecate } from 'storybook/internal/client-logger';
 import type { DecoratorFunction } from 'storybook/internal/csf';
@@ -174,7 +181,10 @@ function BaseModal({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isMounted]);
 
-  useEffect(() => {
+  // Layout effect, so this runs in the same task that inserted the portal: it disconnects an
+  // already-open modal's ariaHideOutside MutationObserver before that observer processes the
+  // insertion and makes this modal inert (unfocusable and unclickable).
+  useLayoutEffect(() => {
     if (isMounted && (open || defaultOpen) && overlayRef.current) {
       return ariaHideOutside([overlayRef.current], { shouldUseInert: true });
     }
@@ -189,6 +199,9 @@ function BaseModal({
       if (e.key !== 'Escape') {
         modalProps.onKeyDown?.(e);
       } else {
+        // Consume the event either way: it must not reach a parent modal in the React tree (which
+        // portals bubble through) or a document-level shortcut handler underneath this modal.
+        e.stopPropagation();
         if (dismissOnEscape) {
           onEscapeKeyDown?.(e.nativeEvent);
           if (!e.nativeEvent.defaultPrevented) {


### PR DESCRIPTION
## What I did

Opening a `Modal` while another `Modal` is already open — e.g. the create-story modal from inside the mobile menu drawer — left the new modal unfocusable and unclickable.

<img width="256" height="373" alt="image" src="https://github.com/user-attachments/assets/fdf74358-a19a-4fe3-9f72-4a02edc3178a" />
<img width="252" height="373" alt="image" src="https://github.com/user-attachments/assets/7b944dcb-e4d6-45c6-b8ce-dddcc6595b04" />

- Each modal applies react-aria's `ariaHideOutside(..., { shouldUseInert: true })`, whose MutationObserver also inert-hides any DOM added outside the modal. Because the new modal's own `ariaHideOutside` ran in a passive effect, the parent modal's observer processed the portal insertion first (observer callbacks are microtasks) and marked the new modal's DOM `inert`. Both dialogs ended up inert: focus fell to `body`, Escape did nothing, and clicks on the modal's own content fell through to the body, where react-aria counted them as interact-outside and dismissed the modal.
- Running the modal's `ariaHideOutside` in a **layout effect** disconnects the parent's observer in the same task that inserted the portal, before its queued mutation records are delivered (`disconnect()` empties the record queue), so the new modal is never hidden. The parent modal is then correctly inert while the child is open, and restored when it closes.

Separately, Escape in the inner modal closed **both** modals: portals propagate events through the React tree, so the keydown also reached the parent modal's handler. The Escape handler now stops propagation once a modal receives it — this also keeps Escape from reaching document-level shortcut handlers underneath an open modal.

Verified against the original repro (mobile viewport → open sidebar → "Create a new story"): the modal gets focus immediately, typing/clicking inside it works, Escape closes only the modal, and clicking outside closes only the modal while the drawer stays open and interactive.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories (`StackedModals` in `Modal.stories.tsx`, run via the Storybook Vitest project)
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run SB, open it in a browser and narrow the window down
3. Open the sidebar via the bottom bar menu button, then click the "+" (Create a new story) button next to the search field
4. The modal should receive focus immediately; clicking its input and typing should work; Escape should close only the modal (the drawer stays open); clicking the dimmed area should also close only the modal
5. On desktop, open the same modal and confirm Escape and click-outside still dismiss it as before

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169Un4YR1Bvn5ATuAeXidrZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0169Un4YR1Bvn5ATuAeXidrZ)_