### PR TITLE
Nextjs-Vite: Resolve styled-jsx through Next.js under strict pnpm

### DIFF
--- a/code/lib/vite-plugin-storybook-nextjs/src/index.test.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/index.test.ts
@@ -132,6 +132,18 @@ describe('VitePlugin', () => {
     });
   });
 
+  it('resolves styled-jsx through Next.js during dependency optimization', async () => {
+    const { default: VitePlugin } = await import('./index.ts');
+
+    const plugins = VitePlugin({ dir: '/root' });
+    const configPlugin = plugins[1];
+    const config = await configPlugin?.config?.({});
+
+    expect(
+      config?.optimizeDeps?.include?.filter((dependency) => dependency.includes('styled-jsx'))
+    ).toEqual(['next > styled-jsx', 'next > styled-jsx/style']);
+  });
+
   it('uses native tsconfig paths support on Vite 8 and newer', async () => {
     getViteMajorVersionMock.mockReturnValue(8);
 

--- a/code/lib/vite-plugin-storybook-nextjs/src/index.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/index.ts
@@ -147,8 +147,6 @@ function VitePlugin({ dir = process.cwd(), image }: PluginOptions = {}): PluginO
               'next/dist/client/head-manager.js',
               'next/dist/client/components/is-next-router-error.js',
               'next/dist/shared/lib/segment.js',
-              'styled-jsx',
-              'styled-jsx/style',
               'sb-original/image-context',
               'sb-original/default-loader',
               'next/dist/compiled/react',
@@ -158,6 +156,7 @@ function VitePlugin({ dir = process.cwd(), image }: PluginOptions = {}): PluginO
               // Required for pnpm setups, since styled-jsx is a transitive dependency of Next.js and not directly listed.
               // Refer to this pnpm issue for more details:
               // https://github.com/vitejs/vite/issues/16293
+              'next > styled-jsx',
               'next > styled-jsx/style',
               ...(nextConfig.compiler?.emotion ? ['@emotion/react/jsx-dev-runtime'] : []),
               ...(isNext16orNewer ? [] : ['next/config']),


### PR DESCRIPTION
Closes #35873

## What I did

- replaced the bare `styled-jsx` optimizer entries with Vite's nested-dependency syntax
- added the missing `next > styled-jsx` root entry alongside `next > styled-jsx/style`
- added a unit test that keeps every styled-jsx optimizer entry scoped through Next.js

This keeps dependency optimization resolvable when `styled-jsx` is only a transitive dependency of `next`, as it is in strict pnpm installs.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Create a pnpm project with `next`, `react`, `react-dom`, and Vite, but do not add `styled-jsx` directly.
2. Configure Vite with this plugin and force dependency optimization.
3. Confirm that Vite optimizes `next > styled-jsx` and `next > styled-jsx/style` without the previous `Failed to resolve dependency: styled-jsx` warnings.

Locally verified with pnpm 11.5.3, Next 16.3.0-canary.39, and Vite 8.2.2. Both optimized styled-jsx bundles were emitted.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update `MIGRATION.MD`

## AI assistance disclosure

Codex assisted with repository search, the implementation, and test execution. I reviewed the issue evidence, the complete diff, and all reported verification results before submission.
