### PR TITLE
CLI: Keep pnpm catalog references during upgrade

### DIFF
--- a/code/core/src/common/js-package-manager/PNPMProxy.catalog.test.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.catalog.test.ts
@@ -101,6 +101,114 @@ describe('PNPMProxy catalogs', () => {
     });
   });
 
+  describe('addDependencies', () => {
+    it('updates an existing catalog entry without replacing its package.json reference', async () => {
+      const packageJson = {
+        dependencies: {},
+        devDependencies: {
+          '@storybook/vue3-vite': 'catalog:',
+          storybook: 'catalog:',
+        },
+      };
+      const writePackageJson = vi.spyOn(pnpmProxy, 'writePackageJson').mockImplementation(vi.fn());
+      vol.fromJSON({
+        [WORKSPACE_YAML]:
+          '# workspace\ncatalog:\n  "@storybook/vue3-vite": ^10.4.4 # framework\n  storybook: ^10.4.4 # core\n',
+      });
+
+      await pnpmProxy.addDependencies(
+        {
+          skipInstall: true,
+          type: 'devDependencies',
+          packageJsonInfo: {
+            packageJsonPath: '/root/project/package.json',
+            operationDir: '/root/project',
+            packageJson,
+          },
+        },
+        ['@storybook/vue3-vite@10.6.0-beta.0', 'storybook@10.6.0-beta.0']
+      );
+
+      expect(writePackageJson).toHaveBeenCalledWith(
+        {
+          dependencies: {},
+          devDependencies: {
+            '@storybook/vue3-vite': 'catalog:',
+            storybook: 'catalog:',
+          },
+        },
+        '/root/project'
+      );
+      expect(writtenYaml()).toContain('"@storybook/vue3-vite": 10.6.0-beta.0 # framework');
+      expect(writtenYaml()).toContain('storybook: 10.6.0-beta.0 # core');
+    });
+
+    it('updates a named catalog and keeps the named catalog reference', async () => {
+      const packageJson = {
+        dependencies: { '@storybook/react': 'catalog:testing' },
+        devDependencies: {},
+      };
+      const writePackageJson = vi.spyOn(pnpmProxy, 'writePackageJson').mockImplementation(vi.fn());
+      vol.fromJSON({
+        [WORKSPACE_YAML]: 'catalogs:\n  testing:\n    "@storybook/react": ^10.4.4\n',
+      });
+
+      await pnpmProxy.addDependencies(
+        {
+          skipInstall: true,
+          type: 'dependencies',
+          packageJsonInfo: {
+            packageJsonPath: '/root/project/package.json',
+            operationDir: '/root/project',
+            packageJson,
+          },
+        },
+        ['@storybook/react@11.0.0']
+      );
+
+      expect(writePackageJson).toHaveBeenCalledWith(
+        {
+          dependencies: { '@storybook/react': 'catalog:testing' },
+          devDependencies: {},
+        },
+        '/root/project'
+      );
+      expect(writtenYaml()).toContain('"@storybook/react": 11.0.0');
+      expect(writtenYaml()).not.toContain('catalog:\n');
+    });
+
+    it('falls back to a direct pin when the catalog entry cannot be updated', async () => {
+      const packageJson = {
+        dependencies: { '@storybook/react': 'catalog:' },
+        devDependencies: {},
+      };
+      const writePackageJson = vi.spyOn(pnpmProxy, 'writePackageJson').mockImplementation(vi.fn());
+      vol.fromJSON({ [WORKSPACE_YAML]: 'catalog:\n  react: ^18.0.0\n' });
+
+      await pnpmProxy.addDependencies(
+        {
+          skipInstall: true,
+          type: 'dependencies',
+          packageJsonInfo: {
+            packageJsonPath: '/root/project/package.json',
+            operationDir: '/root/project',
+            packageJson,
+          },
+        },
+        ['@storybook/react@11.0.0']
+      );
+
+      expect(writePackageJson).toHaveBeenCalledWith(
+        {
+          dependencies: { '@storybook/react': '11.0.0' },
+          devDependencies: {},
+        },
+        '/root/project'
+      );
+      expect(writtenYaml()).toBe('catalog:\n  react: ^18.0.0\n');
+    });
+  });
+
   describe('applyVersionToRelatedPackages', () => {
     it('pins directly when the anchor is not declared through a catalog', () => {
       vi.spyOn(pnpmProxy, 'getAllDependencies').mockReturnValue({ vitest: '^3.2.0' });

--- a/code/core/src/common/js-package-manager/PNPMProxy.ts
+++ b/code/core/src/common/js-package-manager/PNPMProxy.ts
@@ -18,7 +18,7 @@ import { type Document, parseDocument } from 'yaml';
 import type { ExecuteCommandOptions } from '../utils/command.ts';
 import { executeCommand, executeCommandSync } from '../utils/command.ts';
 import { getProjectRoot } from '../utils/paths.ts';
-import { JsPackageManager, PackageManagerName } from './JsPackageManager.ts';
+import { getPackageDetails, JsPackageManager, PackageManagerName } from './JsPackageManager.ts';
 import type { PackageJson } from './PackageJson.ts';
 import type { InstallationMetadata, PackageMetadata } from './types.ts';
 import {
@@ -262,6 +262,33 @@ export class PNPMProxy extends JsPackageManager {
     };
   }
 
+  override addDependencies(
+    options: Parameters<JsPackageManager['addDependencies']>[0],
+    dependencies: string[]
+  ) {
+    if (!options.skipInstall) {
+      return super.addDependencies(options, dependencies);
+    }
+
+    const packageJsonInfo = options.packageJsonInfo ?? this.primaryPackageJson;
+    const declaredDependencies = packageJsonInfo.packageJson[options.type] ?? {};
+    const catalogEntries = dependencies.flatMap((dependency) => {
+      const [packageName, version] = getPackageDetails(dependency);
+      const catalogName = this.#getCatalogName(declaredDependencies[packageName]);
+      return catalogName === null || version === undefined
+        ? []
+        : [{ packageName, version, catalogName }];
+    });
+    const updatedCatalogs = this.#updateCatalogEntries(catalogEntries);
+    const catalogAwareDependencies = dependencies.map((dependency) => {
+      const [packageName] = getPackageDetails(dependency);
+      const catalogName = updatedCatalogs.get(packageName);
+      return catalogName === undefined ? dependency : `${packageName}@catalog:${catalogName}`;
+    });
+
+    return super.addDependencies(options, catalogAwareDependencies);
+  }
+
   override async getDeclaredVersionSpecifier(packageName: string): Promise<string | null> {
     const specifier = await super.getDeclaredVersionSpecifier(packageName);
     if (specifier) {
@@ -347,6 +374,45 @@ export class PNPMProxy extends JsPackageManager {
       return ['catalogs', catalogName];
     }
     return doc.hasIn(['catalogs', 'default']) ? ['catalogs', 'default'] : ['catalog'];
+  }
+
+  #updateCatalogEntries(
+    entries: Array<{ packageName: string; version: string; catalogName: string }>
+  ): Map<string, string> {
+    if (entries.length === 0) {
+      return new Map();
+    }
+
+    const workspace = this.#readWorkspaceYaml();
+    if (!workspace) {
+      return new Map();
+    }
+
+    try {
+      const updatedCatalogs = new Map<string, string>();
+      let changed = false;
+      for (const { packageName, version, catalogName } of entries) {
+        const keyPath = [...this.#catalogKeyPath(workspace.doc, catalogName), packageName];
+        const currentVersion = workspace.doc.getIn(keyPath);
+        if (typeof currentVersion !== 'string' && typeof currentVersion !== 'number') {
+          continue;
+        }
+
+        updatedCatalogs.set(packageName, catalogName);
+        if (version !== String(currentVersion)) {
+          workspace.doc.setIn(keyPath, version);
+          changed = true;
+        }
+      }
+
+      if (changed) {
+        writeFileSync(workspace.path, workspace.doc.toString(), 'utf8');
+      }
+      return updatedCatalogs;
+    } catch (e) {
+      logger.warn(`Could not update pnpm catalog in ${workspace.path}: ${String(e)}`);
+      return new Map();
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #36174

## What I did

- Made pnpm's skip-install dependency updates detect existing `catalog:` and `catalog:<name>` declarations.
- Updated the corresponding entries in `pnpm-workspace.yaml` while keeping package manifests on their catalog references.
- Batched catalog edits through the YAML document API so comments and surrounding formatting are retained.
- Kept the existing safe fallback to direct version pins when a workspace or catalog entry cannot be updated.
- Added regression coverage for the reported `10.4.4` to `10.6.0-beta.0` upgrade, named catalogs, and fallback behavior.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Create a pnpm workspace with two packages that both declare `storybook` and a Storybook framework through `catalog:`. Set both catalog entries to `^10.4.4`.
2. From one package, run `storybook upgrade` using this PR's canary and `--package-manager pnpm --skip-install`.
3. Verify that both dependencies in the package's `package.json` still use `catalog:`.
4. Verify that their entries in `pnpm-workspace.yaml` contain the upgrade target and that existing comments remain.
5. Run `pnpm install`, then `pnpm list -r storybook <framework-package>` and verify that both workspace packages resolve the same upgraded versions.
6. Repeat with a named catalog (`catalog:testing`) and verify that only `catalogs.testing` is updated.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

AI assistance disclosure: OpenAI Codex assisted with investigation, implementation, and test drafting. I reviewed the issue reproduction, the complete patch, test behavior, and manual pnpm 11.6.0 verification before submitting.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR has one release-note label (this is a `bug` fix)
