### PR TITLE
Core: Remove client-side WebSocket timeout detection

### DIFF
--- a/code/core/src/channels/index.ts
+++ b/code/core/src/channels/index.ts
@@ -19,12 +19,7 @@ export {
 export default Channel;
 
 export { PostMessageTransport } from './postmessage/index.ts';
-export {
-  WebsocketTransport,
-  HEARTBEAT_INTERVAL,
-  HEARTBEAT_MAX_LATENCY,
-  SERVER_CHANNEL_PATH,
-} from './websocket/index.ts';
+export { WebsocketTransport, HEARTBEAT_INTERVAL, SERVER_CHANNEL_PATH } from './websocket/index.ts';
 export type { ChannelWebSocket } from './websocket/index.ts';
 
 type Options = Config & {

--- a/code/core/src/channels/websocket/index.test.ts
+++ b/code/core/src/channels/websocket/index.test.ts
@@ -2,16 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { parse, stringify } from 'telejson';
 
-import { HEARTBEAT_INTERVAL, HEARTBEAT_MAX_LATENCY, WebsocketTransport } from './index.ts';
-
-const TIMEOUT = HEARTBEAT_INTERVAL + HEARTBEAT_MAX_LATENCY;
+import { HEARTBEAT_INTERVAL, WebsocketTransport } from './index.ts';
 
 const socketRef = { current: undefined as unknown as MockWebSocket };
 
-/**
- * Minimal WebSocket stub that keeps outgoing `send` calls separate from incoming messages, so tests
- * can assert heartbeat behavior without a pong echoing straight back into the message handler.
- */
 class MockWebSocket {
   static OPEN = 1;
 
@@ -56,7 +50,6 @@ const createConnectedTransport = () => {
     onError,
   });
   transport.setHandler(handler);
-  // onopen marks the transport ready and starts the heartbeat watchdog
   socketRef.current.onopen?.();
   return { transport, handler, socket: socketRef.current };
 };
@@ -75,78 +68,20 @@ describe('WebsocketTransport heartbeat', () => {
     vi.unstubAllGlobals();
   });
 
-  it('closes with code 3008 when no message is received within the timeout window', () => {
+  it('does not close the socket when no message arrives', () => {
     const { socket } = createConnectedTransport();
 
-    vi.advanceTimersByTime(TIMEOUT - 1);
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL * 4);
     expect(socket.closed).toBeUndefined();
-
-    vi.advanceTimersByTime(1);
-    expect(socket.closed).toEqual({ code: 3008, reason: 'timeout' });
   });
 
-  it('does not close while the heartbeat is paused, then restarts the watchdog on resume', () => {
-    const { transport, socket } = createConnectedTransport();
-
-    transport.pauseHeartbeat();
-    vi.advanceTimersByTime(TIMEOUT * 3);
-    expect(socket.closed).toBeUndefined();
-
-    transport.resumeHeartbeat();
-    vi.advanceTimersByTime(TIMEOUT - 1);
-    expect(socket.closed).toBeUndefined();
-
-    vi.advanceTimersByTime(1);
-    expect(socket.closed).toEqual({ code: 3008, reason: 'timeout' });
-  });
-
-  it('does not start the receive watchdog when enableHeartbeat is false', () => {
-    const transport = new WebsocketTransport({
-      url: 'ws://localhost:6006',
-      page: 'manager',
-      onError: vi.fn(),
-      enableHeartbeat: false,
-    });
-    transport.setHandler(vi.fn());
-    socketRef.current.onopen?.();
-
-    vi.advanceTimersByTime(TIMEOUT * 3);
-    expect(socketRef.current.closed).toBeUndefined();
-
-    transport.resumeHeartbeat();
-    vi.advanceTimersByTime(TIMEOUT * 3);
-    expect(socketRef.current.closed).toBeUndefined();
-  });
-
-  it('resets the heartbeat and replies with pong when a ping is received', () => {
+  it('replies with pong when a ping is received', () => {
     const { socket } = createConnectedTransport();
 
-    vi.advanceTimersByTime(TIMEOUT - 1);
     socket.receive({ type: 'ping' });
 
     expect(sentEvents(socket)).toContainEqual({ type: 'pong' });
-
-    // The heartbeat was reset, so another near-full window can elapse without closing
-    vi.advanceTimersByTime(TIMEOUT - 1);
     expect(socket.closed).toBeUndefined();
-
-    vi.advanceTimersByTime(1);
-    expect(socket.closed).toEqual({ code: 3008, reason: 'timeout' });
-  });
-
-  it('resets the heartbeat when a non-ping event is received', () => {
-    const { socket } = createConnectedTransport();
-
-    vi.advanceTimersByTime(TIMEOUT - 1);
-    socket.receive({ type: 'test', args: [], from: 'preview' });
-
-    // Any message is evidence the connection is alive, not just a literal ping - so this arrival
-    // must reset the watchdog too, even though it's not the `ping` type.
-    vi.advanceTimersByTime(TIMEOUT - 1);
-    expect(socket.closed).toBeUndefined();
-
-    vi.advanceTimersByTime(1);
-    expect(socket.closed).toEqual({ code: 3008, reason: 'timeout' });
   });
 
   it('does not forward ping events to the channel handler', () => {
@@ -165,38 +100,14 @@ describe('WebsocketTransport heartbeat', () => {
     expect(handler).toHaveBeenCalledWith(expect.objectContaining({ type: 'test' }));
   });
 
-  it('resets the heartbeat for pings even when the channel handler throws', () => {
+  it('replies with pong even when the channel handler throws', () => {
     const { transport, socket } = createConnectedTransport();
 
-    // Simulate an overloaded/failing channel handler. Heartbeat processing must not depend on it,
-    // otherwise a busy channel could starve the reset and close a healthy connection with code 3008.
     transport.setHandler(() => {
       throw new Error('handler boom');
     });
 
-    vi.advanceTimersByTime(TIMEOUT - 1);
     expect(() => socket.receive({ type: 'ping' })).not.toThrow();
     expect(sentEvents(socket)).toContainEqual({ type: 'pong' });
-
-    vi.advanceTimersByTime(TIMEOUT - 1);
-    expect(socket.closed).toBeUndefined();
-  });
-
-  it('resets the heartbeat for non-ping events even when the channel handler throws', () => {
-    const { transport, socket } = createConnectedTransport();
-
-    transport.setHandler(() => {
-      throw new Error('handler boom');
-    });
-
-    vi.advanceTimersByTime(TIMEOUT - 1);
-    // The handler throwing is expected to propagate to the caller (the socket's own onmessage
-    // dispatch), but the heartbeat reset must already have happened before that point.
-    expect(() => socket.receive({ type: 'test', args: [], from: 'preview' })).toThrow(
-      'handler boom'
-    );
-
-    vi.advanceTimersByTime(TIMEOUT - 1);
-    expect(socket.closed).toBeUndefined();
   });
 });

--- a/code/core/src/channels/websocket/index.ts
+++ b/code/core/src/channels/websocket/index.ts
@@ -28,11 +28,9 @@ interface WebsocketTransportArgs extends Partial<Config> {
   url: string;
   onError: OnError;
   createSocket?: (url: string) => ChannelWebSocket;
-  enableHeartbeat?: boolean;
 }
 
 export const HEARTBEAT_INTERVAL = 15000;
-export const HEARTBEAT_MAX_LATENCY = 5000;
 export const SERVER_CHANNEL_PATH = '/storybook-server-channel';
 
 const CHANNEL_OPTIONS = globalThis.CHANNEL_OPTIONS || {};
@@ -48,55 +46,16 @@ export class WebsocketTransport implements ChannelTransport {
 
   private isClosed = false;
 
-  private pingTimeout: number | NodeJS.Timeout = 0;
-
-  private heartbeatPaused = false;
-
-  private enableHeartbeat = true;
-
-  private heartbeat() {
-    clearTimeout(this.pingTimeout);
-    if (!this.enableHeartbeat || this.heartbeatPaused || this.isClosed) {
-      return;
-    }
-
-    this.pingTimeout = setTimeout(() => {
-      this.socket.close(3008, 'timeout');
-    }, HEARTBEAT_INTERVAL + HEARTBEAT_MAX_LATENCY);
-  }
-
-  pauseHeartbeat() {
-    this.heartbeatPaused = true;
-    clearTimeout(this.pingTimeout);
-  }
-
-  resumeHeartbeat() {
-    this.heartbeatPaused = false;
-    if (this.isReady) {
-      this.heartbeat();
-    }
-  }
-
-  constructor({
-    url,
-    onError,
-    page,
-    createSocket,
-    enableHeartbeat = true,
-  }: WebsocketTransportArgs) {
-    this.enableHeartbeat = enableHeartbeat;
+  constructor({ url, onError, page, createSocket }: WebsocketTransportArgs) {
     // eslint-disable-next-line compat/compat
     this.socket = createSocket ? createSocket(url) : new WebSocket(url);
     this.socket.onopen = () => {
       this.isReady = true;
-      this.heartbeat();
       this.flush();
     };
     this.socket.onmessage = ({ data }: { data: any }) => {
       const event = typeof data === 'string' && isJSON(data) ? parse(data) : data;
       invariant(this.handler, 'WebsocketTransport handler should be set');
-
-      this.heartbeat();
 
       if (event.type === 'ping') {
         // Pings are internal to the transport and have no channel listeners.
@@ -119,7 +78,6 @@ export class WebsocketTransport implements ChannelTransport {
         from: page || 'preview',
       });
       this.isClosed = true;
-      clearTimeout(this.pingTimeout);
     };
   }
 

--- a/code/core/src/cli/tools/sdk/node-channel.test.ts
+++ b/code/core/src/cli/tools/sdk/node-channel.test.ts
@@ -152,10 +152,10 @@ describe('createNodeChannel', () => {
     channel.on(CHANNEL_WS_DISCONNECT, (payload) => disconnects.push(payload));
     const connection = await firstConnection();
 
-    connection.close(3008, 'timeout');
+    connection.close(1000);
 
     await expect(disconnected).rejects.toThrow('Storybook dev server disconnected');
-    expect(disconnects).toEqual([{ code: 3008, reason: 'timeout' }]);
+    expect(disconnects).toEqual([{ code: 1000, reason: '' }]);
   });
 
   it('rejects with a dev server disconnected error when the server was never reachable', async () => {

--- a/code/core/src/cli/tools/sdk/node-channel.ts
+++ b/code/core/src/cli/tools/sdk/node-channel.ts
@@ -86,8 +86,6 @@ export function createNodeChannel({ url, token }: NodeChannelOptions): NodeChann
     url: socketUrl.href,
     onError: () => {},
     createSocket: () => socket,
-    // Config load and tool calls occupy this event loop longer than the 20s receive watchdog.
-    enableHeartbeat: false,
   });
 
   const channel = new Channel({ transports: [transport] });

--- a/code/core/src/manager/globals/exports.ts
+++ b/code/core/src/manager/globals/exports.ts
@@ -488,7 +488,6 @@ export default {
   'storybook/internal/channels': [
     'Channel',
     'HEARTBEAT_INTERVAL',
-    'HEARTBEAT_MAX_LATENCY',
     'PostMessageTransport',
     'SERVER_CHANNEL_PATH',
     'WebsocketTransport',

--- a/code/core/src/manager/index.stories.tsx
+++ b/code/core/src/manager/index.stories.tsx
@@ -80,14 +80,13 @@ class ReactProvider extends Provider {
       api.selectStory('example-button--primary', undefined, { viewMode: 'story' });
     });
 
-    this.channel.on(CHANNEL_WS_DISCONNECT, (ev) => {
-      const TIMEOUT_CODE = 3008;
+    this.channel.on(CHANNEL_WS_DISCONNECT, () => {
       this.wsDisconnected = true;
 
       api.addNotification({
         id: WS_DISCONNECTED_NOTIFICATION_ID,
         content: {
-          headline: ev.code === TIMEOUT_CODE ? 'Server timed out' : 'Connection lost',
+          headline: 'Connection lost',
           subHeadline: 'Please restart your Storybook server and reload the page',
         },
         icon: <FailedIcon color={color.negative} />,
@@ -180,13 +179,7 @@ export const FullScreen = meta.story({
 
 export const ConnectionLost = meta.story({
   play: async () => {
-    channel.emit(CHANNEL_WS_DISCONNECT, { code: 3007 });
-  },
-});
-
-export const ServerTimedOut = meta.story({
-  play: async () => {
-    channel.emit(CHANNEL_WS_DISCONNECT, { code: 3008 });
+    channel.emit(CHANNEL_WS_DISCONNECT, { code: 1006 });
   },
 });
 

--- a/code/core/src/manager/runtime.tsx
+++ b/code/core/src/manager/runtime.tsx
@@ -54,14 +54,13 @@ class ReactProvider extends Provider {
   handleAPI(api: API) {
     this.addons.loadAddons(api);
 
-    this.channel.on(CHANNEL_WS_DISCONNECT, (ev) => {
-      const TIMEOUT_CODE = 3008;
+    this.channel.on(CHANNEL_WS_DISCONNECT, () => {
       this.wsDisconnected = true;
 
       api.addNotification({
         id: WS_DISCONNECTED_NOTIFICATION_ID,
         content: {
-          headline: ev.code === TIMEOUT_CODE ? 'Server timed out' : 'Connection lost',
+          headline: 'Connection lost',
           subHeadline: 'Please restart your Storybook server and reload the page',
         },
         icon: <FailedIcon color={color.negative} />,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

Related: #36229 (perf fixes stay there; this is the timeout-detection follow-up from review).

## What I did

Removed the client-side WebSocket receive watchdog that closed `/storybook-server-channel` with code 3008 and showed **Server timed out**.

That 20s `setTimeout` ran on the manager main thread. A busy UI (large Component Testing run, webpack compile, CLI docgen) made the timer fire late, so a healthy server looked dead. The original user report this code was added for ([#28258](https://github.com/storybookjs/storybook/issues/28258), shipped in [#30288](https://github.com/storybookjs/storybook/pull/30288)) was a false disconnect during webpack, not a hung TCP connection.

A crashed or killed server already closes the socket. The manager still shows **Connection lost** on `CHANNEL_WS_DISCONNECT`. Server JSON `ping` every 15s and client `pong` stay in place so idle proxies and NATs do not drop a quiet tab.

Also removed:

- `enableHeartbeat`, `pauseHeartbeat`, and `resumeHeartbeat` (the CLI already had to disable the watchdog because the same event loop blocked past 20s)
- The **Server timed out** toast branch and the `ServerTimedOut` story
- Unused `HEARTBEAT_MAX_LATENCY` export

The leftover gap is a process that is frozen (`SIGSTOP`, deadlock) with TCP still open. That case was never the filed bug, and this detector could not tell it apart from a busy manager.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.
-->

1. From the repo root: `yarn` then `yarn nx compile core`.
2. Start the internal UI: `cd code && yarn storybook:ui`.
3. Open http://localhost:6006/?path=/story/manager-main--connection-lost. Confirm the toast headline is **Connection lost**, and that there is no **Server Timed Out** story under Manager / Main.
4. In DevTools → Network, select the `storybook-server-channel` WebSocket. Confirm `{type:"ping"}` still arrives from the server about every 15s and the client replies `{type:"pong"}`.
5. Click **Run tests** in the Testing widget and let a full run finish. Confirm there is no **Server timed out** / **Connection lost** notification while the server is healthy.
6. Stop the Storybook process without reloading the manager. Confirm the toast is **Connection lost** (not **Server timed out**), and that the socket closes because the server went away, not after a 20s client timer.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e1ff5c5-3113-42be-b582-0cb09656235e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e1ff5c5-3113-42be-b582-0cb09656235e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

