### PR TITLE
Addon A11y: Make the Vision Simulator optional

### DIFF
--- a/code/addons/a11y/src/components/VisionSimulator.stories.tsx
+++ b/code/addons/a11y/src/components/VisionSimulator.stories.tsx
@@ -9,6 +9,8 @@ import { VisionSimulator } from './VisionSimulator.tsx';
 const managerContext: any = {
   state: {},
   api: {
+    on: fn(),
+    off: fn(),
     getGlobals: fn(() => ({ vision: undefined })),
     updateGlobals: fn(),
     getStoryGlobals: fn(() => ({ vision: undefined })),
@@ -20,8 +22,16 @@ const meta = preview.meta({
   title: 'Vision Simulator',
   component: VisionSimulator,
   decorators: [
-    (Story: any) => (
-      <ManagerContext.Provider value={managerContext}>
+    (Story: any, context) => (
+      <ManagerContext.Provider
+        value={{
+          ...managerContext,
+          api: {
+            ...managerContext.api,
+            getCurrentParameter: (key: string) => context.parameters[key],
+          },
+        }}
+      >
         <Story />
       </ManagerContext.Provider>
     ),
@@ -53,5 +63,16 @@ export const Selection = meta.story({
     await expect(
       context.canvas.getByRole('button', { name: 'Vision filter Blurred vision' })
     ).toBeVisible();
+  },
+});
+
+export const Disabled = meta.story({
+  parameters: {
+    visionSimulator: {
+      disable: true,
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.queryByRole('button', { name: 'Vision filter' })).not.toBeInTheDocument();
   },
 });

--- a/code/addons/a11y/src/components/VisionSimulator.tsx
+++ b/code/addons/a11y/src/components/VisionSimulator.tsx
@@ -8,6 +8,7 @@ import { useGlobals, useParameter } from 'storybook/manager-api';
 import { styled } from 'storybook/theming';
 
 import { VISION_GLOBAL_KEY, VISION_SIMULATOR_PARAM_KEY } from '../constants.ts';
+import type { A11yParameters } from '../types.ts';
 import { filterDefs, filters } from '../visionSimulatorFilters.ts';
 
 const Hidden = styled.div({
@@ -36,7 +37,10 @@ const ColorIcon = styled.span<{ $filter: string }>(
 );
 
 export const VisionSimulator = () => {
-  const { disable } = useParameter<{ disable?: boolean }>(VISION_SIMULATOR_PARAM_KEY, {});
+  const { disable } = useParameter<NonNullable<A11yParameters['visionSimulator']>>(
+    VISION_SIMULATOR_PARAM_KEY,
+    {}
+  );
   const [globals, updateGlobals, storyGlobals] = useGlobals();
 
   if (disable) {

--- a/code/addons/a11y/src/components/VisionSimulator.tsx
+++ b/code/addons/a11y/src/components/VisionSimulator.tsx
@@ -4,10 +4,10 @@ import { Select } from 'storybook/internal/components';
 
 import { AccessibilityIcon } from '@storybook/icons';
 
-import { useGlobals } from 'storybook/manager-api';
+import { useGlobals, useParameter } from 'storybook/manager-api';
 import { styled } from 'storybook/theming';
 
-import { VISION_GLOBAL_KEY } from '../constants.ts';
+import { VISION_GLOBAL_KEY, VISION_SIMULATOR_PARAM_KEY } from '../constants.ts';
 import { filterDefs, filters } from '../visionSimulatorFilters.ts';
 
 const Hidden = styled.div({
@@ -36,7 +36,13 @@ const ColorIcon = styled.span<{ $filter: string }>(
 );
 
 export const VisionSimulator = () => {
+  const { disable } = useParameter<{ disable?: boolean }>(VISION_SIMULATOR_PARAM_KEY, {});
   const [globals, updateGlobals, storyGlobals] = useGlobals();
+
+  if (disable) {
+    return null;
+  }
+
   const value = globals[VISION_GLOBAL_KEY];
   const isLocked = storyGlobals[VISION_GLOBAL_KEY] !== undefined;
 

--- a/code/addons/a11y/src/constants.ts
+++ b/code/addons/a11y/src/constants.ts
@@ -2,6 +2,7 @@ export const ADDON_ID = 'storybook/a11y';
 export const PANEL_ID = `${ADDON_ID}/panel`;
 export const PARAM_KEY = `a11y`;
 export const VISION_GLOBAL_KEY = `vision`;
+export const VISION_SIMULATOR_PARAM_KEY = `visionSimulator`;
 export const UI_STATE_ID = `${ADDON_ID}/ui`;
 const RESULT = `${ADDON_ID}/result`;
 const REQUEST = `${ADDON_ID}/request`;

--- a/code/addons/a11y/src/types.ts
+++ b/code/addons/a11y/src/types.ts
@@ -11,6 +11,12 @@ export interface A11yParameters {
    * @see https://storybook.js.org/docs/writing-tests/accessibility-testing
    */
   a11y?: A11yParams;
+
+  /** Vision Simulator configuration. */
+  visionSimulator?: {
+    /** Whether to hide the Vision Simulator toolbar control. */
+    disable?: boolean;
+  };
 }
 
 export interface A11yGlobals {

--- a/docs/_snippets/addon-a11y-disable-vision-simulator.md
+++ b/docs/_snippets/addon-a11y-disable-vision-simulator.md
@@ -1,0 +1,24 @@
+```js filename=".storybook/preview.js|jsx" renderer="common" language="js" tabTitle="CSF 3"
+export default {
+  parameters: {
+    visionSimulator: {
+      disable: true,
+    },
+  },
+};
+```
+
+```ts filename=".storybook/preview.ts|tsx" renderer="common" language="ts" tabTitle="CSF 3"
+// Replace your-framework with the framework you are using, e.g. react-vite, nextjs, vue3-vite, etc.
+import type { Preview } from '@storybook/your-framework';
+
+const preview: Preview = {
+  parameters: {
+    visionSimulator: {
+      disable: true,
+    },
+  },
+};
+
+export default preview;
+```

--- a/docs/writing-tests/accessibility-testing.mdx
+++ b/docs/writing-tests/accessibility-testing.mdx
@@ -52,13 +52,14 @@ The results are broken down into three sub-tabs:
 
 Because the addon is built on top of `axe-core`, much of the configuration available maps to its available options:
 
-| Property                  | Default     | Description                                                                                                                                                                                              |
-| ------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `parameters.a11y.context` | `'body'`    | [Context](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#context-parameter) passed to `axe.run`. Defines which elements to run checks against.                                            |
-| `parameters.a11y.config`  | (see below) | Configuration passed to [`axe.configure()`](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#api-name-axeconfigure). Most commonly used to [configure individual rules](#individual-rules). |
-| `parameters.a11y.options` | `{}`        | [Options](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter) passed to `axe.run`. Can be used to adjust the rulesets checked against.                                      |
-| `parameters.a11y.test`    | `undefined` | Determines test behavior when run with the Vitest addon. [More details below](#test-behavior).                                                                                                           |
-| `globals.a11y.manual`     | `undefined` | Set to `true` to prevent stories from being automatically analyzed when visited. [More details below](#disable-automated-checks)                                                                         |
+| Property                             | Default     | Description                                                                                                                                                                                              |
+| ------------------------------------ | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `parameters.a11y.context`            | `'body'`    | [Context](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#context-parameter) passed to `axe.run`. Defines which elements to run checks against.                                            |
+| `parameters.a11y.config`             | (see below) | Configuration passed to [`axe.configure()`](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#api-name-axeconfigure). Most commonly used to [configure individual rules](#individual-rules). |
+| `parameters.a11y.options`            | `{}`        | [Options](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter) passed to `axe.run`. Can be used to adjust the rulesets checked against.                                      |
+| `parameters.a11y.test`               | `undefined` | Determines test behavior when run with the Vitest addon. [More details below](#test-behavior).                                                                                                           |
+| `parameters.visionSimulator.disable` | `false`     | Set to `true` to hide the Vision Simulator toolbar control. [More details below](#disable-the-vision-simulator).                                                                                         |
+| `globals.a11y.manual`                | `undefined` | Set to `true` to prevent stories from being automatically analyzed when visited. [More details below](#disable-automated-checks)                                                                         |
 
 <details>
 <summary>Default `parameters.a11y.config`</summary>
@@ -87,6 +88,12 @@ Here, they are applied to all stories in a project, in `.storybook/preview.*`:
 You can also apply the configuration for all stories in a file (in the `meta`) or an individual story:
 
 <CodeSnippets path="addon-a11y-config-in-meta-and-story.md" />
+
+### Disable the Vision Simulator
+
+The Vision Simulator toolbar control is enabled by default. If you do not need it, you can hide it for all stories by setting `parameters.visionSimulator.disable` in `.storybook/preview.*`:
+
+<CodeSnippets path="addon-a11y-disable-vision-simulator.md" />
 
 ### Rulesets
 


### PR DESCRIPTION
Closes #20567

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Added a parameters.visionSimulator.disable option that hides the Vision Simulator toolbar control when set to true. The existing behavior remains unchanged by default.

Added parameter typings, a story covering the disabled state, and documentation with JavaScript and TypeScript configuration examples.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Validated with:

- `yarn storybook:vitest --run code/addons/a11y/src/components/VisionSimulator.stories.tsx`
- `yarn docs:check`
- `yarn nx check addon-a11y`
- `yarn fmt:write`
- `git diff --check upstream/next...HEAD`

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

1. Start the internal Storybook:

   ```sh
   cd code
   yarn storybook:ui
   ```

2. Open the **Addons / Accessibility / Vision Simulator / Default** story and confirm that the Vision Simulator toolbar control is visible and functional.

3. Open the **Disabled** story and confirm that the Vision Simulator toolbar control is not rendered.

4. Return to the **Default** story and confirm that the control is visible again.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
