### PR TITLE
Telemetry: Resolve package versions from Storybook project

### DIFF
--- a/code/core/src/telemetry/get-known-packages.ts
+++ b/code/core/src/telemetry/get-known-packages.ts
@@ -78,7 +78,8 @@ export function getSafeVersionSpecifier(version?: string): string | null {
 }
 
 export async function analyzeEcosystemPackages(
-  packageJson: PackageJson
+  packageJson: PackageJson,
+  cwd = process.cwd()
 ): Promise<KnownPackagesList> {
   const allDependencies = {
     ...packageJson?.dependencies,
@@ -108,7 +109,8 @@ export async function analyzeEcosystemPackages(
     const result = Object.fromEntries(
       await Promise.all(
         pickMatches(packages).map(async (dep) => {
-          const resolved = (await getActualPackageVersion(dep))?.version ?? allDependencies[dep];
+          const resolved =
+            (await getActualPackageVersion(dep, cwd))?.version ?? allDependencies[dep];
 
           const version = getSafeVersionSpecifier(resolved);
           return [dep, version];

--- a/code/core/src/telemetry/package-json.test.ts
+++ b/code/core/src/telemetry/package-json.test.ts
@@ -8,6 +8,7 @@ import { getActualPackageJson, getActualPackageVersion } from './package-json.ts
 
 describe('getActualPackageJson', () => {
   let projectDir: string;
+  let workspaceDir: string;
 
   const addPackage = (name: string, packageJson: Record<string, unknown>) => {
     const packageDir = join(projectDir, 'node_modules', name);
@@ -17,12 +18,14 @@ describe('getActualPackageJson', () => {
 
   beforeEach(() => {
     projectDir = mkdtempSync(join(tmpdir(), 'sb-telemetry-package-json-'));
+    workspaceDir = mkdtempSync(join(tmpdir(), 'sb-telemetry-workspace-'));
     vi.spyOn(process, 'cwd').mockReturnValue(projectDir);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     rmSync(projectDir, { recursive: true, force: true });
+    rmSync(workspaceDir, { recursive: true, force: true });
   });
 
   it('resolves the version installed for the project in the current working directory', async () => {
@@ -32,6 +35,21 @@ describe('getActualPackageJson', () => {
     await expect(getActualPackageVersion('react')).resolves.toEqual({
       name: 'react',
       version: '0.0.0-project',
+    });
+  });
+
+  it('resolves the version installed for an explicitly supplied project directory', async () => {
+    addPackage('react', { version: '0.0.0-project' });
+    const workspacePackageDir = join(workspaceDir, 'node_modules', 'react');
+    mkdirSync(workspacePackageDir, { recursive: true });
+    writeFileSync(
+      join(workspacePackageDir, 'package.json'),
+      JSON.stringify({ name: 'react', version: '0.0.0-workspace' })
+    );
+
+    await expect(getActualPackageVersion('react', workspaceDir)).resolves.toEqual({
+      name: 'react',
+      version: '0.0.0-workspace',
     });
   });
 

--- a/code/core/src/telemetry/package-json.ts
+++ b/code/core/src/telemetry/package-json.ts
@@ -8,14 +8,17 @@ import type { PackageJson } from 'type-fest';
 
 import type { Dependency } from './types.ts';
 
-export const getActualPackageVersions = async (packages: Record<string, Partial<Dependency>>) => {
+export const getActualPackageVersions = async (
+  packages: Record<string, Partial<Dependency>>,
+  cwd = process.cwd()
+) => {
   const packageNames = Object.keys(packages);
-  return Promise.all(packageNames.map(getActualPackageVersion));
+  return Promise.all(packageNames.map((packageName) => getActualPackageVersion(packageName, cwd)));
 };
 
-export const getActualPackageVersion = async (packageName: string) => {
+export const getActualPackageVersion = async (packageName: string, cwd = process.cwd()) => {
   try {
-    const packageJson = await getActualPackageJson(packageName);
+    const packageJson = await getActualPackageJson(packageName, cwd);
     return {
       name: packageJson?.name || packageName,
       version: packageJson?.version || null,
@@ -29,9 +32,10 @@ export const getActualPackageVersion = async (packageName: string) => {
 };
 
 export const getActualPackageJson = async (
-  packageName: string
+  packageName: string,
+  cwd = process.cwd()
 ): Promise<PackageJson | undefined> => {
-  const resolvedPackageJsonPath = resolvePackageJsonPath(packageName);
+  const resolvedPackageJsonPath = resolvePackageJsonPath(packageName, cwd);
   if (!resolvedPackageJsonPath) {
     return undefined;
   }
@@ -54,26 +58,25 @@ const attempt = <T>(fn: () => T): T | undefined => {
 };
 
 /**
- * Resolves the package.json of a package as installed for the project in the current working
- * directory. Resolution must be anchored to the project rather than to this module: when the
- * Storybook CLI runs from outside the project (e.g. via `npx`), module-relative resolution finds
- * the CLI's own dependency tree instead of the project's.
+ * Resolves the package.json of a package as installed for the project directory. Resolution must
+ * be anchored to the project rather than to this module: when the Storybook CLI runs from outside
+ * the project (e.g. via `npx`), module-relative resolution finds the CLI's own dependency tree.
  */
-const resolvePackageJsonPath = (packageName: string): string | undefined => {
-  const projectRequire = createRequire(join(process.cwd(), 'package.json'));
+const resolvePackageJsonPath = (packageName: string, cwd: string): string | undefined => {
+  const projectRequire = createRequire(join(cwd, 'package.json'));
   return (
     attempt(() => projectRequire.resolve(`${packageName}/package.json`)) ??
     attempt(() => pkg.up({ cwd: projectRequire.resolve(packageName) }) || undefined) ??
-    findPackageJsonInNodeModules(packageName)
+    findPackageJsonInNodeModules(packageName, cwd)
   );
 };
 
 /**
  * Fallback for packages whose exports map hides both `./package.json` and any require-able entry:
- * walk up from the current working directory looking for `node_modules/<name>/package.json`.
+ * walk up from the project directory looking for `node_modules/<name>/package.json`.
  */
-const findPackageJsonInNodeModules = (packageName: string): string | undefined => {
-  for (let dir = process.cwd(); ; dir = dirname(dir)) {
+const findPackageJsonInNodeModules = (packageName: string, cwd: string): string | undefined => {
+  for (let dir = cwd; ; dir = dirname(dir)) {
     const candidate = join(dir, 'node_modules', packageName, 'package.json');
     if (existsSync(candidate)) {
       return candidate;

--- a/code/core/src/telemetry/storybook-metadata.test.ts
+++ b/code/core/src/telemetry/storybook-metadata.test.ts
@@ -121,7 +121,7 @@ beforeEach(() => {
   }));
 
   vi.mocked(getActualPackageVersions).mockImplementation((packages) =>
-    Promise.all(Object.keys(packages).map(getActualPackageVersion))
+    Promise.all(Object.keys(packages).map((packageName) => getActualPackageVersion(packageName)))
   );
 });
 

--- a/code/core/src/telemetry/storybook-metadata.ts
+++ b/code/core/src/telemetry/storybook-metadata.ts
@@ -137,10 +137,11 @@ export const computeStorybookMetadata = async ({
     ...packageJson?.devDependencies,
     ...packageJson?.peerDependencies,
   };
+  const projectDir = dirname(resolve(configDir));
 
   const metaFramework = Object.keys(allDependencies).find((dep) => !!metaFrameworks[dep]);
   if (metaFramework) {
-    const { version } = await getActualPackageVersion(metaFramework);
+    const { version } = await getActualPackageVersion(metaFramework, projectDir);
     metadata.metaFramework = {
       name: metaFrameworks[metaFramework],
       packageName: metaFramework,
@@ -148,7 +149,7 @@ export const computeStorybookMetadata = async ({
     };
   }
 
-  metadata.knownPackages = await analyzeEcosystemPackages(packageJson);
+  metadata.knownPackages = await analyzeEcosystemPackages(packageJson, projectDir);
   metadata.hasRouterPackage = getHasRouterPackage(packageJson);
   metadata.hasTurbopack = getHasTurbopack(packageJson);
   metadata.hasModuleFederation = getHasModuleFederation(packageJson);
@@ -185,7 +186,7 @@ export const computeStorybookMetadata = async ({
   const rendererPackages = Object.fromEntries(
     await Promise.all(
       getRendererPackages(frameworkInfo.renderer).map(async (packageName) => {
-        const { version } = await getActualPackageVersion(packageName);
+        const { version } = await getActualPackageVersion(packageName, projectDir);
         return [packageName, version || 'unknown'];
       })
     )
@@ -233,7 +234,7 @@ export const computeStorybookMetadata = async ({
     };
   }
 
-  const addonVersions = await getActualPackageVersions(addons);
+  const addonVersions = await getActualPackageVersions(addons, projectDir);
   addonVersions.forEach(({ name, version }) => {
     addons[name] = addons[name] || {
       name,
@@ -254,7 +255,7 @@ export const computeStorybookMetadata = async ({
       };
     }, {}) as Record<string, Dependency>;
 
-  const storybookPackageVersions = await getActualPackageVersions(storybookPackages);
+  const storybookPackageVersions = await getActualPackageVersions(storybookPackages, projectDir);
   storybookPackageVersions.forEach(({ name, version }) => {
     storybookPackages[name] = storybookPackages[name] || {
       name,
@@ -299,8 +300,8 @@ export const computeStorybookMetadata = async ({
   };
 };
 
-async function getPackageJsonDetails() {
-  const packageJsonPath = pkg.up();
+async function getPackageJsonDetails(cwd = process.cwd()) {
+  const packageJsonPath = pkg.up({ cwd });
   if (packageJsonPath) {
     return {
       packageJsonPath,
@@ -361,7 +362,8 @@ function resolveDefaultConfigDir(packageJson: PackageJson): string {
 }
 
 export const getStorybookMetadata = async (_configDir?: string) => {
-  const { packageJson, packageJsonPath } = await getPackageJsonDetails();
+  const packageJsonDetailsDir = _configDir ? dirname(resolve(_configDir)) : process.cwd();
+  const { packageJson, packageJsonPath } = await getPackageJsonDetails(packageJsonDetailsDir);
   const configDir = _configDir || resolveDefaultConfigDir(packageJson);
   const contentHash = await hashMainConfig(configDir);
   const cacheKey = `${configDir}::${contentHash}`;

--- a/code/core/src/telemetry/storybook-metadata.ts
+++ b/code/core/src/telemetry/storybook-metadata.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
-import { dirname, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 
 import {
   getStorybookConfiguration,
@@ -309,9 +309,9 @@ async function getPackageJsonDetails(cwd = process.cwd()) {
     };
   }
 
-  // If we don't find a `package.json`, we assume it "would have" been in the current working directory
+  // If we don't find a `package.json`, we assume it "would have" been in the project directory
   return {
-    packageJsonPath: process.cwd(),
+    packageJsonPath: join(cwd, 'package.json'),
     packageJson: {},
   };
 }


### PR DESCRIPTION
## What changed

Resolve installed package metadata from the directory containing the Storybook config instead of the process working directory. This keeps telemetry and `project.json` aligned with the package's runtime dependency tree in workspaces where catalogs or sibling packages provide different versions.

The project directory is threaded through addon, Storybook package, renderer, framework, and exact ecosystem package lookups. A regression test covers two separate install trees.

Fixes #36172

#### Manual testing

Not run. This is a telemetry metadata lookup change; the focused unit tests cover resolution from separate project directories.

#### Verification

- `corepack yarn node scripts/check/check-package.ts --cwd code/core`
- `corepack yarn vitest run --config code/core/vitest.config.ts code/core/src/telemetry/package-json.test.ts code/core/src/telemetry/get-known-packages.test.ts code/core/src/telemetry/storybook-metadata.test.ts`
- 3 test files passed, 61 tests passed, no type errors
- `corepack yarn oxfmt --check` on changed files

AI disclosure: Codex assisted with this contribution; the author reviewed the change and verification.
