### PR TITLE
CSF tools: Add safe story object mutations

### DIFF
--- a/code/core/src/csf-tools/CsfFile.ts
+++ b/code/core/src/csf-tools/CsfFile.ts
@@ -30,6 +30,8 @@ import { dedent } from 'ts-dedent';
 
 import { Tag } from '../shared/constants/tags.ts';
 import type { PrintResultType } from './PrintResultType.ts';
+import { type CsfMutationDiagnostic, type CsfObject, type CsfObjectOptions } from './CsfObject.ts';
+import { discoverCsfObjects } from './CsfObjectDiscovery.ts';
 import { findVarInitialization } from './findVarInitialization.ts';
 import { isCanonicalCsf2BindCall, isCsfFactoryCall } from './story-shape/utils.ts';
 
@@ -318,11 +320,34 @@ export class CsfFile {
 
   _tests: StoryTest[] = [];
 
+  #mutationDiagnostics: CsfMutationDiagnostic[] = [];
+
+  #changed = false;
+
   constructor(ast: t.File, options: CsfOptions, file: BabelFile) {
     this._ast = ast;
     this._file = file;
     this._options = options;
     this.imports = [];
+  }
+
+  get mutationDiagnostics(): readonly CsfMutationDiagnostic[] {
+    return this.#mutationDiagnostics;
+  }
+
+  get changed() {
+    return this.#changed;
+  }
+
+  objects(options: CsfObjectOptions = {}): readonly CsfObject[] {
+    return discoverCsfObjects(
+      this,
+      options,
+      (diagnostic) => this.#mutationDiagnostics.push(diagnostic),
+      () => {
+        this.#changed = true;
+      }
+    );
   }
 
   _parseTitle(value: t.Node) {

--- a/code/core/src/csf-tools/CsfFile.ts
+++ b/code/core/src/csf-tools/CsfFile.ts
@@ -313,6 +313,8 @@ export class CsfFile {
 
   _metaNode: t.ObjectExpression | undefined;
 
+  _metaNodeIsSynthetic = false;
+
   _metaPath: NodePath<t.ExportDefaultDeclaration> | undefined;
 
   _metaVariableName: string | undefined;
@@ -867,6 +869,7 @@ export class CsfFile {
 
                   if (!metaDeclarator?.isVariableDeclarator()) {
                     self._metaVariableName = callee.property.name;
+                    self._metaNodeIsSynthetic = true;
                     self._parseMeta(t.objectExpression([]), self._ast.program);
                     return;
                   }
@@ -890,6 +893,7 @@ export class CsfFile {
                   const metaNode = t.isObjectExpression(unwrappedArgument)
                     ? unwrappedArgument
                     : t.objectExpression([]);
+                  self._metaNodeIsSynthetic = !t.isObjectExpression(unwrappedArgument);
                   self._parseMeta(metaNode, self._ast.program);
                 } else if (rootObject.name === 'preview') {
                   // Only throw if the variable is named "preview" - this indicates

--- a/code/core/src/csf-tools/CsfFile.ts
+++ b/code/core/src/csf-tools/CsfFile.ts
@@ -878,7 +878,15 @@ export class CsfFile {
                     ? metaDeclarator.node.id.name
                     : callee.property.name;
                   const [argument] = node.arguments;
-                  const unwrappedArgument = argument && unwrapExpression(argument);
+                  const argumentBinding =
+                    argument && t.isIdentifier(argument)
+                      ? path.scope.getBinding(argument.name)
+                      : undefined;
+                  const argumentNode =
+                    argumentBinding?.constant && argumentBinding.path.isVariableDeclarator()
+                      ? argumentBinding.path.node.init
+                      : argument;
+                  const unwrappedArgument = argumentNode && unwrapExpression(argumentNode);
                   const metaNode = t.isObjectExpression(unwrappedArgument)
                     ? unwrappedArgument
                     : t.objectExpression([]);

--- a/code/core/src/csf-tools/CsfFile.ts
+++ b/code/core/src/csf-tools/CsfFile.ts
@@ -33,7 +33,11 @@ import type { PrintResultType } from './PrintResultType.ts';
 import { type CsfMutationDiagnostic, type CsfObject, type CsfObjectOptions } from './CsfObject.ts';
 import { discoverCsfObjects } from './CsfObjectDiscovery.ts';
 import { findVarInitialization } from './findVarInitialization.ts';
-import { isCanonicalCsf2BindCall, isCsfFactoryCall } from './story-shape/utils.ts';
+import {
+  isCanonicalCsf2BindCall,
+  isCsfFactoryCall,
+  unwrapExpression,
+} from './story-shape/utils.ts';
 
 // We add this BabelFile as a temporary workaround to deal with a BabelFileClass "ImportEquals should have a literal source" issue in no link mode with tsup
 interface BabelFile {
@@ -308,6 +312,8 @@ export class CsfFile {
 
   _metaIsFactory: boolean | undefined;
 
+  _metaFactoryCall: t.CallExpression | undefined;
+
   _storyStatements: Record<string, t.ExportNamedDeclaration | t.Expression> = {};
 
   _storyAnnotations: Record<string, Record<string, t.Node>> = {};
@@ -332,7 +338,7 @@ export class CsfFile {
   }
 
   get mutationDiagnostics(): readonly CsfMutationDiagnostic[] {
-    return this.#mutationDiagnostics;
+    return [...this.#mutationDiagnostics];
   }
 
   get changed() {
@@ -834,7 +840,7 @@ export class CsfFile {
             t.isMemberExpression(callee) &&
             t.isIdentifier(callee.property) &&
             callee.property.name === 'meta' &&
-            node.arguments.length > 0
+            !callee.computed
           ) {
             // Find the root object for factory pattern:
             // - preview.meta() => preview
@@ -850,6 +856,7 @@ export class CsfFile {
               if (t.isImportDeclaration(configParent)) {
                 if (isValidPreviewPath(configParent.source.value)) {
                   self._metaIsFactory = true;
+                  self._metaFactoryCall = node;
                   const metaDeclarator = path.findParent((p) =>
                     p.isVariableDeclarator()
                   ) as NodePath<t.VariableDeclarator>;
@@ -860,7 +867,11 @@ export class CsfFile {
                   self._metaVariableName = t.isIdentifier(metaDeclarator.node.id)
                     ? metaDeclarator.node.id.name
                     : callee.property.name;
-                  const metaNode = node.arguments[0] as t.ObjectExpression;
+                  const [argument] = node.arguments;
+                  const unwrappedArgument = argument && unwrapExpression(argument);
+                  const metaNode = t.isObjectExpression(unwrappedArgument)
+                    ? unwrappedArgument
+                    : t.objectExpression([]);
                   self._parseMeta(metaNode, self._ast.program);
                 } else if (rootObject.name === 'preview') {
                   // Only throw if the variable is named "preview" - this indicates

--- a/code/core/src/csf-tools/CsfFile.ts
+++ b/code/core/src/csf-tools/CsfFile.ts
@@ -51,6 +51,13 @@ interface BabelFile {
   code: string;
 }
 
+type CsfMutationState = {
+  diagnostics: CsfMutationDiagnostic[];
+  changed: boolean;
+};
+
+const mutationStates = new WeakMap<CsfFile, CsfMutationState>();
+
 const PREVIEW_FILE_REGEX = /\/preview(.(js|jsx|mjs|ts|tsx))?$/;
 export const isValidPreviewPath = (filepath: string) => PREVIEW_FILE_REGEX.test(filepath);
 
@@ -326,32 +333,30 @@ export class CsfFile {
 
   _tests: StoryTest[] = [];
 
-  #mutationDiagnostics: CsfMutationDiagnostic[] = [];
-
-  #changed = false;
-
   constructor(ast: t.File, options: CsfOptions, file: BabelFile) {
     this._ast = ast;
     this._file = file;
     this._options = options;
     this.imports = [];
+    mutationStates.set(this, { diagnostics: [], changed: false });
   }
 
   get mutationDiagnostics(): readonly CsfMutationDiagnostic[] {
-    return [...this.#mutationDiagnostics];
+    return [...mutationStates.get(this)!.diagnostics];
   }
 
   get changed() {
-    return this.#changed;
+    return mutationStates.get(this)!.changed;
   }
 
   objects(options: CsfObjectOptions = {}): readonly CsfObject[] {
+    const state = mutationStates.get(this)!;
     return discoverCsfObjects(
       this,
       options,
-      (diagnostic) => this.#mutationDiagnostics.push(diagnostic),
+      (diagnostic) => state.diagnostics.push(diagnostic),
       () => {
-        this.#changed = true;
+        state.changed = true;
       }
     );
   }

--- a/code/core/src/csf-tools/CsfFile.ts
+++ b/code/core/src/csf-tools/CsfFile.ts
@@ -700,6 +700,7 @@ export class CsfFile {
                   : specifier.local;
 
                 if (exportName === 'default') {
+                  self._metaVariableName = localName;
                   let metaNode: t.ObjectExpression | undefined;
 
                   if (t.isObjectExpression(decl)) {
@@ -857,9 +858,13 @@ export class CsfFile {
                 if (isValidPreviewPath(configParent.source.value)) {
                   self._metaIsFactory = true;
                   self._metaFactoryCall = node;
-                  const metaDeclarator = path.findParent((p) =>
-                    p.isVariableDeclarator()
-                  ) as NodePath<t.VariableDeclarator>;
+                  const metaDeclarator = path.findParent((p) => p.isVariableDeclarator());
+
+                  if (!metaDeclarator?.isVariableDeclarator()) {
+                    self._metaVariableName = callee.property.name;
+                    self._parseMeta(t.objectExpression([]), self._ast.program);
+                    return;
+                  }
 
                   // find the name of the meta variable declaration
                   // e.g. const foo = preview.meta({ ... });

--- a/code/core/src/csf-tools/CsfObject.test.ts
+++ b/code/core/src/csf-tools/CsfObject.test.ts
@@ -192,6 +192,24 @@ describe('CsfObject', () => {
     expect(printCsf(csf).code).not.toContain(`1: 'one'`);
   });
 
+  it('removes empty ancestor objects', () => {
+    const csf = parse(
+      `export default { title: 'Example', parameters: { viewport: { disable: true } } };`
+    );
+    const [meta] = csf.objects({ meta: true, stories: false });
+
+    expect(meta.remove(['parameters', 'viewport', 'disable'])).toEqual({
+      ok: true,
+      changed: true,
+    });
+
+    expect(printCsf(csf).code).toMatchInlineSnapshot(`
+      "export default {
+        title: 'Example'
+      };"
+    `);
+  });
+
   it('rejects reassigned direct exports', () => {
     const csf = parse(`
       export default { title: 'Example' };

--- a/code/core/src/csf-tools/CsfObject.test.ts
+++ b/code/core/src/csf-tools/CsfObject.test.ts
@@ -258,6 +258,41 @@ describe('CsfObject', () => {
     expect(printCsf(csf).code).not.toContain('a11y');
   });
 
+  it('rejects computed identifier notation for CSF2 annotations', () => {
+    const csf = parse(`
+      export default { title: 'Example' };
+      export const Basic = () => null;
+      Basic[parameters] = { a11y: true };
+    `);
+
+    expect(csf.objects({ meta: false, stories: false, annotations: ['parameters'] })).toEqual([]);
+  });
+
+  it('does not diagnose exports excluded from the story index', () => {
+    const csf = parse(`
+      export default { title: 'Example', includeStories: ['Basic'] };
+      export let Helper = { args: {} };
+      Helper = { args: { changed: true } };
+      export const Basic = { args: {} };
+    `);
+
+    csf.objects({ meta: false, stories: true });
+
+    expect(csf.mutationDiagnostics).toEqual([]);
+  });
+
+  it('does not diagnose re-exports excluded from the story index', () => {
+    const csf = parse(`
+      export default { title: 'Example', includeStories: ['Basic'] };
+      export { Helper } from './helper';
+      export const Basic = { args: {} };
+    `);
+
+    csf.objects({ meta: false, stories: true });
+
+    expect(csf.mutationDiagnostics).toEqual([]);
+  });
+
   it('reports compound CSF2 annotation assignments', () => {
     const csf = parse(`
       export default { title: 'Example' };
@@ -327,6 +362,22 @@ describe('CsfObject', () => {
     expect(printCsf(csf).code).toBe(`export default { first: true, newName: true, last: true };`);
   });
 
+  it('preserves a shorthand property value when renaming its key', () => {
+    const csf = parse(`const foo = true; export default { foo };`);
+    const [meta] = csf.objects({ meta: true, stories: false });
+
+    expect(meta.rename(['foo'], 'bar')).toEqual({ ok: true, changed: true });
+    expect(printCsf(csf).code).toContain('export default { bar: foo }');
+  });
+
+  it('preserves a shorthand property value when moving its key', () => {
+    const csf = parse(`const foo = true; export default { foo };`);
+    const [meta] = csf.objects({ meta: true, stories: false });
+
+    expect(meta.move(['foo'], ['parameters', 'bar'])).toEqual({ ok: true, changed: true });
+    expect(printCsf(csf).code).toMatch(/parameters: \{\s+bar: foo/);
+  });
+
   it('removes fields from CSF4 extended story objects', () => {
     const csf = parse(`
       import preview from './preview';
@@ -341,22 +392,86 @@ describe('CsfObject', () => {
   });
 
   it.each([
-    ['meta without an argument', `const meta = preview.meta();`],
+    ['meta without an argument', `const meta = preview.meta();`, { kind: 'meta' }],
     [
       'identifier-backed story argument',
       `const meta = preview.meta({});\nconst config = { args: {} };\nexport const Basic = meta.story(config);`,
+      { kind: 'story', exportName: 'Basic', localName: 'Basic' },
     ],
     [
       'dynamic extend argument',
       `const meta = preview.meta({});\nconst Base = meta.story({});\nexport const Basic = Base.extend(makeConfig());`,
+      { kind: 'story', exportName: 'Basic', localName: 'Basic' },
     ],
-  ])('reports an unsupported CSF4 %s', (_kind, code) => {
+  ])('reports an unsupported CSF4 %s', (_kind, code, target) => {
     const csf = parse(`import preview from './preview';\n${code}`);
 
     csf.objects();
 
     expect(csf.mutationDiagnostics).toContainEqual(
-      expect.objectContaining({ code: 'unsupported-initializer' })
+      expect.objectContaining({ code: 'unsupported-initializer', target })
+    );
+  });
+
+  it('preserves identifier-backed factory meta configuration', () => {
+    const csf = parse(`
+      import preview from './preview';
+      const config = { title: 'Example' };
+      const meta = preview.meta(config);
+      export const Basic = meta.story({});
+    `);
+    const [meta] = csf.objects({ meta: true, stories: false });
+
+    expect(meta.get(['title'])).toMatchObject({ type: 'StringLiteral', value: 'Example' });
+  });
+
+  it('rejects mutable identifier-backed factory meta configuration', () => {
+    const csf = parse(`
+      import preview from './preview';
+      let config = { title: 'Example' };
+      config = { title: 'Changed' };
+      const meta = preview.meta(config);
+      export const Basic = meta.story({});
+    `);
+
+    expect(csf.objects({ meta: true, stories: false })).toEqual([]);
+    expect(csf.mutationDiagnostics).toContainEqual(
+      expect.objectContaining({ code: 'unsupported-initializer', target: { kind: 'meta' } })
+    );
+  });
+
+  it('does not mutate unrelated factory-shaped receivers', () => {
+    const csf = parse(`
+      import preview from './preview';
+      const meta = preview.meta({ title: 'Example' });
+      const helper = { story: () => ({}) };
+      export const Basic = helper.story({ parameters: { a11y: { element: '#root' } } });
+    `);
+
+    expect(csf.objects({ meta: false, stories: true })).toEqual([]);
+    expect(csf.mutationDiagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'unsupported-initializer',
+        target: { kind: 'story', exportName: 'Basic', localName: 'Basic' },
+      })
+    );
+  });
+
+  it('does not mutate factory receivers that have been reassigned', () => {
+    const csf = parse(`
+      import preview from './preview';
+      const meta = preview.meta({ title: 'Example' });
+      let Base = meta.story({});
+      Base = helper;
+      export const Basic = Base.extend({ parameters: { a11y: { element: '#root' } } });
+    `);
+
+    expect(csf.objects({ meta: false, stories: true })).toEqual([]);
+    expect(csf.mutationDiagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'unsupported-initializer',
+        target: { kind: 'story', exportName: 'Basic', localName: 'Basic' },
+      })
     );
   });
 

--- a/code/core/src/csf-tools/CsfObject.test.ts
+++ b/code/core/src/csf-tools/CsfObject.test.ts
@@ -319,6 +319,14 @@ describe('CsfObject', () => {
     expect(printCsf(csf).code).toMatch(/Keep the configuration note\.\s+accessibility: true/);
   });
 
+  it('keeps a renamed field in its original position', () => {
+    const csf = parse(`export default { first: true, oldName: true, last: true };`);
+    const [meta] = csf.objects({ meta: true, stories: false });
+
+    expect(meta.rename(['oldName'], 'newName')).toEqual({ ok: true, changed: true });
+    expect(printCsf(csf).code).toBe(`export default { first: true, newName: true, last: true };`);
+  });
+
   it('removes fields from CSF4 extended story objects', () => {
     const csf = parse(`
       import preview from './preview';

--- a/code/core/src/csf-tools/CsfObject.test.ts
+++ b/code/core/src/csf-tools/CsfObject.test.ts
@@ -44,26 +44,6 @@ describe('CsfObject', () => {
     expect(printCsf(csf).code).not.toContain('Mutated');
   });
 
-  it('sets primitive values', () => {
-    const csf = parse(`export default {};`);
-    const [meta] = csf.objects({ meta: true, stories: false });
-
-    expect(meta.set(['title'], 'Example')).toEqual({ ok: true, changed: true });
-    expect(meta.set(['parameters', 'count'], 2)).toEqual({ ok: true, changed: true });
-    expect(meta.set(['parameters', 'enabled'], true)).toEqual({ ok: true, changed: true });
-
-    expect(printCsf(csf).code).toMatchInlineSnapshot(`
-      "export default {
-        title: "Example",
-
-        parameters: {
-          count: 2,
-          enabled: true
-        }
-      };"
-    `);
-  });
-
   it('discovers an identifier-backed aliased story once', () => {
     const csf = parse(`
       export default { title: 'Example' };
@@ -118,8 +98,8 @@ describe('CsfObject', () => {
   });
 
   it.each([
-    ['spread-field', `{ ...base, componentSubtitle: 'Unsafe' }`],
-    ['dynamic-key', `{ [field]: 'Unsafe', componentSubtitle: 'Unsafe' }`],
+    ['spread-field', `{ componentSubtitle: 'Unsafe', ...base }`],
+    ['dynamic-key', `{ componentSubtitle: 'Unsafe', [field]: 'Unsafe' }`],
     ['duplicate-field', `{ componentSubtitle: 'One', componentSubtitle: 'Two' }`],
     ['unsupported-member', `{ get componentSubtitle() { return 'Unsafe' } }`],
   ])('rejects %s without changing the source', (code, parameters) => {
@@ -134,6 +114,24 @@ describe('CsfObject', () => {
     });
     expect(csf.changed).toBe(false);
     expect(printCsf(csf).code).toBe(source);
+  });
+
+  it('allows explicit properties after spreads and computed keys', () => {
+    const csf = parse(
+      `export default { parameters: { ...base, [field]: 'Earlier', componentSubtitle: 'Safe' } };`
+    );
+    const [meta] = csf.objects({ meta: true, stories: false });
+
+    expect(meta.remove(['parameters', 'componentSubtitle'])).toEqual({
+      ok: true,
+      changed: true,
+    });
+    expect(printCsf(csf).code).toMatchInlineSnapshot(`
+      "export default { parameters: {
+        ...base,
+        [field]: 'Earlier'
+      } };"
+    `);
   });
 
   it('rejects an occupied move destination without changing the source', () => {

--- a/code/core/src/csf-tools/CsfObject.test.ts
+++ b/code/core/src/csf-tools/CsfObject.test.ts
@@ -227,6 +227,21 @@ describe('CsfObject', () => {
     );
   });
 
+  it('rejects a reassigned named-default meta object', () => {
+    const source = `
+      let meta = { title: 'First' };
+      meta = { title: 'Second' };
+      export { meta as default };
+    `;
+    const csf = parse(source);
+
+    expect(csf.objects({ meta: true, stories: false })).toHaveLength(0);
+    expect(csf.mutationDiagnostics).toContainEqual(
+      expect.objectContaining({ code: 'ambiguous-binding', target: { kind: 'meta' } })
+    );
+    expect(printCsf(csf).code).toBe(source);
+  });
+
   it('supports static bracket notation for CSF2 annotations', () => {
     const csf = parse(`
       export default { title: 'Example' };
@@ -335,6 +350,17 @@ describe('CsfObject', () => {
     expect(csf.mutationDiagnostics).toContainEqual(
       expect.objectContaining({ code: 'unsupported-initializer' })
     );
+  });
+
+  it('reports a standalone CSF4 meta call without changing the source', () => {
+    const source = `import preview from './preview';\npreview.meta();`;
+    const csf = parse(source);
+
+    expect(csf.objects({ meta: true, stories: false })).toHaveLength(0);
+    expect(csf.mutationDiagnostics).toContainEqual(
+      expect.objectContaining({ code: 'unsupported-initializer', target: { kind: 'meta' } })
+    );
+    expect(printCsf(csf).code).toBe(source);
   });
 
   it('reports an ambiguous CSF4 factory chain', () => {

--- a/code/core/src/csf-tools/CsfObject.test.ts
+++ b/code/core/src/csf-tools/CsfObject.test.ts
@@ -335,17 +335,16 @@ describe('CsfObject', () => {
     );
   });
 
-  it('rejects identifier-backed factory meta configuration', () => {
+  it('supports identifier-backed factory meta configuration', () => {
     const csf = parse(`
       import preview from './preview';
       const config = { title: 'Example' };
       const meta = preview.meta(config);
       export const Basic = meta.story({});
     `);
-    expect(csf.objects({ meta: true, stories: false })).toEqual([]);
-    expect(csf.mutationDiagnostics).toContainEqual(
-      expect.objectContaining({ code: 'unsupported-initializer', target: { kind: 'meta' } })
-    );
+    const [meta] = csf.objects({ meta: true, stories: false });
+
+    expect(meta.get(['title'])).toMatchObject({ type: 'StringLiteral', value: 'Example' });
   });
 
   it('rejects mutable identifier-backed factory meta configuration', () => {

--- a/code/core/src/csf-tools/CsfObject.test.ts
+++ b/code/core/src/csf-tools/CsfObject.test.ts
@@ -40,7 +40,8 @@ describe('CsfObject', () => {
     expect(meta.set(['title'], replacement)).toEqual({ ok: true, changed: true });
     replacement.value = 'Mutated replacement';
 
-    expect(printCsf(csf).code).toBe(`export default { title: 'Replacement' };`);
+    expect(printCsf(csf).code).toContain('title: "Replacement"');
+    expect(printCsf(csf).code).not.toContain('Mutated');
   });
 
   it('discovers an identifier-backed aliased story once', () => {
@@ -139,6 +140,38 @@ describe('CsfObject', () => {
     expect(printCsf(csf).code).toBe(source);
   });
 
+  it('treats a move to the same path as a no-op', () => {
+    const source = `export default { title: 'Example' };`;
+    const csf = parse(source);
+    const [meta] = csf.objects({ meta: true, stories: false });
+
+    expect(meta.rename(['title'], 'title')).toEqual({ ok: true, changed: false });
+    expect(csf.changed).toBe(false);
+    expect(printCsf(csf).code).toBe(source);
+  });
+
+  it('rejects prototype-setting destination paths', () => {
+    const source = `export default { title: 'Example' };`;
+    const csf = parse(source);
+    const [meta] = csf.objects({ meta: true, stories: false });
+
+    expect(meta.set(['parameters', '__proto__', 'polluted'], t.booleanLiteral(true))).toMatchObject(
+      {
+        ok: false,
+        diagnostic: { code: 'unsupported-member' },
+      }
+    );
+    expect(printCsf(csf).code).toBe(source);
+  });
+
+  it('addresses numeric literal keys by their static string value', () => {
+    const csf = parse(`export default { parameters: { 1: 'one' } };`);
+    const [meta] = csf.objects({ meta: true, stories: false });
+
+    expect(meta.remove(['parameters', '1'])).toEqual({ ok: true, changed: true });
+    expect(printCsf(csf).code).not.toContain(`1: 'one'`);
+  });
+
   it('rejects reassigned direct exports', () => {
     const csf = parse(`
       export default { title: 'Example' };
@@ -170,6 +203,73 @@ describe('CsfObject', () => {
     );
   });
 
+  it('selects a retained alias when another alias is excluded', () => {
+    const csf = parse(`
+      export default { title: 'Example', includeStories: ['Second'] };
+      const Local = { args: {} };
+      export { Local as First, Local as Second };
+    `);
+    const [story] = csf.objects({ meta: false, stories: true });
+
+    expect(story.target).toEqual({ kind: 'story', exportName: 'Second', localName: 'Local' });
+  });
+
+  it('rejects a reassigned identifier-backed meta object', () => {
+    const csf = parse(`
+      let meta = { title: 'First' };
+      meta = { title: 'Second' };
+      export default meta;
+    `);
+
+    expect(csf.objects({ meta: true, stories: false })).toHaveLength(0);
+    expect(csf.mutationDiagnostics).toContainEqual(
+      expect.objectContaining({ code: 'ambiguous-binding', target: { kind: 'meta' } })
+    );
+  });
+
+  it('supports static bracket notation for CSF2 annotations', () => {
+    const csf = parse(`
+      export default { title: 'Example' };
+      export const Basic = () => null;
+      Basic['parameters'] = { a11y: true };
+    `);
+    const [parameters] = csf.objects({
+      meta: false,
+      stories: false,
+      annotations: ['parameters'],
+    });
+
+    expect(parameters.remove(['parameters', 'a11y'])).toEqual({ ok: true, changed: true });
+    expect(printCsf(csf).code).not.toContain('a11y');
+  });
+
+  it('reports compound CSF2 annotation assignments', () => {
+    const csf = parse(`
+      export default { title: 'Example' };
+      export const Basic = () => null;
+      Basic.parameters ||= { a11y: true };
+    `);
+
+    expect(csf.objects({ meta: false, stories: false, annotations: ['parameters'] })).toHaveLength(
+      0
+    );
+    expect(csf.mutationDiagnostics).toContainEqual(
+      expect.objectContaining({ code: 'unsupported-initializer' })
+    );
+  });
+
+  it('does not discover or diagnose stories when only meta is requested', () => {
+    const csf = parse(`
+      export default { title: 'Example' };
+      export let Basic = { args: {} };
+      Basic = { args: { changed: true } };
+    `);
+
+    expect(csf.objects({ meta: true, stories: false })).toHaveLength(1);
+    expect(csf.mutationDiagnostics).toEqual([]);
+    expect(csf.mutationDiagnostics).not.toBe(csf.mutationDiagnostics);
+  });
+
   it('mutates CSF4 meta objects', () => {
     const csf = parse(`
       import preview from './preview';
@@ -181,22 +281,35 @@ describe('CsfObject', () => {
     expect(
       meta.move(['parameters', 'componentSubtitle'], ['parameters', 'docs', 'subtitle'])
     ).toEqual({ ok: true, changed: true });
-    expect(printCsf(csf).code).toContain(
-      `const meta = preview.meta({ parameters: { docs: { subtitle: 'Buttons' } } });`
+    expect(printCsf(csf).code).toMatch(
+      /preview\.meta\(\{ parameters: \{ docs: \{\s+subtitle: 'Buttons'/
     );
   });
 
-  it.each([
-    ['story', `export const Basic = meta.story({ parameters: { a11y: true } });`],
-    [
-      'extend',
-      `const Base = meta.story({});\nexport const Basic = Base.extend({ parameters: { a11y: true } });`,
-    ],
-  ])('mutates CSF4 %s objects', (_kind, story) => {
+  it('renames fields in CSF4 story objects', () => {
     const csf = parse(`
       import preview from './preview';
       const meta = preview.meta({ title: 'Example' });
-      ${story}
+      export const Basic = meta.story({ parameters: {
+        // Keep the configuration note.
+        a11y: true,
+      } });
+    `);
+    const [basic] = csf.objects({ meta: false, stories: true });
+
+    expect(basic.rename(['parameters', 'a11y'], 'accessibility')).toEqual({
+      ok: true,
+      changed: true,
+    });
+    expect(printCsf(csf).code).toMatch(/Keep the configuration note\.\s+accessibility: true/);
+  });
+
+  it('removes fields from CSF4 extended story objects', () => {
+    const csf = parse(`
+      import preview from './preview';
+      const meta = preview.meta({ title: 'Example' });
+      const Base = meta.story({});
+      export const Basic = Base.extend({ parameters: { a11y: true } });
     `);
     const [basic] = csf.objects({ meta: false, stories: true });
 

--- a/code/core/src/csf-tools/CsfObject.test.ts
+++ b/code/core/src/csf-tools/CsfObject.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+
+import { loadCsf, printCsf } from './CsfFile.ts';
+
+const parse = (source: string) =>
+  loadCsf(source, { makeTitle: (title) => title ?? 'title' }).parse();
+
+describe('CsfObject', () => {
+  it('moves a nested meta field and preserves its comments', () => {
+    const csf = parse(`
+      export default {
+        parameters: {
+          // Keep this explanation with the subtitle.
+          componentSubtitle: 'Buttons',
+        },
+      };
+    `);
+    const [meta] = csf.objects({ meta: true, stories: false });
+
+    expect(
+      meta.move(['parameters', 'componentSubtitle'], ['parameters', 'docs', 'subtitle'])
+    ).toEqual({ ok: true, changed: true });
+    expect(csf.changed).toBe(true);
+    expect(printCsf(csf).code).toMatch(
+      /docs: \{\s+\/\/ Keep this explanation with the subtitle\.\s+subtitle: 'Buttons'/
+    );
+  });
+
+  it('discovers an identifier-backed aliased story once', () => {
+    const csf = parse(`
+      export default { title: 'Example' };
+      const Local = { parameters: { componentSubtitle: 'Aliased' } } satisfies Story;
+      export { Local as First, Local as Second };
+    `);
+
+    const stories = csf.objects({ meta: false, stories: true });
+
+    expect(stories).toHaveLength(1);
+    expect(stories[0].target).toEqual({ kind: 'story', exportName: 'First', localName: 'Local' });
+    expect(stories[0].get(['parameters', 'componentSubtitle'])).toMatchObject({
+      type: 'StringLiteral',
+      value: 'Aliased',
+    });
+  });
+
+  it('uses logical paths for CSF2 parameter assignments', () => {
+    const csf = parse(`
+      export default { title: 'Example' };
+      export const Basic = () => null;
+      Basic.parameters = { a11y: { element: '#root' } };
+    `);
+    const [parameters] = csf.objects({
+      meta: false,
+      stories: false,
+      annotations: ['parameters'],
+    });
+
+    expect(parameters.rename(['parameters', 'a11y', 'element'], 'context')).toEqual({
+      ok: true,
+      changed: true,
+    });
+    expect(printCsf(csf).code).toContain(`Basic.parameters = { a11y: { context: '#root' } };`);
+  });
+
+  it('rejects repeated CSF2 annotations instead of exposing either object', () => {
+    const csf = parse(`
+      export default { title: 'Example' };
+      export const Basic = () => null;
+      Basic.parameters = { first: true };
+      Basic.parameters = { second: true };
+    `);
+
+    expect(csf.objects({ meta: false, stories: false, annotations: ['parameters'] })).toEqual([]);
+    expect(csf.mutationDiagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'ambiguous-binding',
+        target: expect.objectContaining({ kind: 'story-annotation', exportName: 'Basic' }),
+      })
+    );
+  });
+
+  it.each([
+    ['spread-field', `{ ...base, componentSubtitle: 'Unsafe' }`],
+    ['dynamic-key', `{ [field]: 'Unsafe', componentSubtitle: 'Unsafe' }`],
+    ['duplicate-field', `{ componentSubtitle: 'One', componentSubtitle: 'Two' }`],
+    ['unsupported-member', `{ get componentSubtitle() { return 'Unsafe' } }`],
+  ])('rejects %s without changing the source', (code, parameters) => {
+    const source = `export default { parameters: ${parameters} };`;
+    const csf = parse(source);
+    const [meta] = csf.objects({ meta: true, stories: false });
+
+    expect(meta.remove(['parameters', 'componentSubtitle'])).toMatchObject({
+      ok: false,
+      changed: false,
+      diagnostic: { code },
+    });
+    expect(csf.changed).toBe(false);
+    expect(printCsf(csf).code).toBe(source);
+  });
+
+  it('rejects an occupied move destination without changing the source', () => {
+    const source = `export default { parameters: { componentSubtitle: 'Old', docs: { subtitle: 'New' } } };`;
+    const csf = parse(source);
+    const [meta] = csf.objects({ meta: true, stories: false });
+
+    expect(
+      meta.move(['parameters', 'componentSubtitle'], ['parameters', 'docs', 'subtitle'])
+    ).toMatchObject({ ok: false, diagnostic: { code: 'occupied-destination' } });
+    expect(printCsf(csf).code).toBe(source);
+  });
+
+  it('reports unsupported CSF factory candidates', () => {
+    const csf = parse(`
+      import preview from './preview';
+      const meta = preview.meta({ title: 'Example' });
+      export const Basic = meta.story({ args: {} });
+    `);
+
+    expect(csf.objects()).toEqual([]);
+    expect(csf.mutationDiagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'unsupported-initializer', target: { kind: 'meta' } }),
+        expect.objectContaining({
+          code: 'unsupported-initializer',
+          target: expect.objectContaining({ kind: 'story', exportName: 'Basic' }),
+        }),
+      ])
+    );
+  });
+});

--- a/code/core/src/csf-tools/CsfObject.test.ts
+++ b/code/core/src/csf-tools/CsfObject.test.ts
@@ -44,6 +44,26 @@ describe('CsfObject', () => {
     expect(printCsf(csf).code).not.toContain('Mutated');
   });
 
+  it('sets primitive values', () => {
+    const csf = parse(`export default {};`);
+    const [meta] = csf.objects({ meta: true, stories: false });
+
+    expect(meta.set(['title'], 'Example')).toEqual({ ok: true, changed: true });
+    expect(meta.set(['parameters', 'count'], 2)).toEqual({ ok: true, changed: true });
+    expect(meta.set(['parameters', 'enabled'], true)).toEqual({ ok: true, changed: true });
+
+    expect(printCsf(csf).code).toMatchInlineSnapshot(`
+      "export default {
+        title: "Example",
+
+        parameters: {
+          count: 2,
+          enabled: true
+        }
+      };"
+    `);
+  });
+
   it('discovers an identifier-backed aliased story once', () => {
     const csf = parse(`
       export default { title: 'Example' };

--- a/code/core/src/csf-tools/CsfObject.test.ts
+++ b/code/core/src/csf-tools/CsfObject.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import { types as t } from 'storybook/internal/babel';
 
+import { dedent } from 'ts-dedent';
+
 import { loadCsf, printCsf } from './CsfFile.ts';
 
 const parse = (source: string) =>
@@ -117,20 +119,28 @@ describe('CsfObject', () => {
   });
 
   it('allows explicit properties after spreads and computed keys', () => {
-    const csf = parse(
-      `export default { parameters: { ...base, [field]: 'Earlier', componentSubtitle: 'Safe' } };`
-    );
+    const csf = parse(dedent`
+      export default {
+        parameters: {
+          ...base,
+          [field]: 'Earlier',
+          componentSubtitle: 'Safe',
+        },
+      };
+    `);
     const [meta] = csf.objects({ meta: true, stories: false });
 
     expect(meta.remove(['parameters', 'componentSubtitle'])).toEqual({
       ok: true,
       changed: true,
     });
-    expect(printCsf(csf).code).toMatchInlineSnapshot(`
-      "export default { parameters: {
-        ...base,
-        [field]: 'Earlier'
-      } };"
+    expect(printCsf(csf).code).toBe(dedent`
+      export default {
+        parameters: {
+          ...base,
+          [field]: 'Earlier'
+        },
+      };
     `);
   });
 

--- a/code/core/src/csf-tools/CsfObject.test.ts
+++ b/code/core/src/csf-tools/CsfObject.test.ts
@@ -242,84 +242,6 @@ describe('CsfObject', () => {
     expect(printCsf(csf).code).toBe(source);
   });
 
-  it('supports static bracket notation for CSF2 annotations', () => {
-    const csf = parse(`
-      export default { title: 'Example' };
-      export const Basic = () => null;
-      Basic['parameters'] = { a11y: true };
-    `);
-    const [parameters] = csf.objects({
-      meta: false,
-      stories: false,
-      annotations: ['parameters'],
-    });
-
-    expect(parameters.remove(['parameters', 'a11y'])).toEqual({ ok: true, changed: true });
-    expect(printCsf(csf).code).not.toContain('a11y');
-  });
-
-  it('rejects computed identifier notation for CSF2 annotations', () => {
-    const csf = parse(`
-      export default { title: 'Example' };
-      export const Basic = () => null;
-      Basic[parameters] = { a11y: true };
-    `);
-
-    expect(csf.objects({ meta: false, stories: false, annotations: ['parameters'] })).toEqual([]);
-  });
-
-  it('does not diagnose exports excluded from the story index', () => {
-    const csf = parse(`
-      export default { title: 'Example', includeStories: ['Basic'] };
-      export let Helper = { args: {} };
-      Helper = { args: { changed: true } };
-      export const Basic = { args: {} };
-    `);
-
-    csf.objects({ meta: false, stories: true });
-
-    expect(csf.mutationDiagnostics).toEqual([]);
-  });
-
-  it('does not diagnose re-exports excluded from the story index', () => {
-    const csf = parse(`
-      export default { title: 'Example', includeStories: ['Basic'] };
-      export { Helper } from './helper';
-      export const Basic = { args: {} };
-    `);
-
-    csf.objects({ meta: false, stories: true });
-
-    expect(csf.mutationDiagnostics).toEqual([]);
-  });
-
-  it('reports compound CSF2 annotation assignments', () => {
-    const csf = parse(`
-      export default { title: 'Example' };
-      export const Basic = () => null;
-      Basic.parameters ||= { a11y: true };
-    `);
-
-    expect(csf.objects({ meta: false, stories: false, annotations: ['parameters'] })).toHaveLength(
-      0
-    );
-    expect(csf.mutationDiagnostics).toContainEqual(
-      expect.objectContaining({ code: 'unsupported-initializer' })
-    );
-  });
-
-  it('does not discover or diagnose stories when only meta is requested', () => {
-    const csf = parse(`
-      export default { title: 'Example' };
-      export let Basic = { args: {} };
-      Basic = { args: { changed: true } };
-    `);
-
-    expect(csf.objects({ meta: true, stories: false })).toHaveLength(1);
-    expect(csf.mutationDiagnostics).toEqual([]);
-    expect(csf.mutationDiagnostics).not.toBe(csf.mutationDiagnostics);
-  });
-
   it('mutates CSF4 meta objects', () => {
     const csf = parse(`
       import preview from './preview';
@@ -413,16 +335,17 @@ describe('CsfObject', () => {
     );
   });
 
-  it('preserves identifier-backed factory meta configuration', () => {
+  it('rejects identifier-backed factory meta configuration', () => {
     const csf = parse(`
       import preview from './preview';
       const config = { title: 'Example' };
       const meta = preview.meta(config);
       export const Basic = meta.story({});
     `);
-    const [meta] = csf.objects({ meta: true, stories: false });
-
-    expect(meta.get(['title'])).toMatchObject({ type: 'StringLiteral', value: 'Example' });
+    expect(csf.objects({ meta: true, stories: false })).toEqual([]);
+    expect(csf.mutationDiagnostics).toContainEqual(
+      expect.objectContaining({ code: 'unsupported-initializer', target: { kind: 'meta' } })
+    );
   });
 
   it('rejects mutable identifier-backed factory meta configuration', () => {
@@ -486,7 +409,7 @@ describe('CsfObject', () => {
     expect(printCsf(csf).code).toBe(source);
   });
 
-  it('reports an ambiguous CSF4 factory chain', () => {
+  it('ignores non-story factory-shaped exports', () => {
     const csf = parse(`
       import preview from './preview';
       const meta = preview.meta({ title: 'Example' });
@@ -494,11 +417,6 @@ describe('CsfObject', () => {
     `);
 
     expect(csf.objects({ meta: false, stories: true })).toHaveLength(0);
-    expect(csf.mutationDiagnostics).toContainEqual(
-      expect.objectContaining({
-        code: 'unsupported-initializer',
-        target: expect.objectContaining({ kind: 'story', exportName: 'Basic' }),
-      })
-    );
+    expect(csf.mutationDiagnostics).toEqual([]);
   });
 });

--- a/code/core/src/csf-tools/CsfObject.test.ts
+++ b/code/core/src/csf-tools/CsfObject.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { types as t } from 'storybook/internal/babel';
+
 import { loadCsf, printCsf } from './CsfFile.ts';
 
 const parse = (source: string) =>
@@ -24,6 +26,21 @@ describe('CsfObject', () => {
     expect(printCsf(csf).code).toMatch(
       /docs: \{\s+\/\/ Keep this explanation with the subtitle\.\s+subtitle: 'Buttons'/
     );
+  });
+
+  it('does not expose mutable AST nodes through get or set', () => {
+    const csf = parse(`export default { title: 'Original' };`);
+    const [meta] = csf.objects({ meta: true, stories: false });
+    const value = meta.get(['title']);
+    const replacement = t.stringLiteral('Replacement');
+
+    if (t.isStringLiteral(value)) {
+      value.value = 'Mutated';
+    }
+    expect(meta.set(['title'], replacement)).toEqual({ ok: true, changed: true });
+    replacement.value = 'Mutated replacement';
+
+    expect(printCsf(csf).code).toBe(`export default { title: 'Replacement' };`);
   });
 
   it('discovers an identifier-backed aliased story once', () => {
@@ -109,22 +126,117 @@ describe('CsfObject', () => {
     expect(printCsf(csf).code).toBe(source);
   });
 
-  it('reports unsupported CSF factory candidates', () => {
+  it('rejects moving a field below itself without changing the source', () => {
+    const source = `export default { parameters: { docs: { source: true } } };`;
+    const csf = parse(source);
+    const [meta] = csf.objects({ meta: true, stories: false });
+
+    expect(meta.move(['parameters', 'docs'], ['parameters', 'docs', 'subtitle'])).toMatchObject({
+      ok: false,
+      diagnostic: { code: 'cyclic-move' },
+    });
+    expect(csf.changed).toBe(false);
+    expect(printCsf(csf).code).toBe(source);
+  });
+
+  it('rejects reassigned direct exports', () => {
+    const csf = parse(`
+      export default { title: 'Example' };
+      export let Basic = { args: { label: 'First' } };
+      Basic = { args: { label: 'Second' } };
+    `);
+
+    expect(csf.objects({ meta: false, stories: true })).toHaveLength(0);
+    expect(csf.mutationDiagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'ambiguous-binding',
+        target: { kind: 'story', exportName: 'Basic', localName: 'Basic' },
+      })
+    );
+  });
+
+  it('reports re-exported story candidates', () => {
+    const csf = parse(`
+      export default { title: 'Example' };
+      export { Basic } from './Basic.stories';
+    `);
+
+    expect(csf.objects({ meta: false, stories: true })).toHaveLength(0);
+    expect(csf.mutationDiagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'unsupported-initializer',
+        target: { kind: 'story', exportName: 'Basic', localName: 'Basic' },
+      })
+    );
+  });
+
+  it('mutates CSF4 meta objects', () => {
+    const csf = parse(`
+      import preview from './preview';
+      const meta = preview.meta({ parameters: { componentSubtitle: 'Buttons' } });
+      export const Basic = meta.story({});
+    `);
+    const [meta] = csf.objects({ meta: true, stories: false });
+
+    expect(
+      meta.move(['parameters', 'componentSubtitle'], ['parameters', 'docs', 'subtitle'])
+    ).toEqual({ ok: true, changed: true });
+    expect(printCsf(csf).code).toContain(
+      `const meta = preview.meta({ parameters: { docs: { subtitle: 'Buttons' } } });`
+    );
+  });
+
+  it.each([
+    ['story', `export const Basic = meta.story({ parameters: { a11y: true } });`],
+    [
+      'extend',
+      `const Base = meta.story({});\nexport const Basic = Base.extend({ parameters: { a11y: true } });`,
+    ],
+  ])('mutates CSF4 %s objects', (_kind, story) => {
     const csf = parse(`
       import preview from './preview';
       const meta = preview.meta({ title: 'Example' });
-      export const Basic = meta.story({ args: {} });
+      ${story}
+    `);
+    const [basic] = csf.objects({ meta: false, stories: true });
+
+    expect(basic.remove(['parameters', 'a11y'])).toEqual({ ok: true, changed: true });
+    expect(printCsf(csf).code).not.toContain('a11y');
+  });
+
+  it.each([
+    ['meta without an argument', `const meta = preview.meta();`],
+    [
+      'identifier-backed story argument',
+      `const meta = preview.meta({});\nconst config = { args: {} };\nexport const Basic = meta.story(config);`,
+    ],
+    [
+      'dynamic extend argument',
+      `const meta = preview.meta({});\nconst Base = meta.story({});\nexport const Basic = Base.extend(makeConfig());`,
+    ],
+  ])('reports an unsupported CSF4 %s', (_kind, code) => {
+    const csf = parse(`import preview from './preview';\n${code}`);
+
+    csf.objects();
+
+    expect(csf.mutationDiagnostics).toContainEqual(
+      expect.objectContaining({ code: 'unsupported-initializer' })
+    );
+  });
+
+  it('reports an ambiguous CSF4 factory chain', () => {
+    const csf = parse(`
+      import preview from './preview';
+      const meta = preview.meta({ title: 'Example' });
+      export const Basic = getMeta().story({ args: {} });
     `);
 
-    expect(csf.objects()).toEqual([]);
-    expect(csf.mutationDiagnostics).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ code: 'unsupported-initializer', target: { kind: 'meta' } }),
-        expect.objectContaining({
-          code: 'unsupported-initializer',
-          target: expect.objectContaining({ kind: 'story', exportName: 'Basic' }),
-        }),
-      ])
+    expect(csf.objects({ meta: false, stories: true })).toHaveLength(0);
+    expect(csf.mutationDiagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'unsupported-initializer',
+        target: expect.objectContaining({ kind: 'story', exportName: 'Basic' }),
+      })
     );
   });
 });

--- a/code/core/src/csf-tools/CsfObject.ts
+++ b/code/core/src/csf-tools/CsfObject.ts
@@ -225,12 +225,14 @@ class CsfObjectEditor implements CsfObject {
       sourceParent.length === destinationParent.length &&
       sourceParent.every((part, index) => destinationParent[index] === part)
     ) {
+      source.property.shorthand = false;
       source.property.key = keyNode(destinationPath.at(-1)!);
       source.property.computed = false;
       return this.success();
     }
 
     source.parent.properties.splice(source.parent.properties.indexOf(source.property), 1);
+    source.property.shorthand = false;
     source.property.key = keyNode(destinationPath.at(-1)!);
     source.property.computed = false;
     this.insert(destinationPath, source.property);

--- a/code/core/src/csf-tools/CsfObject.ts
+++ b/code/core/src/csf-tools/CsfObject.ts
@@ -186,6 +186,13 @@ class CsfObjectEditor implements CsfObject {
       return { ok: true, changed: false };
     }
     inspected.parent.properties.splice(inspected.parent.properties.indexOf(inspected.property), 1);
+    for (const ancestor of inspected.ancestors.toReversed()) {
+      const value = unwrapExpression(ancestor.property.value);
+      if (!t.isObjectExpression(value) || value.properties.length > 0) {
+        break;
+      }
+      ancestor.parent.properties.splice(ancestor.parent.properties.indexOf(ancestor.property), 1);
+    }
     return this.success();
   }
 
@@ -272,6 +279,7 @@ class CsfObjectEditor implements CsfObject {
     let object = this.root.node;
     let parent: t.ObjectExpression | undefined;
     let property: t.ObjectProperty | undefined;
+    const ancestors: { parent: t.ObjectExpression; property: t.ObjectProperty }[] = [];
 
     for (const [index, name] of path.entries()) {
       const lookup = lookupProperty(object, name);
@@ -281,16 +289,17 @@ class CsfObjectEditor implements CsfObject {
       parent = object;
       property = lookup.property;
       if (!property || index === path.length - 1) {
-        return { ok: true as const, parent, property };
+        return { ok: true as const, parent, property, ancestors };
       }
       const value = unwrapExpression(property.value);
       if (!t.isObjectExpression(value)) {
         return { ok: false as const, code: 'unsupported-member' as const, node: property.value };
       }
+      ancestors.push({ parent: object, property });
       object = value;
     }
 
-    return { ok: true as const, parent, property };
+    return { ok: true as const, parent, property, ancestors };
   }
 
   private insert(path: readonly string[], property: t.ObjectProperty) {

--- a/code/core/src/csf-tools/CsfObject.ts
+++ b/code/core/src/csf-tools/CsfObject.ts
@@ -34,11 +34,13 @@ export type CsfMutationResult =
   | { ok: true; changed: boolean }
   | { ok: false; changed: false; diagnostic: CsfMutationDiagnostic };
 
+export type CsfValue = t.Expression | string | number | boolean;
+
 export interface CsfObject {
   readonly target: CsfObjectTarget;
   readonly changed: boolean;
   get(path: readonly string[]): t.Expression | undefined;
-  set(path: readonly string[], value: t.Expression): CsfMutationResult;
+  set(path: readonly string[], value: CsfValue): CsfMutationResult;
   remove(path: readonly string[]): CsfMutationResult;
   rename(path: readonly string[], name: string): CsfMutationResult;
   move(from: readonly string[], to: readonly string[]): CsfMutationResult;
@@ -77,6 +79,19 @@ const keyNode = (name: string) =>
   t.isValidIdentifier(name) ? t.identifier(name) : t.stringLiteral(name);
 
 const unsafePath = (path: readonly string[]) => path.includes('__proto__');
+
+const expressionFor = (value: CsfValue): t.Expression => {
+  if (typeof value === 'string') {
+    return t.stringLiteral(value);
+  }
+  if (typeof value === 'number') {
+    return t.numericLiteral(value);
+  }
+  if (typeof value === 'boolean') {
+    return t.booleanLiteral(value);
+  }
+  return value;
+};
 
 const lookupProperty = (object: t.ObjectExpression, name: string): PropertyLookup => {
   const matches: t.ObjectProperty[] = [];
@@ -134,7 +149,7 @@ class CsfObjectEditor implements CsfObject {
       : undefined;
   }
 
-  set(path: readonly string[], value: t.Expression): CsfMutationResult {
+  set(path: readonly string[], value: CsfValue): CsfMutationResult {
     const logicalPath = this.normalizePath(path);
     if (!logicalPath || logicalPath.length === 0 || unsafePath(logicalPath)) {
       return this.failure('unsupported-member', path, this.root.node);
@@ -143,15 +158,16 @@ class CsfObjectEditor implements CsfObject {
     if (!inspected.ok) {
       return this.failure(inspected.code, path, inspected.node);
     }
+    const expression = expressionFor(value);
     if (inspected.property) {
-      if (inspected.property.value === value) {
+      if (inspected.property.value === expression) {
         return { ok: true, changed: false };
       }
-      inspected.property.value = t.cloneNode(value, true);
+      inspected.property.value = t.cloneNode(expression, true);
     } else {
       this.insert(
         logicalPath,
-        t.objectProperty(keyNode(logicalPath.at(-1)!), t.cloneNode(value, true))
+        t.objectProperty(keyNode(logicalPath.at(-1)!), t.cloneNode(expression, true))
       );
     }
     return this.success();

--- a/code/core/src/csf-tools/CsfObject.ts
+++ b/code/core/src/csf-tools/CsfObject.ts
@@ -41,6 +41,14 @@ export interface CsfObject {
   readonly changed: boolean;
   get(path: readonly string[]): t.Expression | undefined;
   set(path: readonly string[], value: CsfValue): CsfMutationResult;
+  /**
+   * Replace a field from its attached AST node. The callback must return a new value or undefined,
+   * and must not mutate or retain the input because those changes bypass diagnostics and tracking.
+   */
+  transform(
+    path: readonly string[],
+    derive: (value: t.Expression) => CsfValue | undefined
+  ): CsfMutationResult;
   remove(path: readonly string[]): CsfMutationResult;
   rename(path: readonly string[], name: string): CsfMutationResult;
   move(from: readonly string[], to: readonly string[]): CsfMutationResult;
@@ -58,6 +66,8 @@ type MarkChanged = () => void;
 type PropertyLookup =
   | { ok: true; property?: t.ObjectProperty }
   | { ok: false; code: CsfMutationDiagnosticCode; node: t.Node };
+
+type PropertyAncestor = { parent: t.ObjectExpression; property: t.ObjectProperty };
 
 const staticKey = (member: t.ObjectMethod | t.ObjectProperty): string | undefined => {
   if (t.isStringLiteral(member.key)) {
@@ -95,14 +105,23 @@ const expressionFor = (value: CsfValue): t.Expression => {
 
 const lookupProperty = (object: t.ObjectExpression, name: string): PropertyLookup => {
   const matches: t.ObjectProperty[] = [];
+  let uncertain: Exclude<PropertyLookup, { ok: true }> | undefined;
 
   for (const member of object.properties) {
     if (t.isSpreadElement(member)) {
-      return { ok: false, code: 'spread-field', node: member };
+      if (matches.length > 0) {
+        return { ok: false, code: 'spread-field', node: member };
+      }
+      uncertain ??= { ok: false, code: 'spread-field', node: member };
+      continue;
     }
     const key = staticKey(member);
     if (key === undefined) {
-      return { ok: false, code: 'dynamic-key', node: member };
+      if (matches.length > 0) {
+        return { ok: false, code: 'dynamic-key', node: member };
+      }
+      uncertain ??= { ok: false, code: 'dynamic-key', node: member };
+      continue;
     }
     if (key !== name) {
       continue;
@@ -111,10 +130,14 @@ const lookupProperty = (object: t.ObjectExpression, name: string): PropertyLooku
       return { ok: false, code: 'unsupported-member', node: member };
     }
     matches.push(member);
+    uncertain = undefined;
   }
 
   if (matches.length > 1) {
     return { ok: false, code: 'duplicate-field', node: matches[1] };
+  }
+  if (matches.length === 0 && uncertain) {
+    return uncertain;
   }
   return { ok: true, property: matches[0] };
 };
@@ -173,6 +196,33 @@ class CsfObjectEditor implements CsfObject {
     return this.success();
   }
 
+  transform(
+    path: readonly string[],
+    derive: (value: t.Expression) => CsfValue | undefined
+  ): CsfMutationResult {
+    const logicalPath = this.normalizePath(path);
+    if (!logicalPath || logicalPath.length === 0 || unsafePath(logicalPath)) {
+      return this.failure('unsupported-member', path, this.root.node);
+    }
+    const inspected = this.inspect(logicalPath);
+    if (!inspected.ok) {
+      return this.failure(inspected.code, path, inspected.node);
+    }
+    if (!inspected.property || !t.isExpression(inspected.property.value)) {
+      return { ok: true, changed: false };
+    }
+    const derived = derive(inspected.property.value);
+    if (derived === undefined) {
+      return { ok: true, changed: false };
+    }
+    const replacement = expressionFor(derived);
+    if (replacement === inspected.property.value) {
+      return { ok: true, changed: false };
+    }
+    inspected.property.value = replacement;
+    return this.success();
+  }
+
   remove(path: readonly string[]): CsfMutationResult {
     const logicalPath = this.normalizePath(path);
     if (!logicalPath || logicalPath.length === 0 || unsafePath(logicalPath)) {
@@ -186,13 +236,7 @@ class CsfObjectEditor implements CsfObject {
       return { ok: true, changed: false };
     }
     inspected.parent.properties.splice(inspected.parent.properties.indexOf(inspected.property), 1);
-    for (const ancestor of inspected.ancestors.toReversed()) {
-      const value = unwrapExpression(ancestor.property.value);
-      if (!t.isObjectExpression(value) || value.properties.length > 0) {
-        break;
-      }
-      ancestor.parent.properties.splice(ancestor.parent.properties.indexOf(ancestor.property), 1);
-    }
+    this.pruneEmptyAncestors(inspected.ancestors);
     return this.success();
   }
 
@@ -259,6 +303,7 @@ class CsfObjectEditor implements CsfObject {
     source.property.key = keyNode(destinationPath.at(-1)!);
     source.property.computed = false;
     this.insert(destinationPath, source.property);
+    this.pruneEmptyAncestors(source.ancestors);
     return this.success();
   }
 
@@ -279,7 +324,7 @@ class CsfObjectEditor implements CsfObject {
     let object = this.root.node;
     let parent: t.ObjectExpression | undefined;
     let property: t.ObjectProperty | undefined;
-    const ancestors: { parent: t.ObjectExpression; property: t.ObjectProperty }[] = [];
+    const ancestors: PropertyAncestor[] = [];
 
     for (const [index, name] of path.entries()) {
       const lookup = lookupProperty(object, name);
@@ -300,6 +345,16 @@ class CsfObjectEditor implements CsfObject {
     }
 
     return { ok: true as const, parent, property, ancestors };
+  }
+
+  private pruneEmptyAncestors(ancestors: readonly PropertyAncestor[]) {
+    for (const ancestor of ancestors.toReversed()) {
+      const value = unwrapExpression(ancestor.property.value);
+      if (!t.isObjectExpression(value) || value.properties.length > 0) {
+        break;
+      }
+      ancestor.parent.properties.splice(ancestor.parent.properties.indexOf(ancestor.property), 1);
+    }
   }
 
   private insert(path: readonly string[], property: t.ObjectProperty) {

--- a/code/core/src/csf-tools/CsfObject.ts
+++ b/code/core/src/csf-tools/CsfObject.ts
@@ -1,0 +1,287 @@
+import { type NodePath, types as t } from 'storybook/internal/babel';
+
+import { unwrapExpression } from './story-shape/index.ts';
+
+export type CsfObjectTarget =
+  | { kind: 'meta' }
+  | { kind: 'story'; exportName: string; localName: string }
+  | {
+      kind: 'story-annotation';
+      exportName: string;
+      localName: string;
+      annotation: 'parameters' | 'story';
+    };
+
+export type CsfMutationDiagnosticCode =
+  | 'unsupported-initializer'
+  | 'ambiguous-binding'
+  | 'duplicate-field'
+  | 'spread-field'
+  | 'dynamic-key'
+  | 'unsupported-member'
+  | 'occupied-destination';
+
+export interface CsfMutationDiagnostic {
+  code: CsfMutationDiagnosticCode;
+  target: CsfObjectTarget;
+  path: readonly string[];
+  message: string;
+  loc?: t.SourceLocation;
+}
+
+export type CsfMutationResult =
+  | { ok: true; changed: boolean }
+  | { ok: false; changed: false; diagnostic: CsfMutationDiagnostic };
+
+export interface CsfObject {
+  readonly target: CsfObjectTarget;
+  readonly changed: boolean;
+  get(path: readonly string[]): t.Expression | undefined;
+  set(path: readonly string[], value: t.Expression): CsfMutationResult;
+  remove(path: readonly string[]): CsfMutationResult;
+  rename(path: readonly string[], name: string): CsfMutationResult;
+  move(from: readonly string[], to: readonly string[]): CsfMutationResult;
+}
+
+export interface CsfObjectOptions {
+  meta?: boolean;
+  stories?: boolean;
+  annotations?: readonly ('parameters' | 'story')[];
+}
+
+type ReportDiagnostic = (diagnostic: CsfMutationDiagnostic) => void;
+type MarkChanged = () => void;
+
+type PropertyLookup =
+  | { ok: true; property?: t.ObjectProperty }
+  | { ok: false; code: CsfMutationDiagnosticCode; node: t.Node };
+
+const staticKey = (member: t.ObjectMethod | t.ObjectProperty): string | undefined => {
+  if (t.isStringLiteral(member.key)) {
+    return member.key.value;
+  }
+  if (t.isIdentifier(member.key) && !member.computed) {
+    return member.key.name;
+  }
+  if (t.isTemplateLiteral(member.key) && member.key.expressions.length === 0) {
+    return member.key.quasis[0]?.value.cooked ?? member.key.quasis[0]?.value.raw;
+  }
+  return undefined;
+};
+
+const keyNode = (name: string) =>
+  t.isValidIdentifier(name) ? t.identifier(name) : t.stringLiteral(name);
+
+const lookupProperty = (object: t.ObjectExpression, name: string): PropertyLookup => {
+  const matches: t.ObjectProperty[] = [];
+
+  for (const member of object.properties) {
+    if (t.isSpreadElement(member)) {
+      return { ok: false, code: 'spread-field', node: member };
+    }
+    const key = staticKey(member);
+    if (key === undefined) {
+      return { ok: false, code: 'dynamic-key', node: member };
+    }
+    if (key !== name) {
+      continue;
+    }
+    if (!t.isObjectProperty(member)) {
+      return { ok: false, code: 'unsupported-member', node: member };
+    }
+    matches.push(member);
+  }
+
+  if (matches.length > 1) {
+    return { ok: false, code: 'duplicate-field', node: matches[1] };
+  }
+  return { ok: true, property: matches[0] };
+};
+
+class CsfObjectEditor implements CsfObject {
+  #changed = false;
+
+  constructor(
+    readonly target: CsfObjectTarget,
+    private readonly root: NodePath<t.ObjectExpression>,
+    private readonly prefix: readonly string[],
+    private readonly reportDiagnostic: ReportDiagnostic,
+    private readonly markChanged: MarkChanged
+  ) {}
+
+  get changed() {
+    return this.#changed;
+  }
+
+  get(path: readonly string[]): t.Expression | undefined {
+    const logicalPath = this.normalizePath(path);
+    if (!logicalPath) {
+      return undefined;
+    }
+    const found = this.inspect(logicalPath);
+    if (!found.ok) {
+      this.failure(found.code, path, found.node);
+      return undefined;
+    }
+    return found.property && t.isExpression(found.property.value)
+      ? found.property.value
+      : undefined;
+  }
+
+  set(path: readonly string[], value: t.Expression): CsfMutationResult {
+    const logicalPath = this.normalizePath(path);
+    if (!logicalPath || logicalPath.length === 0) {
+      return this.failure('unsupported-member', path, this.root.node);
+    }
+    const inspected = this.inspect(logicalPath);
+    if (!inspected.ok) {
+      return this.failure(inspected.code, path, inspected.node);
+    }
+    if (inspected.property) {
+      if (inspected.property.value === value) {
+        return { ok: true, changed: false };
+      }
+      inspected.property.value = value;
+    } else {
+      this.insert(logicalPath, t.objectProperty(keyNode(logicalPath.at(-1)!), value));
+    }
+    return this.success();
+  }
+
+  remove(path: readonly string[]): CsfMutationResult {
+    const logicalPath = this.normalizePath(path);
+    if (!logicalPath || logicalPath.length === 0) {
+      return this.failure('unsupported-member', path, this.root.node);
+    }
+    const inspected = this.inspect(logicalPath);
+    if (!inspected.ok) {
+      return this.failure(inspected.code, path, inspected.node);
+    }
+    if (!inspected.property || !inspected.parent) {
+      return { ok: true, changed: false };
+    }
+    inspected.parent.properties.splice(inspected.parent.properties.indexOf(inspected.property), 1);
+    return this.success();
+  }
+
+  rename(path: readonly string[], name: string): CsfMutationResult {
+    const destination = [...path.slice(0, -1), name];
+    return this.move(path, destination);
+  }
+
+  move(from: readonly string[], to: readonly string[]): CsfMutationResult {
+    const sourcePath = this.normalizePath(from);
+    const destinationPath = this.normalizePath(to);
+    if (
+      !sourcePath ||
+      !destinationPath ||
+      sourcePath.length === 0 ||
+      destinationPath.length === 0
+    ) {
+      return this.failure('unsupported-member', !sourcePath ? from : to, this.root.node);
+    }
+
+    const source = this.inspect(sourcePath);
+    if (!source.ok) {
+      return this.failure(source.code, from, source.node);
+    }
+    if (!source.property || !source.parent) {
+      return { ok: true, changed: false };
+    }
+    const destination = this.inspect(destinationPath);
+    if (!destination.ok) {
+      return this.failure(destination.code, to, destination.node);
+    }
+    if (destination.property) {
+      return this.failure('occupied-destination', to, destination.property);
+    }
+
+    source.parent.properties.splice(source.parent.properties.indexOf(source.property), 1);
+    source.property.key = keyNode(destinationPath.at(-1)!);
+    source.property.computed = false;
+    this.insert(destinationPath, source.property);
+    return this.success();
+  }
+
+  private normalizePath(path: readonly string[]) {
+    if (this.prefix.length === 0) {
+      return [...path];
+    }
+    if (
+      path.length < this.prefix.length ||
+      this.prefix.some((part, index) => path[index] !== part)
+    ) {
+      return undefined;
+    }
+    return path.slice(this.prefix.length);
+  }
+
+  private inspect(path: readonly string[]) {
+    let object = this.root.node;
+    let parent: t.ObjectExpression | undefined;
+    let property: t.ObjectProperty | undefined;
+
+    for (const [index, name] of path.entries()) {
+      const lookup = lookupProperty(object, name);
+      if (!lookup.ok) {
+        return lookup;
+      }
+      parent = object;
+      property = lookup.property;
+      if (!property || index === path.length - 1) {
+        return { ok: true as const, parent, property };
+      }
+      const value = unwrapExpression(property.value);
+      if (!t.isObjectExpression(value)) {
+        return { ok: false as const, code: 'unsupported-member' as const, node: property.value };
+      }
+      object = value;
+    }
+
+    return { ok: true as const, parent, property };
+  }
+
+  private insert(path: readonly string[], property: t.ObjectProperty) {
+    let object = this.root.node;
+    for (const name of path.slice(0, -1)) {
+      const lookup = lookupProperty(object, name);
+      if (!lookup.ok) {
+        throw this.root.buildCodeFrameError('CsfObject mutation preflight was invalidated');
+      }
+      if (!lookup.property) {
+        const child = t.objectExpression([]);
+        object.properties.push(t.objectProperty(keyNode(name), child));
+        object = child;
+      } else {
+        object = unwrapExpression(lookup.property.value) as t.ObjectExpression;
+      }
+    }
+    object.properties.push(property);
+  }
+
+  private failure(code: CsfMutationDiagnosticCode, path: readonly string[], node: t.Node) {
+    const diagnostic: CsfMutationDiagnostic = {
+      code,
+      target: this.target,
+      path: [...path],
+      message: `Cannot mutate ${path.join('.')} because the target contains ${code.replaceAll('-', ' ')}`,
+      ...(node.loc ? { loc: node.loc } : {}),
+    };
+    this.reportDiagnostic(diagnostic);
+    return { ok: false as const, changed: false as const, diagnostic };
+  }
+
+  private success(): CsfMutationResult {
+    this.#changed = true;
+    this.markChanged();
+    return { ok: true, changed: true };
+  }
+}
+
+export const createCsfObject = (
+  target: CsfObjectTarget,
+  root: NodePath<t.ObjectExpression>,
+  prefix: readonly string[],
+  report: ReportDiagnostic,
+  markChanged: MarkChanged
+): CsfObject => new CsfObjectEditor(target, root, prefix, report, markChanged);

--- a/code/core/src/csf-tools/CsfObject.ts
+++ b/code/core/src/csf-tools/CsfObject.ts
@@ -19,7 +19,8 @@ export type CsfMutationDiagnosticCode =
   | 'spread-field'
   | 'dynamic-key'
   | 'unsupported-member'
-  | 'occupied-destination';
+  | 'occupied-destination'
+  | 'cyclic-move';
 
 export interface CsfMutationDiagnostic {
   code: CsfMutationDiagnosticCode;
@@ -60,6 +61,9 @@ const staticKey = (member: t.ObjectMethod | t.ObjectProperty): string | undefine
   if (t.isStringLiteral(member.key)) {
     return member.key.value;
   }
+  if (t.isNumericLiteral(member.key)) {
+    return String(member.key.value);
+  }
   if (t.isIdentifier(member.key) && !member.computed) {
     return member.key.name;
   }
@@ -71,6 +75,8 @@ const staticKey = (member: t.ObjectMethod | t.ObjectProperty): string | undefine
 
 const keyNode = (name: string) =>
   t.isValidIdentifier(name) ? t.identifier(name) : t.stringLiteral(name);
+
+const unsafePath = (path: readonly string[]) => path.includes('__proto__');
 
 const lookupProperty = (object: t.ObjectExpression, name: string): PropertyLookup => {
   const matches: t.ObjectProperty[] = [];
@@ -124,13 +130,13 @@ class CsfObjectEditor implements CsfObject {
       return undefined;
     }
     return found.property && t.isExpression(found.property.value)
-      ? found.property.value
+      ? t.cloneNode(found.property.value, true)
       : undefined;
   }
 
   set(path: readonly string[], value: t.Expression): CsfMutationResult {
     const logicalPath = this.normalizePath(path);
-    if (!logicalPath || logicalPath.length === 0) {
+    if (!logicalPath || logicalPath.length === 0 || unsafePath(logicalPath)) {
       return this.failure('unsupported-member', path, this.root.node);
     }
     const inspected = this.inspect(logicalPath);
@@ -141,16 +147,19 @@ class CsfObjectEditor implements CsfObject {
       if (inspected.property.value === value) {
         return { ok: true, changed: false };
       }
-      inspected.property.value = value;
+      inspected.property.value = t.cloneNode(value, true);
     } else {
-      this.insert(logicalPath, t.objectProperty(keyNode(logicalPath.at(-1)!), value));
+      this.insert(
+        logicalPath,
+        t.objectProperty(keyNode(logicalPath.at(-1)!), t.cloneNode(value, true))
+      );
     }
     return this.success();
   }
 
   remove(path: readonly string[]): CsfMutationResult {
     const logicalPath = this.normalizePath(path);
-    if (!logicalPath || logicalPath.length === 0) {
+    if (!logicalPath || logicalPath.length === 0 || unsafePath(logicalPath)) {
       return this.failure('unsupported-member', path, this.root.node);
     }
     const inspected = this.inspect(logicalPath);
@@ -176,9 +185,23 @@ class CsfObjectEditor implements CsfObject {
       !sourcePath ||
       !destinationPath ||
       sourcePath.length === 0 ||
-      destinationPath.length === 0
+      destinationPath.length === 0 ||
+      unsafePath(sourcePath) ||
+      unsafePath(destinationPath)
     ) {
       return this.failure('unsupported-member', !sourcePath ? from : to, this.root.node);
+    }
+    if (
+      sourcePath.length === destinationPath.length &&
+      sourcePath.every((part, index) => destinationPath[index] === part)
+    ) {
+      return { ok: true, changed: false };
+    }
+    if (
+      destinationPath.length > sourcePath.length &&
+      sourcePath.every((part, index) => destinationPath[index] === part)
+    ) {
+      return this.failure('cyclic-move', to, this.root.node);
     }
 
     const source = this.inspect(sourcePath);

--- a/code/core/src/csf-tools/CsfObject.ts
+++ b/code/core/src/csf-tools/CsfObject.ts
@@ -219,6 +219,17 @@ class CsfObjectEditor implements CsfObject {
       return this.failure('occupied-destination', to, destination.property);
     }
 
+    const sourceParent = sourcePath.slice(0, -1);
+    const destinationParent = destinationPath.slice(0, -1);
+    if (
+      sourceParent.length === destinationParent.length &&
+      sourceParent.every((part, index) => destinationParent[index] === part)
+    ) {
+      source.property.key = keyNode(destinationPath.at(-1)!);
+      source.property.computed = false;
+      return this.success();
+    }
+
     source.parent.properties.splice(source.parent.properties.indexOf(source.property), 1);
     source.property.key = keyNode(destinationPath.at(-1)!);
     source.property.computed = false;

--- a/code/core/src/csf-tools/CsfObjectDiscovery.test.ts
+++ b/code/core/src/csf-tools/CsfObjectDiscovery.test.ts
@@ -129,6 +129,21 @@ describe('CsfObject discovery', () => {
     ],
     ['a non-object binding', `const config = []`],
     ['an unresolved binding', ''],
+    [
+      'a direct mutating call',
+      `
+        const config = { title: 'Example' };
+        Object.assign(config, getOverrides());
+      `,
+    ],
+    [
+      'a mutable alias',
+      `
+        const config = { title: 'Example' };
+        const alias = config;
+        alias.title = 'Changed';
+      `,
+    ],
   ])('rejects identifier-backed factory meta configuration with %s', (_kind, config) => {
     const csf = parse(`
       import preview from './preview';

--- a/code/core/src/csf-tools/CsfObjectDiscovery.test.ts
+++ b/code/core/src/csf-tools/CsfObjectDiscovery.test.ts
@@ -112,6 +112,17 @@ describe('CsfObject discovery', () => {
     expect(meta.get(['title'])).toMatchObject({ type: 'StringLiteral', value: 'Example' });
   });
 
+  it('marks unresolved factory meta configuration as synthetic', () => {
+    const csf = parse(`
+      import preview from './preview';
+      import config from './config';
+      const meta = preview.meta(config);
+      export const Basic = meta.story({});
+    `);
+
+    expect(csf._metaNodeIsSynthetic).toBe(true);
+  });
+
   it.each([
     [
       'a reassigned binding',

--- a/code/core/src/csf-tools/CsfObjectDiscovery.test.ts
+++ b/code/core/src/csf-tools/CsfObjectDiscovery.test.ts
@@ -100,11 +100,39 @@ describe('CsfObject discovery', () => {
     expect(csf.mutationDiagnostics).toEqual([]);
   });
 
-  it('rejects identifier-backed factory meta configurations with member writes', () => {
+  it('discovers an identifier-backed factory meta configuration', () => {
     const csf = parse(`
       import preview from './preview';
-      const config = { title: 'Example', parameters: { componentSubtitle: 'old' } };
-      config.parameters = { componentSubtitle: 'new' };
+      const config = { title: 'Example' };
+      const meta = preview.meta(config);
+      export const Basic = meta.story({});
+    `);
+    const [meta] = csf.objects({ meta: true, stories: false });
+
+    expect(meta.get(['title'])).toMatchObject({ type: 'StringLiteral', value: 'Example' });
+  });
+
+  it.each([
+    [
+      'a reassigned binding',
+      `
+        let config = { title: 'Example' };
+        config = { title: 'Changed' };
+      `,
+    ],
+    [
+      'a member-mutated binding',
+      `
+        const config = { title: 'Example', parameters: { componentSubtitle: 'old' } };
+        config.parameters = { componentSubtitle: 'new' };
+      `,
+    ],
+    ['a non-object binding', `const config = []`],
+    ['an unresolved binding', ''],
+  ])('rejects identifier-backed factory meta configuration with %s', (_kind, config) => {
+    const csf = parse(`
+      import preview from './preview';
+      ${config}
       const meta = preview.meta(config);
       export const Basic = meta.story({});
     `);

--- a/code/core/src/csf-tools/CsfObjectDiscovery.test.ts
+++ b/code/core/src/csf-tools/CsfObjectDiscovery.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import { loadCsf, printCsf } from './CsfFile.ts';
+
+const parse = (source: string) =>
+  loadCsf(source, { makeTitle: (title) => title ?? 'title' }).parse();
+
+describe('CsfObject discovery', () => {
+  it('supports static bracket notation for CSF2 annotations', () => {
+    const csf = parse(`
+      export default { title: 'Example' };
+      export const Basic = () => null;
+      Basic['parameters'] = { a11y: true };
+    `);
+    const [parameters] = csf.objects({
+      meta: false,
+      stories: false,
+      annotations: ['parameters'],
+    });
+
+    expect(parameters.remove(['parameters', 'a11y'])).toEqual({ ok: true, changed: true });
+    expect(printCsf(csf).code).not.toContain('a11y');
+  });
+
+  it('reports computed CSF2 annotations with a nonliteral name', () => {
+    const csf = parse(`
+      const key = getKey();
+      export default { title: 'Example' };
+      export const Basic = () => null;
+      Basic[key] = { a11y: true };
+    `);
+
+    expect(csf.objects({ meta: false, stories: false, annotations: ['parameters'] })).toEqual([]);
+    expect(csf.mutationDiagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'unsupported-initializer',
+        target: {
+          kind: 'story-annotation',
+          exportName: 'Basic',
+          localName: 'Basic',
+          annotation: 'parameters',
+        },
+      })
+    );
+  });
+
+  it('does not discover excluded CSF4 factory exports', () => {
+    const csf = parse(`
+      import preview from './preview';
+      const meta = preview.meta({ title: 'Example', includeStories: ['Basic'] });
+      export const Helper = meta.story({ parameters: { viewport: { defaultViewport: 'mobile' } } });
+      export const Basic = meta.story({});
+    `);
+
+    expect(csf.objects({ meta: false, stories: true })).toHaveLength(1);
+    expect(csf.mutationDiagnostics).toEqual([]);
+  });
+
+  it('does not diagnose excluded direct exports or re-exports', () => {
+    const direct = parse(`
+      export default { title: 'Example', includeStories: ['Basic'] };
+      export let Helper = { args: {} };
+      Helper = { args: { changed: true } };
+      export const Basic = { args: {} };
+    `);
+    const reExport = parse(`
+      export default { title: 'Example', includeStories: ['Basic'] };
+      export { Helper } from './helper';
+      export const Basic = { args: {} };
+    `);
+
+    direct.objects({ meta: false, stories: true });
+    reExport.objects({ meta: false, stories: true });
+
+    expect(direct.mutationDiagnostics).toEqual([]);
+    expect(reExport.mutationDiagnostics).toEqual([]);
+  });
+
+  it('reports compound CSF2 annotation assignments', () => {
+    const csf = parse(`
+      export default { title: 'Example' };
+      export const Basic = () => null;
+      Basic.parameters ||= { a11y: true };
+    `);
+
+    expect(csf.objects({ meta: false, stories: false, annotations: ['parameters'] })).toEqual([]);
+    expect(csf.mutationDiagnostics).toContainEqual(
+      expect.objectContaining({ code: 'unsupported-initializer' })
+    );
+  });
+
+  it('does not discover or diagnose stories when only meta is requested', () => {
+    const csf = parse(`
+      export default { title: 'Example' };
+      export let Basic = { args: {} };
+      Basic = { args: { changed: true } };
+    `);
+
+    expect(csf.objects({ meta: true, stories: false })).toHaveLength(1);
+    expect(csf.mutationDiagnostics).toEqual([]);
+  });
+
+  it('rejects identifier-backed factory meta configurations with member writes', () => {
+    const csf = parse(`
+      import preview from './preview';
+      const config = { title: 'Example', parameters: { componentSubtitle: 'old' } };
+      config.parameters = { componentSubtitle: 'new' };
+      const meta = preview.meta(config);
+      export const Basic = meta.story({});
+    `);
+
+    expect(csf.objects({ meta: true, stories: false })).toEqual([]);
+    expect(csf.mutationDiagnostics).toContainEqual(
+      expect.objectContaining({ code: 'unsupported-initializer', target: { kind: 'meta' } })
+    );
+  });
+
+  it('rejects direct factory receivers that were reassigned', () => {
+    const csf = parse(`
+      import preview from './preview';
+      let meta = preview.meta({ title: 'Example' });
+      meta = helper;
+      export const Basic = meta.story({ parameters: { a11y: true } });
+    `);
+
+    expect(csf.objects({ meta: false, stories: true })).toEqual([]);
+    expect(csf.mutationDiagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'unsupported-initializer',
+        target: { kind: 'story', exportName: 'Basic', localName: 'Basic' },
+      })
+    );
+  });
+});

--- a/code/core/src/csf-tools/CsfObjectDiscovery.ts
+++ b/code/core/src/csf-tools/CsfObjectDiscovery.ts
@@ -1,0 +1,278 @@
+import { type NodePath, types as t } from 'storybook/internal/babel';
+
+import type { CsfFile } from './CsfFile.ts';
+import {
+  type CsfMutationDiagnostic,
+  type CsfObject,
+  type CsfObjectOptions,
+  type CsfObjectTarget,
+  createCsfObject,
+} from './CsfObject.ts';
+import {
+  isCsfFactoryCall,
+  metaObjectPath,
+  pathForNode,
+  unwrapExpression,
+} from './story-shape/index.ts';
+
+type ReportDiagnostic = (diagnostic: CsfMutationDiagnostic) => void;
+type MarkChanged = () => void;
+
+type StoryBinding = {
+  exportName: string;
+  localName: string;
+  declaration: NodePath<t.VariableDeclarator | t.FunctionDeclaration>;
+};
+
+type AnnotationCandidate = {
+  target: Extract<CsfObjectTarget, { kind: 'story-annotation' }>;
+  annotation: 'parameters' | 'story';
+  root?: NodePath<t.ObjectExpression>;
+  node: t.Node;
+};
+
+const storyTarget = ({ exportName, localName }: StoryBinding): CsfObjectTarget => ({
+  kind: 'story',
+  exportName,
+  localName,
+});
+
+const addDirectBindings = (
+  statement: NodePath<t.ExportNamedDeclaration>,
+  bindings: Map<string, StoryBinding>
+) => {
+  const declaration = statement.get('declaration');
+  if (declaration.isVariableDeclaration()) {
+    for (const declarator of declaration.get('declarations')) {
+      const id = declarator.get('id');
+      if (id.isIdentifier()) {
+        bindings.set(id.node.name, {
+          exportName: id.node.name,
+          localName: id.node.name,
+          declaration: declarator,
+        });
+      }
+    }
+  } else if (declaration.isFunctionDeclaration() && declaration.node.id) {
+    bindings.set(declaration.node.id.name, {
+      exportName: declaration.node.id.name,
+      localName: declaration.node.id.name,
+      declaration,
+    });
+  }
+};
+
+const addAliasedBindings = (
+  statement: NodePath<t.ExportNamedDeclaration>,
+  bindings: Map<string, StoryBinding>,
+  report: ReportDiagnostic
+) => {
+  if (statement.node.source) {
+    return;
+  }
+  for (const specifier of statement.get('specifiers')) {
+    if (!specifier.isExportSpecifier() || !t.isIdentifier(specifier.node.local)) {
+      continue;
+    }
+    const exportName = t.isIdentifier(specifier.node.exported)
+      ? specifier.node.exported.name
+      : specifier.node.exported.value;
+    if (exportName === 'default') {
+      continue;
+    }
+    const localName = specifier.node.local.name;
+    const binding = specifier.scope.getBinding(localName);
+    if (
+      !binding?.constant ||
+      (!binding.path.isVariableDeclarator() && !binding.path.isFunctionDeclaration())
+    ) {
+      report({
+        code: 'ambiguous-binding',
+        target: { kind: 'story', exportName, localName },
+        path: [],
+        message: `Cannot mutate ${exportName} because ${localName} is not a unique constant binding`,
+        ...(specifier.node.loc ? { loc: specifier.node.loc } : {}),
+      });
+    } else if (!bindings.has(localName)) {
+      bindings.set(localName, { exportName, localName, declaration: binding.path });
+    }
+  }
+};
+
+const storyBindings = (csf: CsfFile, report: ReportDiagnostic): StoryBinding[] => {
+  const bindings = new Map<string, StoryBinding>();
+  for (const statement of csf._file.path.get('body')) {
+    if (!statement.isExportNamedDeclaration() || statement.node.exportKind === 'type') {
+      continue;
+    }
+    addDirectBindings(statement, bindings);
+    addAliasedBindings(statement, bindings, report);
+  }
+  return [...bindings.values()].filter(({ exportName }) => exportName in csf._stories);
+};
+
+const discoverMeta = (
+  csf: CsfFile,
+  report: ReportDiagnostic,
+  markChanged: MarkChanged
+): CsfObject[] => {
+  const meta = metaObjectPath(csf);
+  if (meta && !csf._metaIsFactory) {
+    return [createCsfObject({ kind: 'meta' }, meta, [], report, markChanged)];
+  }
+  if (csf._metaIsFactory && csf._metaNode) {
+    report({
+      code: 'unsupported-initializer',
+      target: { kind: 'meta' },
+      path: [],
+      message: 'Cannot mutate CSF factory meta automatically; move the field manually',
+      ...(csf._metaNode.loc ? { loc: csf._metaNode.loc } : {}),
+    });
+  }
+  return [];
+};
+
+const discoverStories = (
+  csf: CsfFile,
+  bindings: StoryBinding[],
+  report: ReportDiagnostic,
+  markChanged: MarkChanged
+): CsfObject[] =>
+  bindings.flatMap((binding) => {
+    const declaration = binding.declaration;
+    const init = declaration.isVariableDeclarator() ? declaration.get('init') : declaration;
+    const node = init.node && unwrapExpression(init.node);
+    if (node && isCsfFactoryCall(node)) {
+      report({
+        code: 'unsupported-initializer',
+        target: storyTarget(binding),
+        path: [],
+        message: `Cannot mutate CSF factory story ${binding.exportName} automatically; move the field manually`,
+        ...(node.loc ? { loc: node.loc } : {}),
+      });
+      return [];
+    }
+    const expression = init.isExpression() ? init : undefined;
+    const unwrapped = expression && unwrapExpression(expression.node);
+    const root =
+      unwrapped && t.isObjectExpression(unwrapped)
+        ? pathForNode(csf._file.path, unwrapped)
+        : undefined;
+    return root ? [createCsfObject(storyTarget(binding), root, [], report, markChanged)] : [];
+  });
+
+const annotationCandidate = (
+  csf: CsfFile,
+  statement: NodePath<t.Statement>,
+  bindings: Map<string, StoryBinding>,
+  annotations: Set<'parameters' | 'story'>
+): AnnotationCandidate | undefined => {
+  if (!statement.isExpressionStatement()) {
+    return undefined;
+  }
+  const expression = statement.get('expression');
+  if (!expression.isAssignmentExpression()) {
+    return undefined;
+  }
+  const left = expression.get('left');
+  const right = expression.get('right');
+  if (!left.isMemberExpression() || !right.isExpression()) {
+    return undefined;
+  }
+  const object = left.get('object');
+  const property = left.get('property');
+  if (!object.isIdentifier() || !property.isIdentifier() || left.node.computed) {
+    return undefined;
+  }
+  const annotation =
+    property.node.name === 'parameters'
+      ? 'parameters'
+      : property.node.name === 'story'
+        ? 'story'
+        : undefined;
+  const binding = bindings.get(object.node.name);
+  if (!annotation || !binding || !annotations.has(annotation)) {
+    return undefined;
+  }
+  const rootNode = unwrapExpression(right.node);
+  return {
+    target: {
+      kind: 'story-annotation',
+      exportName: binding.exportName,
+      localName: binding.localName,
+      annotation,
+    },
+    annotation,
+    root: t.isObjectExpression(rootNode) ? pathForNode(csf._file.path, rootNode) : undefined,
+    node: right.node,
+  };
+};
+
+const reportOrCreateAnnotation = (
+  matches: AnnotationCandidate[],
+  report: ReportDiagnostic,
+  markChanged: MarkChanged
+): CsfObject[] => {
+  const [candidate] = matches;
+  if (matches.length > 1) {
+    report({
+      code: 'ambiguous-binding',
+      target: candidate.target,
+      path: [candidate.annotation],
+      message: `Cannot mutate repeated ${candidate.target.localName}.${candidate.annotation} assignments`,
+      ...(candidate.node.loc ? { loc: candidate.node.loc } : {}),
+    });
+    return [];
+  }
+  if (!candidate.root) {
+    report({
+      code: 'unsupported-initializer',
+      target: candidate.target,
+      path: [candidate.annotation],
+      message: `Cannot mutate ${candidate.target.localName}.${candidate.annotation} because its value is not an object literal`,
+      ...(candidate.node.loc ? { loc: candidate.node.loc } : {}),
+    });
+    return [];
+  }
+  return [
+    createCsfObject(candidate.target, candidate.root, [candidate.annotation], report, markChanged),
+  ];
+};
+
+const discoverAnnotations = (
+  csf: CsfFile,
+  storyBindings: StoryBinding[],
+  annotations: Set<'parameters' | 'story'>,
+  report: ReportDiagnostic,
+  markChanged: MarkChanged
+): CsfObject[] => {
+  const bindings = new Map(storyBindings.map((binding) => [binding.localName, binding]));
+  const candidates = new Map<string, AnnotationCandidate[]>();
+  for (const statement of csf._file.path.get('body')) {
+    const candidate = annotationCandidate(csf, statement, bindings, annotations);
+    if (candidate) {
+      const identity = `${candidate.target.localName}:${candidate.annotation}`;
+      candidates.set(identity, [...(candidates.get(identity) ?? []), candidate]);
+    }
+  }
+  return [...candidates.values()].flatMap((matches) =>
+    reportOrCreateAnnotation(matches, report, markChanged)
+  );
+};
+
+export const discoverCsfObjects = (
+  csf: CsfFile,
+  options: CsfObjectOptions,
+  report: ReportDiagnostic,
+  markChanged: MarkChanged
+): readonly CsfObject[] => {
+  const bindings = storyBindings(csf, report);
+  const annotations = new Set(options.annotations ?? []);
+  return [
+    ...((options.meta ?? true) ? discoverMeta(csf, report, markChanged) : []),
+    ...((options.stories ?? true) ? discoverStories(csf, bindings, report, markChanged) : []),
+    ...(annotations.size > 0
+      ? discoverAnnotations(csf, bindings, annotations, report, markChanged)
+      : []),
+  ];
+};

--- a/code/core/src/csf-tools/CsfObjectDiscovery.ts
+++ b/code/core/src/csf-tools/CsfObjectDiscovery.ts
@@ -57,14 +57,17 @@ const addQualifiedBinding = (
   exportName: string,
   localName: string,
   bindings: Map<string, StoryBinding>,
-  report: ReportDiagnostic
+  report: ReportDiagnostic,
+  isStory: boolean
 ) => {
   const binding = candidate.scope.getBinding(localName);
   if (
     !binding?.constant ||
     (!binding.path.isVariableDeclarator() && !binding.path.isFunctionDeclaration())
   ) {
-    reportBindingFailure(exportName, localName, candidate.node, report);
+    if (isStory) {
+      reportBindingFailure(exportName, localName, candidate.node, report);
+    }
   } else {
     bindings.set(`${localName}:${exportName}`, {
       exportName,
@@ -77,26 +80,35 @@ const addQualifiedBinding = (
 const addDirectBindings = (
   statement: NodePath<t.ExportNamedDeclaration>,
   bindings: Map<string, StoryBinding>,
-  report: ReportDiagnostic
+  report: ReportDiagnostic,
+  csf: CsfFile
 ) => {
   const declaration = statement.get('declaration');
   if (declaration.isVariableDeclaration()) {
     for (const declarator of declaration.get('declarations')) {
       const id = declarator.get('id');
       if (id.isIdentifier()) {
-        addQualifiedBinding(id, id.node.name, id.node.name, bindings, report);
+        addQualifiedBinding(
+          id,
+          id.node.name,
+          id.node.name,
+          bindings,
+          report,
+          id.node.name in csf._stories
+        );
       }
     }
   } else if (declaration.isFunctionDeclaration() && declaration.node.id) {
     const name = declaration.node.id.name;
-    addQualifiedBinding(declaration, name, name, bindings, report);
+    addQualifiedBinding(declaration, name, name, bindings, report, name in csf._stories);
   }
 };
 
 const addAliasedBindings = (
   statement: NodePath<t.ExportNamedDeclaration>,
   bindings: Map<string, StoryBinding>,
-  report: ReportDiagnostic
+  report: ReportDiagnostic,
+  csf: CsfFile
 ) => {
   if (statement.node.source) {
     for (const specifier of statement.get('specifiers')) {
@@ -106,7 +118,7 @@ const addAliasedBindings = (
       const exportName = t.isIdentifier(specifier.node.exported)
         ? specifier.node.exported.name
         : specifier.node.exported.value;
-      if (exportName !== 'default') {
+      if (exportName !== 'default' && exportName in csf._stories) {
         report({
           code: 'unsupported-initializer',
           target: { kind: 'story', exportName, localName: specifier.node.local.name },
@@ -129,7 +141,14 @@ const addAliasedBindings = (
       continue;
     }
     const localName = specifier.node.local.name;
-    addQualifiedBinding(specifier, exportName, localName, bindings, report);
+    addQualifiedBinding(
+      specifier,
+      exportName,
+      localName,
+      bindings,
+      report,
+      exportName in csf._stories
+    );
   }
 };
 
@@ -156,8 +175,8 @@ const storyBindings = (csf: CsfFile, report: ReportDiagnostic): StoryBinding[] =
     if (!statement.isExportNamedDeclaration() || statement.node.exportKind === 'type') {
       continue;
     }
-    addDirectBindings(statement, bindings, report);
-    addAliasedBindings(statement, bindings, report);
+    addDirectBindings(statement, bindings, report, csf);
+    addAliasedBindings(statement, bindings, report, csf);
   }
   const candidates = [...bindings.values()].filter(
     (binding) => binding.exportName in csf._stories || factoryMember(initializer(binding))
@@ -173,6 +192,24 @@ const storyBindings = (csf: CsfFile, report: ReportDiagnostic): StoryBinding[] =
     }
   }
   return [...unique.values()];
+};
+
+const isFactoryStory = (csf: CsfFile, node: t.Node, seen = new Set<string>()): boolean => {
+  if (!isCsfFactoryCall(node)) {
+    return false;
+  }
+  const receiver = node.callee.object.name;
+  if (node.callee.property.name === 'story') {
+    return receiver === csf._metaVariableName;
+  }
+  if (seen.has(receiver)) {
+    return false;
+  }
+  seen.add(receiver);
+  const binding = csf._file.path.scope.getBinding(receiver);
+  const initializer =
+    binding?.constant && binding.path.isVariableDeclarator() ? binding.path.node.init : undefined;
+  return initializer ? isFactoryStory(csf, unwrapExpression(initializer), seen) : false;
 };
 
 const discoverMeta = (
@@ -224,7 +261,8 @@ const discoverStories = (
       const argumentNode =
         argument && t.isExpression(argument) ? unwrapExpression(argument) : undefined;
       if (
-        isCsfFactoryCall(node) &&
+        t.isCallExpression(node) &&
+        isFactoryStory(csf, node) &&
         node.arguments.length === 1 &&
         argumentNode &&
         t.isObjectExpression(argumentNode)
@@ -273,12 +311,13 @@ const annotationCandidate = (
   if (!object.isIdentifier()) {
     return undefined;
   }
-  const propertyName = property.isIdentifier()
-    ? property.node.name
-    : property.isStringLiteral()
-      ? property.node.value
-      : undefined;
-  if ((!left.node.computed && !property.isIdentifier()) || !propertyName) {
+  const propertyName =
+    !left.node.computed && property.isIdentifier()
+      ? property.node.name
+      : left.node.computed && property.isStringLiteral()
+        ? property.node.value
+        : undefined;
+  if (!propertyName) {
     return undefined;
   }
   const annotation =

--- a/code/core/src/csf-tools/CsfObjectDiscovery.ts
+++ b/code/core/src/csf-tools/CsfObjectDiscovery.ts
@@ -227,18 +227,7 @@ const factoryMetaConfigurationIsSafe = (csf: CsfFile): boolean => {
   if (!initializer || !t.isObjectExpression(unwrapExpression(initializer))) {
     return false;
   }
-  return !binding.referencePaths.some((reference) => {
-    let member = reference;
-    while (member.parentPath?.isMemberExpression() && member.key === 'object') {
-      member = member.parentPath;
-    }
-    const parent = member.parentPath;
-    return (
-      (parent?.isAssignmentExpression() && parent.node.left === member.node) ||
-      parent?.isUpdateExpression() ||
-      (parent?.isUnaryExpression() && parent.node.operator === 'delete')
-    );
-  });
+  return binding.referencePaths.every((reference) => unwrapExpression(argument) === reference.node);
 };
 
 const discoverMeta = (

--- a/code/core/src/csf-tools/CsfObjectDiscovery.ts
+++ b/code/core/src/csf-tools/CsfObjectDiscovery.ts
@@ -152,11 +152,6 @@ const addAliasedBindings = (
   }
 };
 
-const initializer = ({ declaration }: StoryBinding): t.Node | undefined =>
-  declaration.isVariableDeclarator()
-    ? (declaration.get('init').node ?? undefined)
-    : declaration.node;
-
 const factoryMember = (node: t.Node | undefined): 'story' | 'extend' | undefined => {
   const unwrapped = node && unwrapExpression(node);
   if (!unwrapped || !t.isCallExpression(unwrapped) || !t.isMemberExpression(unwrapped.callee)) {
@@ -178,9 +173,7 @@ const storyBindings = (csf: CsfFile, report: ReportDiagnostic): StoryBinding[] =
     addDirectBindings(statement, bindings, report, csf);
     addAliasedBindings(statement, bindings, report, csf);
   }
-  const candidates = [...bindings.values()].filter(
-    (binding) => binding.exportName in csf._stories || factoryMember(initializer(binding))
-  );
+  const candidates = [...bindings.values()].filter((binding) => binding.exportName in csf._stories);
   const unique = new Map<t.Node, StoryBinding>();
   for (const candidate of candidates) {
     const previous = unique.get(candidate.declaration.node);
@@ -200,7 +193,16 @@ const isFactoryStory = (csf: CsfFile, node: t.Node, seen = new Set<string>()): b
   }
   const receiver = node.callee.object.name;
   if (node.callee.property.name === 'story') {
-    return receiver === csf._metaVariableName;
+    if (receiver !== csf._metaVariableName || !csf._metaFactoryCall) {
+      return false;
+    }
+    const binding = csf._file.path.scope.getBinding(receiver);
+    return (
+      binding?.constant === true &&
+      binding.path.isVariableDeclarator() &&
+      t.isExpression(binding.path.node.init) &&
+      unwrapExpression(binding.path.node.init) === csf._metaFactoryCall
+    );
   }
   if (seen.has(receiver)) {
     return false;
@@ -217,6 +219,20 @@ const discoverMeta = (
   report: ReportDiagnostic,
   markChanged: MarkChanged
 ): CsfObject[] => {
+  if (
+    csf._metaIsFactory &&
+    csf._metaFactoryCall &&
+    t.isIdentifier(csf._metaFactoryCall.arguments[0])
+  ) {
+    report({
+      code: 'unsupported-initializer',
+      target: { kind: 'meta' },
+      path: [],
+      message: 'Cannot mutate CSF factory meta with an identifier-backed configuration',
+      ...(csf._metaFactoryCall.loc ? { loc: csf._metaFactoryCall.loc } : {}),
+    });
+    return [];
+  }
   const meta = metaObjectPath(csf);
   if (meta) {
     const binding = csf._metaVariableName
@@ -317,12 +333,26 @@ const annotationCandidate = (
       : left.node.computed && property.isStringLiteral()
         ? property.node.value
         : undefined;
+  const binding = bindings.get(object.node.name);
+  if (!propertyName && left.node.computed && binding && annotations.size > 0) {
+    const annotation = annotations.has('parameters') ? 'parameters' : 'story';
+    return {
+      target: {
+        kind: 'story-annotation',
+        exportName: binding.exportName,
+        localName: binding.localName,
+        annotation,
+      },
+      annotation,
+      node: property.node,
+      message: `Cannot mutate ${binding.localName} annotation because its computed name is not a static string literal`,
+    };
+  }
   if (!propertyName) {
     return undefined;
   }
   const annotation =
     propertyName === 'parameters' ? 'parameters' : propertyName === 'story' ? 'story' : undefined;
-  const binding = bindings.get(object.node.name);
   if (!annotation || !binding || !annotations.has(annotation)) {
     return undefined;
   }

--- a/code/core/src/csf-tools/CsfObjectDiscovery.ts
+++ b/code/core/src/csf-tools/CsfObjectDiscovery.ts
@@ -29,6 +29,7 @@ type AnnotationCandidate = {
   annotation: 'parameters' | 'story';
   root?: NodePath<t.ObjectExpression>;
   node: t.Node;
+  message?: string;
 };
 
 const storyTarget = ({ exportName, localName }: StoryBinding): CsfObjectTarget => ({
@@ -37,28 +38,58 @@ const storyTarget = ({ exportName, localName }: StoryBinding): CsfObjectTarget =
   localName,
 });
 
+const reportBindingFailure = (
+  exportName: string,
+  localName: string,
+  node: t.Node,
+  report: ReportDiagnostic
+) =>
+  report({
+    code: 'ambiguous-binding',
+    target: { kind: 'story', exportName, localName },
+    path: [],
+    message: `Cannot mutate ${exportName} because ${localName} is not a unique constant binding`,
+    ...(node.loc ? { loc: node.loc } : {}),
+  });
+
+const addQualifiedBinding = (
+  candidate: NodePath<t.Node>,
+  exportName: string,
+  localName: string,
+  bindings: Map<string, StoryBinding>,
+  report: ReportDiagnostic
+) => {
+  const binding = candidate.scope.getBinding(localName);
+  if (
+    !binding?.constant ||
+    (!binding.path.isVariableDeclarator() && !binding.path.isFunctionDeclaration())
+  ) {
+    reportBindingFailure(exportName, localName, candidate.node, report);
+  } else {
+    bindings.set(`${localName}:${exportName}`, {
+      exportName,
+      localName,
+      declaration: binding.path,
+    });
+  }
+};
+
 const addDirectBindings = (
   statement: NodePath<t.ExportNamedDeclaration>,
-  bindings: Map<string, StoryBinding>
+  bindings: Map<string, StoryBinding>,
+  report: ReportDiagnostic
 ) => {
   const declaration = statement.get('declaration');
   if (declaration.isVariableDeclaration()) {
     for (const declarator of declaration.get('declarations')) {
       const id = declarator.get('id');
       if (id.isIdentifier()) {
-        bindings.set(id.node.name, {
-          exportName: id.node.name,
-          localName: id.node.name,
-          declaration: declarator,
-        });
+        addQualifiedBinding(id, id.node.name, id.node.name, bindings, report);
       }
     }
   } else if (declaration.isFunctionDeclaration() && declaration.node.id) {
-    bindings.set(declaration.node.id.name, {
-      exportName: declaration.node.id.name,
-      localName: declaration.node.id.name,
-      declaration,
-    });
+    const name = declaration.node.id.name;
+    addQualifiedBinding(declaration, name, name, bindings, report);
   }
 };
 
@@ -68,6 +99,23 @@ const addAliasedBindings = (
   report: ReportDiagnostic
 ) => {
   if (statement.node.source) {
+    for (const specifier of statement.get('specifiers')) {
+      if (!specifier.isExportSpecifier() || !t.isIdentifier(specifier.node.local)) {
+        continue;
+      }
+      const exportName = t.isIdentifier(specifier.node.exported)
+        ? specifier.node.exported.name
+        : specifier.node.exported.value;
+      if (exportName !== 'default') {
+        report({
+          code: 'unsupported-initializer',
+          target: { kind: 'story', exportName, localName: specifier.node.local.name },
+          path: [],
+          message: `Cannot mutate re-exported story ${exportName} automatically`,
+          ...(specifier.node.loc ? { loc: specifier.node.loc } : {}),
+        });
+      }
+    }
     return;
   }
   for (const specifier of statement.get('specifiers')) {
@@ -81,22 +129,25 @@ const addAliasedBindings = (
       continue;
     }
     const localName = specifier.node.local.name;
-    const binding = specifier.scope.getBinding(localName);
-    if (
-      !binding?.constant ||
-      (!binding.path.isVariableDeclarator() && !binding.path.isFunctionDeclaration())
-    ) {
-      report({
-        code: 'ambiguous-binding',
-        target: { kind: 'story', exportName, localName },
-        path: [],
-        message: `Cannot mutate ${exportName} because ${localName} is not a unique constant binding`,
-        ...(specifier.node.loc ? { loc: specifier.node.loc } : {}),
-      });
-    } else if (!bindings.has(localName)) {
-      bindings.set(localName, { exportName, localName, declaration: binding.path });
-    }
+    addQualifiedBinding(specifier, exportName, localName, bindings, report);
   }
+};
+
+const initializer = ({ declaration }: StoryBinding): t.Node | undefined =>
+  declaration.isVariableDeclarator()
+    ? (declaration.get('init').node ?? undefined)
+    : declaration.node;
+
+const factoryMember = (node: t.Node | undefined): 'story' | 'extend' | undefined => {
+  const unwrapped = node && unwrapExpression(node);
+  if (!unwrapped || !t.isCallExpression(unwrapped) || !t.isMemberExpression(unwrapped.callee)) {
+    return undefined;
+  }
+  const property = unwrapped.callee.property;
+  if (unwrapped.callee.computed || !t.isIdentifier(property)) {
+    return undefined;
+  }
+  return property.name === 'story' || property.name === 'extend' ? property.name : undefined;
 };
 
 const storyBindings = (csf: CsfFile, report: ReportDiagnostic): StoryBinding[] => {
@@ -105,10 +156,23 @@ const storyBindings = (csf: CsfFile, report: ReportDiagnostic): StoryBinding[] =
     if (!statement.isExportNamedDeclaration() || statement.node.exportKind === 'type') {
       continue;
     }
-    addDirectBindings(statement, bindings);
+    addDirectBindings(statement, bindings, report);
     addAliasedBindings(statement, bindings, report);
   }
-  return [...bindings.values()].filter(({ exportName }) => exportName in csf._stories);
+  const candidates = [...bindings.values()].filter(
+    (binding) => binding.exportName in csf._stories || factoryMember(initializer(binding))
+  );
+  const unique = new Map<t.Node, StoryBinding>();
+  for (const candidate of candidates) {
+    const previous = unique.get(candidate.declaration.node);
+    if (
+      !previous ||
+      (!(previous.exportName in csf._stories) && candidate.exportName in csf._stories)
+    ) {
+      unique.set(candidate.declaration.node, candidate);
+    }
+  }
+  return [...unique.values()];
 };
 
 const discoverMeta = (
@@ -117,16 +181,29 @@ const discoverMeta = (
   markChanged: MarkChanged
 ): CsfObject[] => {
   const meta = metaObjectPath(csf);
-  if (meta && !csf._metaIsFactory) {
+  if (meta) {
+    const binding = csf._metaVariableName
+      ? meta.scope.getBinding(csf._metaVariableName)
+      : undefined;
+    if (binding && !binding.constant) {
+      report({
+        code: 'ambiguous-binding',
+        target: { kind: 'meta' },
+        path: [],
+        message: `Cannot mutate meta because ${csf._metaVariableName} is not a unique constant binding`,
+        ...(binding.path.node.loc ? { loc: binding.path.node.loc } : {}),
+      });
+      return [];
+    }
     return [createCsfObject({ kind: 'meta' }, meta, [], report, markChanged)];
   }
-  if (csf._metaIsFactory && csf._metaNode) {
+  if (csf._metaIsFactory && csf._metaFactoryCall) {
     report({
       code: 'unsupported-initializer',
       target: { kind: 'meta' },
       path: [],
       message: 'Cannot mutate CSF factory meta automatically; move the field manually',
-      ...(csf._metaNode.loc ? { loc: csf._metaNode.loc } : {}),
+      ...(csf._metaFactoryCall.loc ? { loc: csf._metaFactoryCall.loc } : {}),
     });
   }
   return [];
@@ -141,13 +218,25 @@ const discoverStories = (
   bindings.flatMap((binding) => {
     const declaration = binding.declaration;
     const init = declaration.isVariableDeclarator() ? declaration.get('init') : declaration;
-    const node = init.node && unwrapExpression(init.node);
-    if (node && isCsfFactoryCall(node)) {
+    const node = init.node ? unwrapExpression(init.node) : undefined;
+    if (node && factoryMember(node)) {
+      const argument = t.isCallExpression(node) ? node.arguments[0] : undefined;
+      const argumentNode =
+        argument && t.isExpression(argument) ? unwrapExpression(argument) : undefined;
+      if (
+        isCsfFactoryCall(node) &&
+        node.arguments.length === 1 &&
+        argumentNode &&
+        t.isObjectExpression(argumentNode)
+      ) {
+        const root = pathForNode(csf._file.path, argumentNode);
+        return root ? [createCsfObject(storyTarget(binding), root, [], report, markChanged)] : [];
+      }
       report({
         code: 'unsupported-initializer',
         target: storyTarget(binding),
         path: [],
-        message: `Cannot mutate CSF factory story ${binding.exportName} automatically; move the field manually`,
+        message: `Cannot mutate CSF factory story ${binding.exportName} because its configuration is not an inline object literal`,
         ...(node.loc ? { loc: node.loc } : {}),
       });
       return [];
@@ -181,15 +270,19 @@ const annotationCandidate = (
   }
   const object = left.get('object');
   const property = left.get('property');
-  if (!object.isIdentifier() || !property.isIdentifier() || left.node.computed) {
+  if (!object.isIdentifier()) {
+    return undefined;
+  }
+  const propertyName = property.isIdentifier()
+    ? property.node.name
+    : property.isStringLiteral()
+      ? property.node.value
+      : undefined;
+  if ((!left.node.computed && !property.isIdentifier()) || !propertyName) {
     return undefined;
   }
   const annotation =
-    property.node.name === 'parameters'
-      ? 'parameters'
-      : property.node.name === 'story'
-        ? 'story'
-        : undefined;
+    propertyName === 'parameters' ? 'parameters' : propertyName === 'story' ? 'story' : undefined;
   const binding = bindings.get(object.node.name);
   if (!annotation || !binding || !annotations.has(annotation)) {
     return undefined;
@@ -203,8 +296,16 @@ const annotationCandidate = (
       annotation,
     },
     annotation,
-    root: t.isObjectExpression(rootNode) ? pathForNode(csf._file.path, rootNode) : undefined,
+    root:
+      expression.node.operator === '=' && t.isObjectExpression(rootNode)
+        ? pathForNode(csf._file.path, rootNode)
+        : undefined,
     node: right.node,
+    ...(expression.node.operator === '='
+      ? {}
+      : {
+          message: `Cannot mutate ${binding.localName}.${annotation} because it uses ${expression.node.operator} assignment`,
+        }),
   };
 };
 
@@ -229,7 +330,9 @@ const reportOrCreateAnnotation = (
       code: 'unsupported-initializer',
       target: candidate.target,
       path: [candidate.annotation],
-      message: `Cannot mutate ${candidate.target.localName}.${candidate.annotation} because its value is not an object literal`,
+      message:
+        candidate.message ??
+        `Cannot mutate ${candidate.target.localName}.${candidate.annotation} because its value is not an object literal`,
       ...(candidate.node.loc ? { loc: candidate.node.loc } : {}),
     });
     return [];
@@ -266,11 +369,12 @@ export const discoverCsfObjects = (
   report: ReportDiagnostic,
   markChanged: MarkChanged
 ): readonly CsfObject[] => {
-  const bindings = storyBindings(csf, report);
   const annotations = new Set(options.annotations ?? []);
+  const includeStories = options.stories ?? true;
+  const bindings = includeStories || annotations.size > 0 ? storyBindings(csf, report) : [];
   return [
     ...((options.meta ?? true) ? discoverMeta(csf, report, markChanged) : []),
-    ...((options.stories ?? true) ? discoverStories(csf, bindings, report, markChanged) : []),
+    ...(includeStories ? discoverStories(csf, bindings, report, markChanged) : []),
     ...(annotations.size > 0
       ? discoverAnnotations(csf, bindings, annotations, report, markChanged)
       : []),

--- a/code/core/src/csf-tools/CsfObjectDiscovery.ts
+++ b/code/core/src/csf-tools/CsfObjectDiscovery.ts
@@ -214,16 +214,39 @@ const isFactoryStory = (csf: CsfFile, node: t.Node, seen = new Set<string>()): b
   return initializer ? isFactoryStory(csf, unwrapExpression(initializer), seen) : false;
 };
 
+const factoryMetaConfigurationIsSafe = (csf: CsfFile): boolean => {
+  const argument = csf._metaFactoryCall?.arguments[0];
+  if (!argument || !t.isIdentifier(argument)) {
+    return true;
+  }
+  const binding = csf._file.path.scope.getBinding(argument.name);
+  if (!binding?.constant || !binding.path.isVariableDeclarator()) {
+    return false;
+  }
+  const initializer = binding.path.node.init;
+  if (!initializer || !t.isObjectExpression(unwrapExpression(initializer))) {
+    return false;
+  }
+  return !binding.referencePaths.some((reference) => {
+    let member = reference;
+    while (member.parentPath?.isMemberExpression() && member.key === 'object') {
+      member = member.parentPath;
+    }
+    const parent = member.parentPath;
+    return (
+      (parent?.isAssignmentExpression() && parent.node.left === member.node) ||
+      parent?.isUpdateExpression() ||
+      (parent?.isUnaryExpression() && parent.node.operator === 'delete')
+    );
+  });
+};
+
 const discoverMeta = (
   csf: CsfFile,
   report: ReportDiagnostic,
   markChanged: MarkChanged
 ): CsfObject[] => {
-  if (
-    csf._metaIsFactory &&
-    csf._metaFactoryCall &&
-    t.isIdentifier(csf._metaFactoryCall.arguments[0])
-  ) {
+  if (csf._metaIsFactory && csf._metaFactoryCall && !factoryMetaConfigurationIsSafe(csf)) {
     report({
       code: 'unsupported-initializer',
       target: { kind: 'meta' },

--- a/code/core/src/csf-tools/CsfObjectValue.test.ts
+++ b/code/core/src/csf-tools/CsfObjectValue.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { types as t } from 'storybook/internal/babel';
+
+import { loadCsf, printCsf } from './CsfFile.ts';
+
+const parse = (source: string) =>
+  loadCsf(source, { makeTitle: (title) => title ?? 'title' }).parse();
+
+describe('CsfObject values', () => {
+  it('sets primitive values', () => {
+    const csf = parse(`export default {};`);
+    const [meta] = csf.objects({ meta: true, stories: false });
+
+    expect(meta.set(['title'], 'Example')).toEqual({ ok: true, changed: true });
+    expect(meta.set(['parameters', 'count'], 2)).toEqual({ ok: true, changed: true });
+    expect(meta.set(['parameters', 'enabled'], true)).toEqual({ ok: true, changed: true });
+
+    expect(printCsf(csf).code).toMatchInlineSnapshot(`
+      "export default {
+        title: "Example",
+
+        parameters: {
+          count: 2,
+          enabled: true
+        }
+      };"
+    `);
+  });
+
+  it('transforms a value while retaining the source nodes returned by the callback', () => {
+    const csf = parse(
+      `export default { parameters: { backgrounds: { values: [{ name: 'Gray', value: '#CCC' }] } } };`
+    );
+    const [meta] = csf.objects({ meta: true, stories: false });
+
+    expect(
+      meta.transform(['parameters', 'backgrounds', 'values'], (value) => {
+        if (!t.isArrayExpression(value)) {
+          return undefined;
+        }
+        const [gray] = value.elements;
+        return t.isObjectExpression(gray)
+          ? t.objectExpression([t.objectProperty(t.identifier('gray'), gray)])
+          : undefined;
+      })
+    ).toEqual({ ok: true, changed: true });
+
+    expect(printCsf(csf).code).toContain(`gray: { name: 'Gray', value: '#CCC' }`);
+  });
+
+  it('keeps a transformed field when the callback returns undefined', () => {
+    const source = `export default { title: 'Example' };`;
+    const csf = parse(source);
+    const [meta] = csf.objects({ meta: true, stories: false });
+
+    expect(meta.transform(['title'], () => undefined)).toEqual({ ok: true, changed: false });
+    expect(printCsf(csf).code).toBe(source);
+  });
+});

--- a/code/core/src/csf-tools/CsfObjectValue.test.ts
+++ b/code/core/src/csf-tools/CsfObjectValue.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import { types as t } from 'storybook/internal/babel';
 
+import { dedent } from 'ts-dedent';
+
 import { loadCsf, printCsf } from './CsfFile.ts';
 
 const parse = (source: string) =>
@@ -16,22 +18,31 @@ describe('CsfObject values', () => {
     expect(meta.set(['parameters', 'count'], 2)).toEqual({ ok: true, changed: true });
     expect(meta.set(['parameters', 'enabled'], true)).toEqual({ ok: true, changed: true });
 
-    expect(printCsf(csf).code).toMatchInlineSnapshot(`
-      "export default {
+    expect(printCsf(csf).code).toBe(dedent`
+      export default {
         title: "Example",
 
         parameters: {
           count: 2,
           enabled: true
         }
-      };"
+      };
     `);
   });
 
-  it('transforms a value while retaining the source nodes returned by the callback', () => {
-    const csf = parse(
-      `export default { parameters: { backgrounds: { values: [{ name: 'Gray', value: '#CCC' }] } } };`
-    );
+  it('preserves comments on source nodes returned by a transform callback', () => {
+    const csf = parse(dedent`
+      export default {
+        parameters: {
+          backgrounds: {
+            values: [
+              // Keep the original color description.
+              { name: 'Gray', value: '#CCC' },
+            ],
+          },
+        },
+      };
+    `);
     const [meta] = csf.objects({ meta: true, stories: false });
 
     expect(
@@ -46,7 +57,18 @@ describe('CsfObject values', () => {
       })
     ).toEqual({ ok: true, changed: true });
 
-    expect(printCsf(csf).code).toContain(`gray: { name: 'Gray', value: '#CCC' }`);
+    expect(printCsf(csf).code).toBe(dedent`
+      export default {
+        parameters: {
+          backgrounds: {
+            values: {
+              gray: // Keep the original color description.
+              { name: 'Gray', value: '#CCC' }
+            },
+          },
+        },
+      };
+    `);
   });
 
   it('keeps a transformed field when the callback returns undefined', () => {

--- a/code/core/src/csf-tools/enrichCsf.ts
+++ b/code/core/src/csf-tools/enrichCsf.ts
@@ -131,7 +131,7 @@ export const enrichCsfMeta = (csf: CsfFile, csfSource: CsfFile, options?: Enrich
   // docs: { description: { component: %%description%% } },
   if (description) {
     const metaNode = csf._metaNode;
-    if (metaNode && t.isObjectExpression(metaNode)) {
+    if (metaNode && !csf._metaNodeIsSynthetic) {
       addComponentDescription(
         metaNode,
         ['parameters', 'docs', 'description'],

--- a/code/core/src/csf-tools/index.ts
+++ b/code/core/src/csf-tools/index.ts
@@ -1,4 +1,12 @@
 export * from './CsfFile.ts';
+export type {
+  CsfMutationDiagnostic,
+  CsfMutationDiagnosticCode,
+  CsfMutationResult,
+  CsfObject,
+  CsfObjectOptions,
+  CsfObjectTarget,
+} from './CsfObject.ts';
 export * from './ConfigFile.ts';
 export * from './getStorySortParameter.ts';
 export * from './jsdoc.ts';

--- a/code/core/src/csf-tools/index.ts
+++ b/code/core/src/csf-tools/index.ts
@@ -6,6 +6,7 @@ export type {
   CsfObject,
   CsfObjectOptions,
   CsfObjectTarget,
+  CsfValue,
 } from './CsfObject.ts';
 export * from './ConfigFile.ts';
 export * from './getStorySortParameter.ts';

--- a/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
@@ -49,6 +49,19 @@ const transform = async ({
 };
 
 describe('transformer', () => {
+  it('rejects an unresolved factory meta configuration', async () => {
+    const code = `
+      import preview from './preview';
+      import config from './config';
+      const meta = preview.meta(config);
+      export const Story = meta.story({});
+    `;
+
+    await expect(transform({ code })).rejects.toThrow(
+      'could not detect the meta (default export) object'
+    );
+  });
+
   describe('CSF v1/v2/v3', () => {
     describe('default exports (meta)', () => {
       it('should add title to inline default export if not present', async () => {

--- a/code/core/src/csf-tools/vitest-plugin/transformer.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.ts
@@ -148,7 +148,13 @@ export async function vitestTransform({
 
   const metaExportName = parsed._metaVariableName!;
 
-  const metaNode = parsed._metaNode as t.ObjectExpression;
+  const metaNode = parsed._metaNode;
+
+  if (!metaNode || parsed._metaNodeIsSynthetic || !parsed._meta) {
+    throw new Error(
+      'The Storybook vitest plugin could not detect the meta (default export) object in the story file. \n\nPlease make sure you have a default export with the meta object. If you are using a different export format that is not supported, please file an issue with details about your use case.'
+    );
+  }
 
   const metaTitleProperty = metaNode.properties.find(
     (prop) => t.isObjectProperty(prop) && t.isIdentifier(prop.key) && prop.key.name === 'title'
@@ -160,12 +166,6 @@ export async function vitestTransform({
   } else if (t.isObjectProperty(metaTitleProperty)) {
     // If the title is present in meta, overwrite it because autotitle can still affect existing titles
     metaTitleProperty.value = metaTitle;
-  }
-
-  if (!metaNode || !parsed._meta) {
-    throw new Error(
-      'The Storybook vitest plugin could not detect the meta (default export) object in the story file. \n\nPlease make sure you have a default export with the meta object. If you are using a different export format that is not supported, please file an issue with details about your use case.'
-    );
   }
 
   // Filter out stories based on the passed tags filter

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.csf-object.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.csf-object.test.ts
@@ -62,7 +62,7 @@ describe('addon-globals-api story objects', () => {
       export const Primary = meta.story({
         globals: {
           viewport: {
-            value: "mobile",
+            value: 'mobile',
             isRotated: false
           }
         },
@@ -80,6 +80,31 @@ describe('addon-globals-api story objects', () => {
     `;
 
     expect(transform(source)).toBeNull();
+  });
+
+  it('migrates an explicit in-place field after a spread', () => {
+    const source = dedent`
+      export default { title: 'Button' };
+      export const Primary = {
+        ...base,
+        parameters: { backgrounds: { disable: true } },
+      };
+    `;
+
+    expect(transform(source)).toContain(`backgrounds: { disabled: true }`);
+  });
+
+  it('keeps unrelated empty objects when their migration is disabled', () => {
+    const source = `export default { parameters: { viewport: {} } };`;
+
+    const result = transformStoryFile(source, {
+      needsViewportMigration: false,
+      needsBackgroundsMigration: true,
+      viewportsOptions: undefined,
+      backgroundsOptions: undefined,
+    });
+
+    expect(result).toBeNull();
   });
 
   it('keeps default orientation when it cannot write isRotated', () => {

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.csf-object.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.csf-object.test.ts
@@ -82,7 +82,7 @@ describe('addon-globals-api story objects', () => {
     expect(transform(source)).toBeNull();
   });
 
-  it('migrates an explicit in-place field after a spread', () => {
+  it('migrates an explicit property after a spread', () => {
     const source = dedent`
       export default { title: 'Button' };
       export const Primary = {
@@ -91,7 +91,13 @@ describe('addon-globals-api story objects', () => {
       };
     `;
 
-    expect(transform(source)).toContain(`backgrounds: { disabled: true }`);
+    expect(transform(source)).toBe(dedent`
+      export default { title: 'Button' };
+      export const Primary = {
+        ...base,
+        parameters: { backgrounds: { disabled: true } },
+      };
+    `);
   });
 
   it('keeps unrelated empty objects when their migration is disabled', () => {

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.csf-object.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.csf-object.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import { printCsf } from 'storybook/internal/csf-tools';
+
+import { dedent } from 'ts-dedent';
+
+import { transformStoryFile } from './addon-globals-api.ts';
+
+const transform = (source: string) => {
+  const result = transformStoryFile(source, {
+    needsViewportMigration: true,
+    needsBackgroundsMigration: true,
+    viewportsOptions: undefined,
+    backgroundsOptions: undefined,
+  });
+  return result ? printCsf(result).code : null;
+};
+
+describe('addon-globals-api story objects', () => {
+  it('migrates CSF2 story annotations in place', () => {
+    const source = dedent`
+      export default { title: 'Button' };
+      export const Primary = () => null;
+      Primary.parameters = {
+        backgrounds: { disable: true },
+      };
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "export default { title: 'Button' };
+      export const Primary = () => null;
+      Primary.parameters = {
+        backgrounds: { disabled: true },
+      };"
+    `);
+  });
+
+  it('preserves CSF2 defaults that require a separate globals annotation', () => {
+    const source = dedent`
+      export default { title: 'Button' };
+      export const Primary = () => null;
+      Primary.parameters = {
+        backgrounds: { default: 'Dark' },
+      };
+    `;
+
+    expect(transform(source)).toBeNull();
+  });
+
+  it('migrates CSF4 story objects', () => {
+    const source = dedent`
+      import preview from './preview';
+      const meta = preview.meta({ title: 'Button' });
+      export const Primary = meta.story({
+        parameters: { viewport: { defaultViewport: 'mobile' } },
+      });
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import preview from './preview';
+      const meta = preview.meta({ title: 'Button' });
+      export const Primary = meta.story({
+        globals: {
+          viewport: {
+            value: "mobile",
+            isRotated: false
+          }
+        },
+      });"
+    `);
+  });
+
+  it('leaves unsafe story objects unchanged', () => {
+    const source = dedent`
+      export default { title: 'Button' };
+      export const Primary = {
+        ...base,
+        parameters: { backgrounds: { default: 'Dark' } },
+      };
+    `;
+
+    expect(transform(source)).toBeNull();
+  });
+});

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.csf-object.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.csf-object.test.ts
@@ -81,4 +81,64 @@ describe('addon-globals-api story objects', () => {
 
     expect(transform(source)).toBeNull();
   });
+
+  it('keeps default orientation when it cannot write isRotated', () => {
+    const source = dedent`
+      export default { title: 'Button' };
+      export const Primary = {
+        globals: { viewport: { value: 'mobile' } },
+        parameters: { viewport: { defaultOrientation: 'portrait' } },
+      };
+    `;
+
+    expect(transform(source)).toBeNull();
+  });
+
+  it('keeps dynamic default orientation', () => {
+    const source = dedent`
+      export default { title: 'Button' };
+      export const Primary = {
+        parameters: { viewport: { defaultViewport: 'mobile', defaultOrientation: orientation } },
+      };
+    `;
+
+    expect(transform(source)).toContain('defaultOrientation: orientation');
+  });
+
+  it('preserves an existing rotation when adding a viewport value', () => {
+    const source = dedent`
+      export default { title: 'Button' };
+      export const Primary = {
+        globals: { viewport: { isRotated: true } },
+        parameters: { viewport: { defaultViewport: 'mobile', defaultOrientation: 'landscape' } },
+      };
+    `;
+
+    expect(transform(source)).toContain(`isRotated: true`);
+    expect(transform(source)).toContain(`defaultOrientation: 'landscape'`);
+  });
+
+  it('removes deprecated disable when disabled already exists', () => {
+    const source = dedent`
+      export default { title: 'Button' };
+      export const Primary = {
+        parameters: { backgrounds: { disable: true, disabled: false } },
+      };
+    `;
+
+    expect(transform(source)).toContain('disabled: false');
+    expect(transform(source)).not.toMatch(/\bdisable:/);
+  });
+
+  it('removes deprecated viewport disable when disabled already exists', () => {
+    const source = dedent`
+      export default { title: 'Button' };
+      export const Primary = {
+        parameters: { viewport: { disable: true, disabled: false } },
+      };
+    `;
+
+    expect(transform(source)).toContain('disabled: false');
+    expect(transform(source)).not.toMatch(/\bdisable:/);
+  });
 });

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.test.ts
@@ -5,13 +5,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { printCsf } from 'storybook/internal/csf-tools';
 
-// Import common to mock
 import { dedent } from 'ts-dedent';
 
-// Import FixResult type
 import { addonGlobalsApi, transformStoryFile } from './addon-globals-api.ts';
 
-// Mock fs/promises
 vi.mock('node:fs/promises', async () => import('../../../../../__mocks__/fs/promises.ts'));
 
 vi.mock(import('storybook/internal/babel'), async (actualImport) => {
@@ -28,13 +25,13 @@ vi.mock(import('storybook/internal/babel'), async (actualImport) => {
 const previewConfigPath = join('.storybook', 'preview.js');
 
 const check = async (previewContents: string) => {
-  vi.mocked<typeof import('../../../../../__mocks__/fs/promises')>(fsp as any).__setMockFiles({
+  vi.mocked<typeof import('../../../../../__mocks__/fs/promises')>(fsp as never).__setMockFiles({
     [previewConfigPath]: previewContents,
   });
   return addonGlobalsApi.check({
-    packageManager: {} as any,
+    packageManager: {} as never,
     configDir: '',
-    mainConfig: {} as any,
+    mainConfig: {} as never,
     storybookVersion: '9.0.0', // Assume v9 for testing migrations
     previewConfigPath,
     storiesPaths: [],
@@ -42,25 +39,21 @@ const check = async (previewContents: string) => {
   });
 };
 
-// Helper to run the migration for preview file and capture transform function
 const runMigrationAndGetTransformFn = async (previewContents: string) => {
   const result = await check(previewContents);
   const mockWriteFile = vi.mocked(fsp.writeFile);
 
   let transformFn: (filePath: string, content: string) => string | null = () => null;
 
-  let transformOptions: any;
-
   if (result) {
     await addonGlobalsApi.run?.({
       result,
       dryRun: false,
       storiesPaths: ['**/*.stories.{js,jsx,ts,tsx,mdx}'], // Mock stories paths
-      packageManager: {} as any, // Add necessary mock properties
-    } as any);
+      packageManager: {} as never, // Add necessary mock properties
+    } as never);
 
     if (result) {
-      // Create a transform function that uses transformStoryFile + printCsf
       transformFn = (filePath: string, content: string) => {
         const transformed = transformStoryFile(content, {
           needsViewportMigration: result.needsViewportMigration,
@@ -70,20 +63,12 @@ const runMigrationAndGetTransformFn = async (previewContents: string) => {
         });
         return transformed ? printCsf(transformed, {}).code : null;
       };
-      // Extract options passed to transformStoryFile from the closure
-      // This is a bit indirect, relying on the implementation detail
-      transformOptions = {
-        needsViewportMigration: result.needsViewportMigration,
-        needsBackgroundsMigration: result.needsBackgroundsMigration,
-        backgroundValues: result.backgroundsOptions?.values,
-      };
     }
   }
 
   return {
     previewFileContent: mockWriteFile.mock.calls[0]?.[1] as string | undefined,
     transformFn,
-    transformOptions,
     migrationResult: result,
   };
 };
@@ -922,7 +907,10 @@ describe('addon-globals-api', () => {
           parameters: {
             backgrounds: {
               options: {
-                gray: { name: 'Gray', value: '#CCC' }
+                gray: {
+                  name: 'Gray',
+                  value: '#CCC'
+                }
               }
             },
           },

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.test.ts
@@ -923,10 +923,7 @@ describe('addon-globals-api', () => {
           parameters: {
             backgrounds: {
               options: {
-                gray: {
-                  name: 'Gray',
-                  value: '#CCC'
-                }
+                gray: { name: 'Gray', value: '#CCC' }
               }
             },
           },

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.test.ts
@@ -49,8 +49,8 @@ const runMigrationAndGetTransformFn = async (previewContents: string) => {
     await addonGlobalsApi.run?.({
       result,
       dryRun: false,
-      storiesPaths: ['**/*.stories.{js,jsx,ts,tsx,mdx}'], // Mock stories paths
-      packageManager: {} as never, // Add necessary mock properties
+      storiesPaths: ['**/*.stories.{js,jsx,ts,tsx,mdx}'],
+      packageManager: {} as never,
     } as never);
 
     if (result) {
@@ -314,6 +314,22 @@ describe('addon-globals-api', () => {
           }
         }"
       `);
+    });
+
+    it('should remove deprecated backgrounds disable when disabled already exists', async () => {
+      const { previewFileContent } = await runMigrationAndGetTransformFn(dedent`
+        export default {
+          parameters: {
+            backgrounds: {
+              disable: false,
+              disabled: true
+            }
+          }
+        }
+      `);
+
+      expect(previewFileContent).toContain('disabled: true');
+      expect(previewFileContent).not.toMatch(/\bdisable:/);
     });
 
     it('should migrate both viewport and backgrounds configurations', async () => {

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.ts
@@ -202,16 +202,13 @@ export const addonGlobalsApi: Fix<AddonGlobalsApiOptions> = {
         );
       }
 
-      // If disable exists, rename to disabled
-      if (backgroundsOptions?.disable === true) {
-        // Remove the old disable property
-        removeProperty(getFieldNode(['parameters', 'backgrounds']) as ObjectExpression, 'disable');
-
-        addProperty(
-          getFieldNode(['parameters', 'backgrounds']) as ObjectExpression,
-          'disabled',
-          t.booleanLiteral(true)
-        );
+      if (typeof backgroundsOptions?.disable === 'boolean') {
+        const backgrounds = getFieldNode(['parameters', 'backgrounds']) as ObjectExpression;
+        const disabled = getFieldNode(['parameters', 'backgrounds', 'disabled']);
+        removeProperty(backgrounds, 'disable');
+        if (!disabled) {
+          addProperty(backgrounds, 'disabled', t.booleanLiteral(backgroundsOptions.disable));
+        }
       }
     }
 
@@ -304,6 +301,9 @@ const migrateStoryGlobals = (
   const viewportGlobal = options.needsViewportMigration
     ? object.get(['globals', 'viewport', 'value'])
     : undefined;
+  const viewportRotated = options.needsViewportMigration
+    ? object.get(['globals', 'viewport', 'isRotated'])
+    : undefined;
   const backgroundValues = options.needsBackgroundsMigration
     ? object.get(['parameters', 'backgrounds', 'values'])
     : undefined;
@@ -334,20 +334,28 @@ const migrateStoryGlobals = (
   ) {
     if (!viewportGlobal) {
       object.set(['globals', 'viewport', 'value'], viewportDefault);
-      object.set(
-        ['globals', 'viewport', 'isRotated'],
-        t.booleanLiteral(
-          t.isStringLiteral(viewportOrientation) && viewportOrientation.value === 'portrait'
-        )
-      );
+      const orientationCanBeMigrated =
+        !viewportOrientation ||
+        (t.isStringLiteral(viewportOrientation) &&
+          (viewportOrientation.value === 'portrait' || viewportOrientation.value === 'landscape'));
+      if (!viewportRotated && orientationCanBeMigrated) {
+        object.set(
+          ['globals', 'viewport', 'isRotated'],
+          t.booleanLiteral(
+            t.isStringLiteral(viewportOrientation) && viewportOrientation.value === 'portrait'
+          )
+        );
+        object.remove(['parameters', 'viewport', 'defaultOrientation']);
+      }
     }
     object.remove(['parameters', 'viewport', 'defaultViewport']);
   }
-  if (canSetGlobals && viewportOrientation) {
-    object.remove(['parameters', 'viewport', 'defaultOrientation']);
-  }
-  if (t.isBooleanLiteral(viewportDisable) && !viewportDisabled) {
-    object.rename(['parameters', 'viewport', 'disable'], 'disabled');
+  if (t.isBooleanLiteral(viewportDisable)) {
+    if (viewportDisabled) {
+      object.remove(['parameters', 'viewport', 'disable']);
+    } else {
+      object.rename(['parameters', 'viewport', 'disable'], 'disabled');
+    }
   }
 
   if (t.isArrayExpression(backgroundValues) && !backgroundOptions) {
@@ -366,8 +374,12 @@ const migrateStoryGlobals = (
     }
     object.remove(['parameters', 'backgrounds', 'default']);
   }
-  if (t.isBooleanLiteral(backgroundDisable) && !backgroundDisabled) {
-    object.rename(['parameters', 'backgrounds', 'disable'], 'disabled');
+  if (t.isBooleanLiteral(backgroundDisable)) {
+    if (backgroundDisabled) {
+      object.remove(['parameters', 'backgrounds', 'disable']);
+    } else {
+      object.rename(['parameters', 'backgrounds', 'disable'], 'disabled');
+    }
   }
 
   removeEmptyObject(object, ['parameters', 'viewport']);

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
 
 import { types as t } from 'storybook/internal/babel';
-import type { ConfigFile, CsfFile } from 'storybook/internal/csf-tools';
+import type { ConfigFile, CsfFile, CsfObject } from 'storybook/internal/csf-tools';
 import { formatConfig, loadConfig, loadCsf, writeCsf } from 'storybook/internal/csf-tools';
 
 import type { ArrayExpression, Expression, ObjectExpression } from '@babel/types';
@@ -9,9 +9,7 @@ import type { ArrayExpression, Expression, ObjectExpression } from '@babel/types
 import {
   addProperty,
   getKeyFromName,
-  getObjectProperty,
   removeProperty,
-  transformStoryParameters,
   transformValuesToOptions,
 } from '../helpers/ast-utils.ts';
 import type { Fix } from '../types.ts';
@@ -35,6 +33,11 @@ interface AddonGlobalsApiOptions {
       }
     | undefined;
 }
+
+type StoryGlobalsMigrationOptions = Pick<
+  AddonGlobalsApiOptions,
+  'needsViewportMigration' | 'needsBackgroundsMigration' | 'viewportsOptions' | 'backgroundsOptions'
+>;
 
 /**
  * Migrate viewport and backgrounds addons to use the new globals API in Storybook 9
@@ -82,7 +85,14 @@ export const addonGlobalsApi: Fix<AddonGlobalsApiOptions> = {
       const needsMigration = hasOldFormat && !hasOptions;
 
       // Collect relevant options from old format
-      const options: Record<string, any> = {};
+      const options: {
+        [key: string]: Expression | string | boolean | undefined;
+        viewports?: Expression;
+        defaultViewport?: string;
+        values?: Expression;
+        default?: string;
+        disable?: boolean;
+      } = {};
 
       if (needsMigration) {
         fieldsToCheck.forEach((field) => {
@@ -229,12 +239,7 @@ export const addonGlobalsApi: Fix<AddonGlobalsApiOptions> = {
 // Story transformation function
 async function transformStoryFiles(
   files: string[],
-  options: {
-    needsViewportMigration: boolean;
-    needsBackgroundsMigration: boolean;
-    viewportsOptions: any;
-    backgroundsOptions: any;
-  },
+  options: StoryGlobalsMigrationOptions,
   dryRun: boolean
 ): Promise<Array<{ file: string; error: Error }>> {
   const errors: Array<{ file: string; error: Error }> = [];
@@ -264,204 +269,115 @@ async function transformStoryFiles(
 // Transform a single story file
 export function transformStoryFile(
   source: string,
-  options: {
-    needsViewportMigration: boolean;
-    needsBackgroundsMigration: boolean;
-    viewportsOptions: any;
-    backgroundsOptions: any;
-  }
+  options: StoryGlobalsMigrationOptions
 ): CsfFile | null {
-  const { needsViewportMigration, needsBackgroundsMigration, backgroundsOptions } = options;
-
-  // Load the story file using CSF tools
   const storyConfig = loadCsf(source, {
     makeTitle: (title?: string) => title || 'default',
   }).parse();
 
-  // Use the story transformer utility to handle all story iteration
-  const hasChanges = transformStoryParameters(storyConfig, (parameters, storyObject) => {
-    let newGlobals: ObjectExpression | undefined;
-    let viewportParams: ObjectExpression | undefined;
-    let backgroundsParams: ObjectExpression | undefined;
-    let storyHasChanges = false;
+  const objects = storyConfig.objects({ annotations: ['parameters'] });
+  for (const object of objects) {
+    migrateStoryGlobals(storyConfig, object, options);
+  }
 
-    // Handle viewport migration
-    if (needsViewportMigration) {
-      viewportParams = getObjectProperty(parameters, 'viewport') as ObjectExpression;
-      if (viewportParams) {
-        const defaultViewport = getObjectProperty(viewportParams, 'defaultViewport');
-        const defaultOrientation = getObjectProperty(viewportParams, 'defaultOrientation');
-        const disableViewport = getObjectProperty(viewportParams, 'disable');
-
-        // Handle both string literals and member expressions for defaultViewport
-        let viewportValue: t.StringLiteral | t.MemberExpression | null = null;
-        if (defaultViewport) {
-          if (t.isStringLiteral(defaultViewport)) {
-            viewportValue = defaultViewport;
-          } else if (t.isMemberExpression(defaultViewport)) {
-            // Preserve the member expression as-is
-            viewportValue = defaultViewport;
-          }
-        }
-
-        if (viewportValue) {
-          // Create globals.viewport
-          if (!newGlobals) {
-            newGlobals = t.objectExpression([]);
-          }
-
-          // Determine isRotated based on defaultOrientation
-          let isRotated = false;
-          if (defaultOrientation && t.isStringLiteral(defaultOrientation)) {
-            isRotated = defaultOrientation.value === 'portrait';
-          }
-
-          newGlobals.properties.push(
-            t.objectProperty(
-              t.identifier('viewport'),
-              t.objectExpression([
-                t.objectProperty(t.identifier('value'), viewportValue),
-                t.objectProperty(t.identifier('isRotated'), t.booleanLiteral(isRotated)),
-              ])
-            )
-          );
-
-          // Remove defaultViewport from parameters
-          removeProperty(viewportParams, 'defaultViewport');
-          storyHasChanges = true;
-        }
-
-        // Handle defaultOrientation removal
-        if (defaultOrientation) {
-          removeProperty(viewportParams, 'defaultOrientation');
-          storyHasChanges = true;
-        }
-
-        // Handle disable -> disabled rename
-        if (disableViewport && t.isBooleanLiteral(disableViewport)) {
-          removeProperty(viewportParams, 'disable');
-          // Rename disable to disabled (preserve both true and false values)
-          addProperty(viewportParams, 'disabled', disableViewport);
-          storyHasChanges = true;
-        }
-      }
-    }
-
-    // Handle backgrounds migration
-    if (needsBackgroundsMigration) {
-      backgroundsParams = getObjectProperty(parameters, 'backgrounds') as ObjectExpression;
-      if (backgroundsParams) {
-        const defaultBackground = getObjectProperty(backgroundsParams, 'default');
-        const disableBackground = getObjectProperty(backgroundsParams, 'disable');
-        const valuesBackground = getObjectProperty(backgroundsParams, 'values');
-
-        // Handle values -> options transformation
-        if (valuesBackground && t.isArrayExpression(valuesBackground)) {
-          // Transform values array to options object
-          const optionsObject = transformValuesToOptions(valuesBackground);
-
-          // Remove the old values property
-          removeProperty(backgroundsParams, 'values');
-          addProperty(backgroundsParams, 'options', optionsObject);
-          storyHasChanges = true;
-        }
-
-        if (defaultBackground && t.isStringLiteral(defaultBackground)) {
-          // Create globals.backgrounds
-          if (!newGlobals) {
-            newGlobals = t.objectExpression([]);
-          }
-
-          const backgroundKey = getKeyFromName(
-            backgroundsOptions?.values as ArrayExpression,
-            defaultBackground.value
-          );
-
-          newGlobals.properties.push(
-            t.objectProperty(
-              t.identifier('backgrounds'),
-              t.objectExpression([
-                t.objectProperty(t.identifier('value'), t.stringLiteral(backgroundKey)),
-              ])
-            )
-          );
-
-          // Remove default from parameters
-          removeProperty(backgroundsParams, 'default');
-          storyHasChanges = true;
-        }
-
-        // Handle disable -> disabled rename
-        if (disableBackground && t.isBooleanLiteral(disableBackground)) {
-          removeProperty(backgroundsParams, 'disable');
-          // Rename disable to disabled (preserve both true and false values)
-          addProperty(backgroundsParams, 'disabled', disableBackground);
-          storyHasChanges = true;
-        }
-      }
-    }
-
-    // Add globals to story if we created any
-    if (newGlobals && newGlobals.properties.length > 0) {
-      const existingGlobals = getObjectProperty(storyObject, 'globals') as
-        | ObjectExpression
-        | undefined;
-
-      if (existingGlobals) {
-        // Merge new globals with existing globals
-        newGlobals.properties.forEach((newGlobal) => {
-          if (t.isObjectProperty(newGlobal) && t.isIdentifier(newGlobal.key)) {
-            const globalName = newGlobal.key.name;
-            const existingGlobal = getObjectProperty(existingGlobals, globalName) as
-              | ObjectExpression
-              | undefined;
-
-            if (existingGlobal) {
-              // Merge properties if both are object expressions
-              if (t.isObjectExpression(newGlobal.value) && t.isObjectExpression(existingGlobal)) {
-                newGlobal.value.properties.forEach((newProp) => {
-                  if (t.isObjectProperty(newProp) && t.isIdentifier(newProp.key)) {
-                    const propName = newProp.key.name;
-                    const existingProp = getObjectProperty(existingGlobal, propName);
-
-                    if (!existingProp) {
-                      existingGlobal.properties.push(newProp);
-                    }
-                  }
-                });
-              }
-            } else {
-              // Add new global to existing globals
-              existingGlobals.properties.push(newGlobal);
-            }
-          }
-        });
-      } else {
-        // No existing globals, add new ones
-        storyObject.properties.push(t.objectProperty(t.identifier('globals'), newGlobals));
-      }
-      storyHasChanges = true;
-    }
-
-    // Clean up empty parameter objects
-    if (viewportParams && viewportParams.properties.length === 0) {
-      removeProperty(parameters, 'viewport');
-      storyHasChanges = true;
-    }
-
-    if (backgroundsParams && backgroundsParams.properties.length === 0) {
-      removeProperty(parameters, 'backgrounds');
-      storyHasChanges = true;
-    }
-
-    // Remove parameters if it's now empty
-    if (parameters.properties.length === 0) {
-      removeProperty(storyObject, 'parameters');
-      storyHasChanges = true;
-    }
-
-    return storyHasChanges;
-  });
-
-  return hasChanges ? storyConfig : null;
+  return storyConfig.changed ? storyConfig : null;
 }
+
+const migrateStoryGlobals = (
+  csf: CsfFile,
+  object: CsfObject,
+  options: StoryGlobalsMigrationOptions
+) => {
+  const diagnosticsBefore = csf.mutationDiagnostics.length;
+  const viewportDefault = options.needsViewportMigration
+    ? object.get(['parameters', 'viewport', 'defaultViewport'])
+    : undefined;
+  const viewportOrientation = options.needsViewportMigration
+    ? object.get(['parameters', 'viewport', 'defaultOrientation'])
+    : undefined;
+  const viewportDisable = options.needsViewportMigration
+    ? object.get(['parameters', 'viewport', 'disable'])
+    : undefined;
+  const viewportDisabled = options.needsViewportMigration
+    ? object.get(['parameters', 'viewport', 'disabled'])
+    : undefined;
+  const viewportGlobal = options.needsViewportMigration
+    ? object.get(['globals', 'viewport', 'value'])
+    : undefined;
+  const backgroundValues = options.needsBackgroundsMigration
+    ? object.get(['parameters', 'backgrounds', 'values'])
+    : undefined;
+  const backgroundOptions = options.needsBackgroundsMigration
+    ? object.get(['parameters', 'backgrounds', 'options'])
+    : undefined;
+  const backgroundDefault = options.needsBackgroundsMigration
+    ? object.get(['parameters', 'backgrounds', 'default'])
+    : undefined;
+  const backgroundDisable = options.needsBackgroundsMigration
+    ? object.get(['parameters', 'backgrounds', 'disable'])
+    : undefined;
+  const backgroundDisabled = options.needsBackgroundsMigration
+    ? object.get(['parameters', 'backgrounds', 'disabled'])
+    : undefined;
+  const backgroundGlobal = options.needsBackgroundsMigration
+    ? object.get(['globals', 'backgrounds', 'value'])
+    : undefined;
+
+  if (csf.mutationDiagnostics.length > diagnosticsBefore) {
+    return;
+  }
+
+  const canSetGlobals = object.target.kind !== 'story-annotation';
+  if (
+    canSetGlobals &&
+    (t.isStringLiteral(viewportDefault) || t.isMemberExpression(viewportDefault))
+  ) {
+    if (!viewportGlobal) {
+      object.set(['globals', 'viewport', 'value'], viewportDefault);
+      object.set(
+        ['globals', 'viewport', 'isRotated'],
+        t.booleanLiteral(
+          t.isStringLiteral(viewportOrientation) && viewportOrientation.value === 'portrait'
+        )
+      );
+    }
+    object.remove(['parameters', 'viewport', 'defaultViewport']);
+  }
+  if (canSetGlobals && viewportOrientation) {
+    object.remove(['parameters', 'viewport', 'defaultOrientation']);
+  }
+  if (t.isBooleanLiteral(viewportDisable) && !viewportDisabled) {
+    object.rename(['parameters', 'viewport', 'disable'], 'disabled');
+  }
+
+  if (t.isArrayExpression(backgroundValues) && !backgroundOptions) {
+    object.set(
+      ['parameters', 'backgrounds', 'options'],
+      transformValuesToOptions(backgroundValues)
+    );
+    object.remove(['parameters', 'backgrounds', 'values']);
+  }
+  if (canSetGlobals && t.isStringLiteral(backgroundDefault)) {
+    if (!backgroundGlobal) {
+      object.set(
+        ['globals', 'backgrounds', 'value'],
+        t.stringLiteral(getKeyFromName(options.backgroundsOptions?.values, backgroundDefault.value))
+      );
+    }
+    object.remove(['parameters', 'backgrounds', 'default']);
+  }
+  if (t.isBooleanLiteral(backgroundDisable) && !backgroundDisabled) {
+    object.rename(['parameters', 'backgrounds', 'disable'], 'disabled');
+  }
+
+  removeEmptyObject(object, ['parameters', 'viewport']);
+  removeEmptyObject(object, ['parameters', 'backgrounds']);
+  removeEmptyObject(object, ['parameters']);
+};
+
+const removeEmptyObject = (object: CsfObject, path: readonly string[]) => {
+  const value = object.get(path);
+  if (t.isObjectExpression(value) && value.properties.length === 0) {
+    object.remove(path);
+  }
+};

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.ts
@@ -341,9 +341,7 @@ const migrateStoryGlobals = (
       if (!viewportRotated && orientationCanBeMigrated) {
         object.set(
           ['globals', 'viewport', 'isRotated'],
-          t.booleanLiteral(
-            t.isStringLiteral(viewportOrientation) && viewportOrientation.value === 'portrait'
-          )
+          t.isStringLiteral(viewportOrientation) && viewportOrientation.value === 'portrait'
         );
         object.remove(['parameters', 'viewport', 'defaultOrientation']);
       }
@@ -369,7 +367,7 @@ const migrateStoryGlobals = (
     if (!backgroundGlobal) {
       object.set(
         ['globals', 'backgrounds', 'value'],
-        t.stringLiteral(getKeyFromName(options.backgroundsOptions?.values, backgroundDefault.value))
+        getKeyFromName(options.backgroundsOptions?.values, backgroundDefault.value)
       );
     }
     object.remove(['parameters', 'backgrounds', 'default']);

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.ts
@@ -286,9 +286,12 @@ const migrateStoryGlobals = (
   options: StoryGlobalsMigrationOptions
 ) => {
   const diagnosticsBefore = csf.mutationDiagnostics.length;
+  const canSetGlobals = object.target.kind !== 'story-annotation';
   const viewportDefault = options.needsViewportMigration
     ? object.get(['parameters', 'viewport', 'defaultViewport'])
     : undefined;
+  const migratesViewportDefault =
+    canSetGlobals && (t.isStringLiteral(viewportDefault) || t.isMemberExpression(viewportDefault));
   const viewportOrientation = options.needsViewportMigration
     ? object.get(['parameters', 'viewport', 'defaultOrientation'])
     : undefined;
@@ -298,10 +301,10 @@ const migrateStoryGlobals = (
   const viewportDisabled = options.needsViewportMigration
     ? object.get(['parameters', 'viewport', 'disabled'])
     : undefined;
-  const viewportGlobal = options.needsViewportMigration
+  const viewportGlobal = migratesViewportDefault
     ? object.get(['globals', 'viewport', 'value'])
     : undefined;
-  const viewportRotated = options.needsViewportMigration
+  const viewportRotated = migratesViewportDefault
     ? object.get(['globals', 'viewport', 'isRotated'])
     : undefined;
   const backgroundValues = options.needsBackgroundsMigration
@@ -313,13 +316,14 @@ const migrateStoryGlobals = (
   const backgroundDefault = options.needsBackgroundsMigration
     ? object.get(['parameters', 'backgrounds', 'default'])
     : undefined;
+  const migratesBackgroundDefault = canSetGlobals && t.isStringLiteral(backgroundDefault);
   const backgroundDisable = options.needsBackgroundsMigration
     ? object.get(['parameters', 'backgrounds', 'disable'])
     : undefined;
   const backgroundDisabled = options.needsBackgroundsMigration
     ? object.get(['parameters', 'backgrounds', 'disabled'])
     : undefined;
-  const backgroundGlobal = options.needsBackgroundsMigration
+  const backgroundGlobal = migratesBackgroundDefault
     ? object.get(['globals', 'backgrounds', 'value'])
     : undefined;
 
@@ -327,13 +331,9 @@ const migrateStoryGlobals = (
     return;
   }
 
-  const canSetGlobals = object.target.kind !== 'story-annotation';
-  if (
-    canSetGlobals &&
-    (t.isStringLiteral(viewportDefault) || t.isMemberExpression(viewportDefault))
-  ) {
+  if (migratesViewportDefault) {
     if (!viewportGlobal) {
-      object.set(['globals', 'viewport', 'value'], viewportDefault);
+      object.move(['parameters', 'viewport', 'defaultViewport'], ['globals', 'viewport', 'value']);
       const orientationCanBeMigrated =
         !viewportOrientation ||
         (t.isStringLiteral(viewportOrientation) &&
@@ -345,8 +345,9 @@ const migrateStoryGlobals = (
         );
         object.remove(['parameters', 'viewport', 'defaultOrientation']);
       }
+    } else {
+      object.remove(['parameters', 'viewport', 'defaultViewport']);
     }
-    object.remove(['parameters', 'viewport', 'defaultViewport']);
   }
   if (t.isBooleanLiteral(viewportDisable)) {
     if (viewportDisabled) {
@@ -357,13 +358,12 @@ const migrateStoryGlobals = (
   }
 
   if (t.isArrayExpression(backgroundValues) && !backgroundOptions) {
-    object.set(
-      ['parameters', 'backgrounds', 'options'],
-      transformValuesToOptions(backgroundValues)
+    object.transform(['parameters', 'backgrounds', 'values'], (value) =>
+      t.isArrayExpression(value) ? transformValuesToOptions(value) : undefined
     );
-    object.remove(['parameters', 'backgrounds', 'values']);
+    object.rename(['parameters', 'backgrounds', 'values'], 'options');
   }
-  if (canSetGlobals && t.isStringLiteral(backgroundDefault)) {
+  if (migratesBackgroundDefault) {
     if (!backgroundGlobal) {
       object.set(
         ['globals', 'backgrounds', 'value'],

--- a/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/addon-globals-api.ts
@@ -379,15 +379,4 @@ const migrateStoryGlobals = (
       object.rename(['parameters', 'backgrounds', 'disable'], 'disabled');
     }
   }
-
-  removeEmptyObject(object, ['parameters', 'viewport']);
-  removeEmptyObject(object, ['parameters', 'backgrounds']);
-  removeEmptyObject(object, ['parameters']);
-};
-
-const removeEmptyObject = (object: CsfObject, path: readonly string[]) => {
-  const value = object.get(path);
-  if (t.isObjectExpression(value) && value.properties.length === 0) {
-    object.remove(path);
-  }
 };

--- a/code/lib/cli-storybook/src/automigrate/helpers/addon-a11y-parameters.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/helpers/addon-a11y-parameters.test.ts
@@ -202,7 +202,7 @@ describe('a11yParameters', () => {
       `);
     });
 
-    it('should leave unsafe story objects unchanged', () => {
+    it('should transform an explicit property after a spread', () => {
       const code = dedent`
         export default { title: 'Button' };
         export const Primary = {
@@ -211,7 +211,13 @@ describe('a11yParameters', () => {
         };
       `;
 
-      expect(transformStories(code)).toBeNull();
+      expect(transformStories(code)).toMatchInlineSnapshot(`
+        export default { title: 'Button' };
+        export const Primary = {
+          ...base,
+          parameters: { a11y: { context: '#root' } },
+        };
+      `);
     });
   });
 

--- a/code/lib/cli-storybook/src/automigrate/helpers/addon-a11y-parameters.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/helpers/addon-a11y-parameters.test.ts
@@ -10,7 +10,7 @@ import {
 } from './addon-a11y-parameters.ts';
 
 expect.addSnapshotSerializer({
-  serialize: (val: any) => (typeof val === 'string' ? val : val.toString()),
+  serialize: (val) => (typeof val === 'string' ? val : val.toString()),
   test: () => true,
 });
 
@@ -160,6 +160,58 @@ describe('a11yParameters', () => {
           }
         }
       `);
+    });
+
+    it('should transform CSF4 meta and story objects', () => {
+      const code = dedent`
+        import preview from './preview';
+
+        const meta = preview.meta({
+          parameters: { a11y: { element: '#meta' } },
+        });
+        export const Primary = meta.story({
+          parameters: { a11y: { element: '#story' } },
+        });
+      `;
+
+      expect(transformStories(code)).toMatchInlineSnapshot(`
+        import preview from './preview';
+
+        const meta = preview.meta({
+          parameters: { a11y: { context: '#meta' } },
+        });
+        export const Primary = meta.story({
+          parameters: { a11y: { context: '#story' } },
+        });
+      `);
+    });
+
+    it('should transform identifier-backed meta objects', () => {
+      const code = dedent`
+        const configuration = {
+          parameters: { a11y: { element: '#meta' } },
+        };
+        export default configuration;
+      `;
+
+      expect(transformStories(code)).toMatchInlineSnapshot(`
+        const configuration = {
+          parameters: { a11y: { context: '#meta' } },
+        };
+        export default configuration;
+      `);
+    });
+
+    it('should leave unsafe story objects unchanged', () => {
+      const code = dedent`
+        export default { title: 'Button' };
+        export const Primary = {
+          ...base,
+          parameters: { a11y: { element: '#root' } },
+        };
+      `;
+
+      expect(transformStories(code)).toBeNull();
     });
   });
 

--- a/code/lib/cli-storybook/src/automigrate/helpers/addon-a11y-parameters.ts
+++ b/code/lib/cli-storybook/src/automigrate/helpers/addon-a11y-parameters.ts
@@ -1,15 +1,8 @@
-import { types as t } from 'storybook/internal/babel';
 import { type ConfigFile, type CsfFile, loadConfig, loadCsf } from 'storybook/internal/csf-tools';
 
-import { getObjectProperty, transformStories } from './ast-utils.ts';
+import { types as t } from 'storybook/internal/babel';
 
-// TODO: this is copied from the codemod, we should move both utilities to the csf-tools package at some point
-const isStoryAnnotation = (stmt: t.Statement, objectExports: Record<string, any>) =>
-  t.isExpressionStatement(stmt) &&
-  t.isAssignmentExpression(stmt.expression) &&
-  t.isMemberExpression(stmt.expression.left) &&
-  t.isIdentifier(stmt.expression.left.object) &&
-  objectExports[stmt.expression.left.object.name];
+import { getObjectProperty } from './ast-utils.ts';
 
 function migrateA11yParameters(obj: t.ObjectExpression): boolean {
   const parametersValue = getObjectProperty(obj, 'parameters') as t.ObjectExpression | undefined;
@@ -35,38 +28,11 @@ function migrateA11yParameters(obj: t.ObjectExpression): boolean {
 export function transformStoryA11yParameters(code: string): CsfFile | null {
   const parsed = loadCsf(code, { makeTitle: (title?: string) => title || 'default' }).parse();
 
-  // Use the story transformer utility to handle all story iteration
-  let hasChanges = transformStories(parsed, (storyObject, storyName, csf) => {
-    return migrateA11yParameters(storyObject);
-  });
+  for (const object of parsed.objects({ annotations: ['parameters'] })) {
+    object.rename(['parameters', 'a11y', 'element'], 'context');
+  }
 
-  // Also handle CSF2-style story annotations
-  parsed._ast.program.body.forEach((stmt: t.Statement) => {
-    const statement = stmt;
-    if (
-      isStoryAnnotation(statement, parsed._storyExports) &&
-      t.isExpressionStatement(statement) &&
-      t.isAssignmentExpression(statement.expression) &&
-      t.isObjectExpression(statement.expression.right)
-    ) {
-      const parameters = statement.expression.right.properties;
-      parameters.forEach((param) => {
-        if (t.isObjectProperty(param) && t.isIdentifier(param.key) && param.key.name === 'a11y') {
-          const a11yValue = param.value as t.ObjectExpression;
-          const elementProp = a11yValue.properties.find(
-            (prop) =>
-              t.isObjectProperty(prop) && t.isIdentifier(prop.key) && prop.key.name === 'element'
-          );
-          if (elementProp && t.isObjectProperty(elementProp)) {
-            elementProp.key = t.identifier('context');
-            hasChanges = true;
-          }
-        }
-      });
-    }
-  });
-
-  return hasChanges ? parsed : null;
+  return parsed.changed ? parsed : null;
 }
 
 export function transformPreviewA11yParameters(code: string): ConfigFile | null {

--- a/code/lib/cli-storybook/src/automigrate/helpers/ast-utils.ts
+++ b/code/lib/cli-storybook/src/automigrate/helpers/ast-utils.ts
@@ -1,5 +1,4 @@
 import { types as t } from 'storybook/internal/babel';
-import type { CsfFile } from 'storybook/internal/csf-tools';
 
 import type { Expression, ObjectExpression } from '@babel/types';
 
@@ -49,31 +48,6 @@ export function addProperty(obj: ObjectExpression, propertyName: string, value: 
   obj.properties.push(t.objectProperty(t.identifier(propertyName), value));
 }
 
-/** Get the story object from a declaration (handles both story exports and meta exports) */
-export function getStoryObject(declaration: t.Node): t.ObjectExpression | undefined {
-  if (t.isVariableDeclarator(declaration)) {
-    // Handle story exports: `export const Story = { ... }`
-    let init = declaration.init;
-    if (t.isTSSatisfiesExpression(init) || t.isTSAsExpression(init)) {
-      init = init.expression;
-    }
-    if (t.isObjectExpression(init)) {
-      return init;
-    }
-  } else if (t.isExportDefaultDeclaration(declaration)) {
-    // Handle meta export: `export default { ... }`
-    let init = declaration.declaration;
-    if (t.isTSSatisfiesExpression(init) || t.isTSAsExpression(init)) {
-      init = init.expression;
-    }
-    if (t.isObjectExpression(init)) {
-      return init;
-    }
-  }
-
-  return undefined;
-}
-
 /** Transform values array to options object for background keys */
 export function transformValuesToOptions(valuesArray: t.ArrayExpression): t.Expression {
   // Transform [{ name: 'Light', value: '#FFF' }] to { light: { name: 'Light', value: '#FFF' } }
@@ -103,7 +77,7 @@ export function transformValuesToOptions(valuesArray: t.ArrayExpression): t.Expr
 }
 
 /** Get key from name using the options mapping */
-export function getKeyFromName(valuesArray: t.ArrayExpression, name: string): string {
+export function getKeyFromName(valuesArray: t.Expression | undefined, name: string): string {
   // Generate a key from a name in the values array
   if (valuesArray && t.isArrayExpression(valuesArray) && valuesArray.elements) {
     for (const element of valuesArray.elements) {
@@ -119,87 +93,4 @@ export function getKeyFromName(valuesArray: t.ArrayExpression, name: string): st
 
   // If not found, generate a key from the name
   return name.toLowerCase().replace(/\s+/g, '_');
-}
-
-/** Options for story transformation */
-export interface StoryTransformOptions {
-  /** Whether to transform the meta export (export default) */
-  includeMeta?: boolean;
-  /** Whether to transform story exports */
-  includeStories?: boolean;
-}
-
-/** Callback function for transforming a story object */
-export type StoryTransformCallback = (
-  storyObject: t.ObjectExpression,
-  storyName: string,
-  csf: CsfFile
-) => boolean;
-
-/** Callback function for transforming story parameters */
-export type StoryParametersTransformCallback = (
-  parameters: t.ObjectExpression,
-  storyObject: t.ObjectExpression,
-  storyName: string,
-  csf: CsfFile
-) => boolean;
-
-/** Callback function for transforming story globals */
-export type StoryGlobalsTransformCallback = (
-  globals: t.ObjectExpression,
-  storyObject: t.ObjectExpression,
-  storyName: string,
-  csf: CsfFile
-) => boolean;
-
-/** Transform all stories in a CSF file using a callback function */
-export function transformStories(
-  csf: CsfFile,
-  transformCallback: StoryTransformCallback,
-  options: StoryTransformOptions = { includeMeta: true, includeStories: true }
-): boolean {
-  let hasChanges = false;
-
-  // Transform story exports
-  if (options.includeStories) {
-    Object.entries(csf._storyExports).forEach(([storyName, declaration]) => {
-      const storyObject = getStoryObject(declaration);
-      if (storyObject) {
-        if (transformCallback(storyObject, storyName, csf)) {
-          hasChanges = true;
-        }
-      }
-    });
-  }
-
-  // Transform meta export
-  if (options.includeMeta && csf._metaPath) {
-    const storyObject = getStoryObject(csf._metaPath.node);
-    if (storyObject) {
-      if (transformCallback(storyObject, 'meta', csf)) {
-        hasChanges = true;
-      }
-    }
-  }
-
-  return hasChanges;
-}
-
-/** Transform stories with parameters-specific logic */
-export function transformStoryParameters(
-  csf: CsfFile,
-  transformParameters: StoryParametersTransformCallback,
-  options: StoryTransformOptions = { includeMeta: true, includeStories: true }
-): boolean {
-  return transformStories(
-    csf,
-    (storyObject, storyName, csf) => {
-      const parameters = getObjectProperty(storyObject, 'parameters') as t.ObjectExpression;
-      if (parameters) {
-        return transformParameters(parameters, storyObject, storyName, csf);
-      }
-      return false;
-    },
-    options
-  );
 }


### PR DESCRIPTION
## What I did

The issue: story-file automigrations currently have to walk and mutate Babel objects themselves. This duplicates CSF discovery logic, transforms some files twice, and makes it easy for migrations to change structures that they cannot handle safely.

The solution:

- Added `CsfFile.objects()` to discover mutable meta, story, and CSF2 annotation objects across CSF2, CSF3, and inline CSF4.
- Added formatting-preserving `get`, `set`, `rename`, and `remove` mutations through `CsfObject`.
- Added explicit diagnostics for structures that cannot be changed safely, including spreads, reassigned or re-exported bindings, reused factory configurations, dynamic factory arguments, compound annotations, and cyclic moves.
- Migrated `addon-a11y-parameters` and `addon-globals-api`, the two existing automigrations that change story-object structure, to the shared API.
- Removed the superseded story traversal helpers from `cli-storybook`.
- Kept migration policy in `cli-storybook`. `csf-tools` only discovers and mutates CSF objects; it does not decide which deprecated APIs should move.

The commit `9ce29c8aa2f` records the failing safety cases first. The implementation and review fixes follow on top.

### Captured Storybook 10 fixture transform

Input:

```ts
import preview from '../.storybook/preview';

const meta = preview.meta({ title: 'Fixture/Globals' });

export const Primary = meta.story({
  parameters: {
    viewport: { defaultViewport: 'mobile' },
    backgrounds: { default: 'Dark', disable: false },
  },
});
```

Output captured from the seeded fixture run:

```ts
import preview from '../.storybook/preview';

const meta = preview.meta({ title: 'Fixture/Globals' });

export const Primary = meta.story({
  parameters: {
    backgrounds: {
      disabled: false
    }
  },

  globals: {
    viewport: {
      value: "mobile",
      isRotated: false
    },

    backgrounds: {
      value: "dark"
    }
  }
});
```

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [x] integration tests
- [ ] end-to-end tests

Commands run:

```sh
yarn vitest run --config code/lib/cli-storybook/vitest.config.ts code/lib/cli-storybook/src/automigrate
yarn vitest run --config code/core/vitest.config.ts code/core/src/csf-tools/CsfObject.test.ts
yarn nx check cli
cd code && yarn lint:js:cmd core/src/csf-tools/CsfObject.ts core/src/csf-tools/CsfObject.test.ts lib/cli-storybook/src/automigrate/fixes/addon-globals-api.ts lib/cli-storybook/src/automigrate/fixes/addon-globals-api.test.ts lib/cli-storybook/src/automigrate/fixes/addon-globals-api.csf-object.test.ts lib/cli-storybook/src/automigrate/helpers/addon-a11y-parameters.ts lib/cli-storybook/src/automigrate/helpers/addon-a11y-parameters.test.ts lib/cli-storybook/src/automigrate/helpers/ast-utils.ts
```

### Manual testing

No browser test is necessary. This PR changes an internal AST mutation API, and the observable result is the generated source. A maintainer can verify it by running the two focused test commands above and comparing the inline snapshots with the captured Storybook 10 fixture output.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.MD)

This PR introduces internal mutation tooling and adopts it in existing migrations. It does not add or remove a user-facing API. Hence, no documentation or `MIGRATION.MD` update is needed here.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
  <details>
    <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

  </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
