### PR TITLE
Open Service: Rename clientId to runtimeId in sync envelopes

### DIFF
--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -650,7 +650,7 @@ Creates a local `ServiceRuntime` from the service definition (identical across r
 
 ### Loop prevention
 
-Every channel event carries the emitter's `clientId` (generated per `registerService` call). Listeners silently ignore events whose `clientId` matches their own, so peers never re-apply state they just emitted.
+Every channel event carries the emitter's `runtimeId` (generated per `registerService` call). Listeners silently ignore events whose `runtimeId` matches their own, so peers never re-apply state they just emitted.
 
 ### State application without re-broadcast
 
@@ -731,14 +731,14 @@ several services routes them correctly.
 
 | Event | Direction | Payload |
 | ---------------------------- | -------------------------- | ----------------------------------------------------- |
-| `services:command-invoke`    | requester → implementers   | `{ serviceId, commandName, input, callId, clientId }` |
-| `services:command-ack`       | implementer → requester    | `{ serviceId, callId, clientId }`                     |
-| `services:command-result`    | implementer → requester    | `{ serviceId, callId, result, clientId }`             |
-| `services:command-error`     | implementer → requester    | `{ serviceId, callId, error, clientId }`              |
-| `services:command-unhandled` | non-implementer → requester | `{ serviceId, callId, clientId }`                     |
+| `services:command-invoke`    | requester → implementers   | `{ serviceId, commandName, input, callId, runtimeId }` |
+| `services:command-ack`       | implementer → requester    | `{ serviceId, callId, runtimeId }`                     |
+| `services:command-result`    | implementer → requester    | `{ serviceId, callId, result, runtimeId }`             |
+| `services:command-error`     | implementer → requester    | `{ serviceId, callId, error, runtimeId }`              |
+| `services:command-unhandled` | non-implementer → requester | `{ serviceId, callId, runtimeId }`                     |
 
 - `callId` is the per-invocation correlation id (see [Correlation and parallel calls](#correlation-and-parallel-calls)).
-- `clientId` is the id of the runtime that emitted the envelope — the requester on an invoke, the
+- `runtimeId` is the id of the runtime that emitted the envelope — the requester on an invoke, the
   responder on a reply.
 - `error` is a transport-safe serialization of the thrown value, including its full `cause` chain (and
   arrays such as the `.loaded()` drain's `cause.aggregated`) plus Storybook fields like
@@ -778,7 +778,7 @@ where the handler lives.
 
 ### Correlation and parallel calls
 
-`callId` is generated fresh (`generateClientId()`) for **every** call, so it is effectively a unique
+`callId` is generated fresh (`generateRuntimeId()`) for **every** call, so it is effectively a unique
 execution id. This is what makes concurrent calls safe:
 
 - Two parallel calls — even with identical input — get two distinct `callId`s, two `pending` promise

--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -650,7 +650,12 @@ Creates a local `ServiceRuntime` from the service definition (identical across r
 
 ### Loop prevention
 
-Every channel event carries the emitter's `runtimeId` (generated per `registerService` call). Listeners silently ignore events whose `runtimeId` matches their own, so peers never re-apply state they just emitted.
+Every channel event that names a writer carries a `runtimeId` generated per `registerService` call.
+Loop prevention is not a single self-id check:
+
+- `services:sync-start` is ignored when its `runtimeId` matches the listener's own, so a runtime does not reply to itself.
+- `services:patches` and `services:sync-start-reply` drop echoes through last-write-wins stamp ordering (`isNewer`). A relay may re-emit a patch under an adopted peer `runtimeId`; that copy is still dropped when the stamp is not strictly newer.
+- Command replies correlate on `callId`, not on `runtimeId`.
 
 ### State application without re-broadcast
 
@@ -735,7 +740,7 @@ several services routes them correctly.
 | `services:command-ack`       | implementer → requester    | `{ serviceId, callId, runtimeId }`                     |
 | `services:command-result`    | implementer → requester    | `{ serviceId, callId, result, runtimeId }`             |
 | `services:command-error`     | implementer → requester    | `{ serviceId, callId, error, runtimeId }`              |
-| `services:command-unhandled` | non-implementer → requester | `{ serviceId, callId, runtimeId }`                     |
+| `services:command-unhandled` | non-implementer → requester | `{ serviceId, callId }`                     |
 
 - `callId` is the per-invocation correlation id (see [Correlation and parallel calls](#correlation-and-parallel-calls)).
 - `runtimeId` is the id of the runtime that emitted the envelope — the requester on an invoke, the
@@ -778,7 +783,7 @@ where the handler lives.
 
 ### Correlation and parallel calls
 
-`callId` is generated fresh (`generateRuntimeId()`) for **every** call, so it is effectively a unique
+`callId` is generated fresh (`generateCallId()`) for **every** call, so it is effectively a unique
 execution id. This is what makes concurrent calls safe:
 
 - Two parallel calls — even with identical input — get two distinct `callId`s, two `pending` promise

--- a/code/core/src/shared/open-service/query-runtime.ts
+++ b/code/core/src/shared/open-service/query-runtime.ts
@@ -64,7 +64,7 @@ type LoadedSession = {
 
 /**
  * Process-global registry of in-flight `load` promises keyed by
- * `${runtimeId}::${serviceId}::${queryName}::${hash}`.
+ * `${loadScopeId}::${serviceId}::${queryName}::${hash}`.
  *
  * The dedup is in-flight only: once a load settles, its entry is removed so a subsequent call can
  * refire it. The same registry is consulted by both same-service and cross-service callers so two
@@ -80,8 +80,8 @@ export const inFlightLoads = new Map<string, Promise<unknown>>();
  * Monotonic instance id for {@link makeInFlightKey}. The load key already names the service;
  * this token only has to be unique among live runtimes.
  */
-let nextRuntimeSequence = 0;
-export const nextRuntimeId = (): string => String((nextRuntimeSequence += 1));
+let nextLoadScopeSequence = 0;
+export const nextLoadScopeId = (): string => String((nextLoadScopeSequence += 1));
 
 /**
  * Active session for `.loaded()` while a sync handler is being re-run for dependency discovery.
@@ -132,8 +132,8 @@ function stableHash(value: unknown): string {
  * The unscoped {@link makeLoadKey} stays the identity used for cycle detection and settled-key
  * bookkeeping, which are per-load-graph rather than per-runtime.
  */
-export function makeInFlightKey(runtimeId: string, loadKey: string): string {
-  return `${runtimeId}::${loadKey}`;
+export function makeInFlightKey(loadScopeId: string, loadKey: string): string {
+  return `${loadScopeId}::${loadKey}`;
 }
 
 export function makeLoadKey(
@@ -243,13 +243,13 @@ function detachSnapshot<TValue>(value: TValue): TValue {
 export type QueryRuntimeRefs<TState> = {
   serviceId: ServiceId;
   /**
-   * Identity of this runtime instance, used to scope {@link inFlightLoads}.
+   * Process-local token used to scope {@link inFlightLoads}.
    *
    * A load body writes through the `self` of the runtime it started on, so a load in flight on one
    * runtime says nothing about another runtime's state. The static build stands up a throwaway
    * runtime per snapshot next to the live registry's runtime, which is where the two meet.
    */
-  runtimeId: string;
+  loadScopeId: string;
   commandSelf: CommandSelf<TState>;
   /** Deep reactive proxy backing this service's state; reads inside a computed track fine-grained. */
   state: TState;
@@ -435,7 +435,7 @@ function triggerLoad<TState>(
   loadKey: string,
   parentAncestorChain: ReadonlySet<string>
 ): Promise<unknown> {
-  const inFlightKey = makeInFlightKey(refs.runtimeId, loadKey);
+  const inFlightKey = makeInFlightKey(refs.loadScopeId, loadKey);
   const existing = inFlightLoads.get(inFlightKey);
   if (existing) {
     return existing;

--- a/code/core/src/shared/open-service/service-channel.ts
+++ b/code/core/src/shared/open-service/service-channel.ts
@@ -109,7 +109,6 @@ export type CommandAckPayload = v.InferOutput<typeof commandAckSchema>;
 export const commandUnhandledSchema = v.object({
   serviceId: v.string(),
   callId: v.string(),
-  runtimeId: v.string(),
 });
 export type CommandUnhandledPayload = v.InferOutput<typeof commandUnhandledSchema>;
 
@@ -138,12 +137,17 @@ export const commandErrorSchema = v.object({
 export type CommandErrorPayload = v.InferOutput<typeof commandErrorSchema>;
 
 /**
- * Generates a unique id for one runtime instance (and for one remote-command `callId`).
+ * Unique id for one service registration.
  *
- * The id is identity-critical: it is the last-write-wins tiebreak for equal versions, the loop guard
- * that drops a peer's own echoes, and the correlation key matching command replies to their calls.
- * `nanoid` is used (over `Math.random`) so collisions cannot silently break that determinism.
+ * It is the last-write-wins tiebreak for equal versions and the loop guard that drops a runtime's
+ * own `services:sync-start`. `nanoid` is used (over `Math.random`) so collisions cannot silently
+ * break that determinism.
  */
 export function generateRuntimeId(): string {
+  return nanoid();
+}
+
+/** Unique id for one remote-command invocation. Replies correlate on this, not on `runtimeId`. */
+export function generateCallId(): string {
   return nanoid();
 }

--- a/code/core/src/shared/open-service/service-channel.ts
+++ b/code/core/src/shared/open-service/service-channel.ts
@@ -51,7 +51,7 @@ const stateSnapshotSchema = v.custom<Record<string, unknown>>(
 /** Sent by a newly-registered peer to initialize its state from any existing peer. */
 export const syncStartSchema = v.object({
   serviceId: v.string(),
-  clientId: v.string(),
+  runtimeId: v.string(),
 });
 export type SyncStartPayload = v.InferOutput<typeof syncStartSchema>;
 
@@ -65,7 +65,7 @@ export const stampedSnapshotSchema = v.object({
   serviceId: v.string(),
   state: stateSnapshotSchema,
   version: v.pipe(v.number(), v.safeInteger(), v.minValue(0)),
-  clientId: v.string(),
+  runtimeId: v.string(),
 });
 export type StampedSnapshotPayload = v.InferOutput<typeof stampedSnapshotSchema>;
 export type PatchesPayload = StampedSnapshotPayload;
@@ -83,7 +83,7 @@ export const commandInvokeSchema = v.object({
   commandName: v.string(),
   input: v.optional(v.unknown()),
   callId: v.string(),
-  clientId: v.string(),
+  runtimeId: v.string(),
 });
 export type CommandInvokePayload = v.InferOutput<typeof commandInvokeSchema>;
 
@@ -97,7 +97,7 @@ export type CommandInvokePayload = v.InferOutput<typeof commandInvokeSchema>;
 export const commandAckSchema = v.object({
   serviceId: v.string(),
   callId: v.string(),
-  clientId: v.string(),
+  runtimeId: v.string(),
 });
 export type CommandAckPayload = v.InferOutput<typeof commandAckSchema>;
 
@@ -109,7 +109,7 @@ export type CommandAckPayload = v.InferOutput<typeof commandAckSchema>;
 export const commandUnhandledSchema = v.object({
   serviceId: v.string(),
   callId: v.string(),
-  clientId: v.string(),
+  runtimeId: v.string(),
 });
 export type CommandUnhandledPayload = v.InferOutput<typeof commandUnhandledSchema>;
 
@@ -118,7 +118,7 @@ export const commandResultSchema = v.object({
   serviceId: v.string(),
   callId: v.string(),
   result: v.optional(v.unknown()),
-  clientId: v.string(),
+  runtimeId: v.string(),
 });
 export type CommandResultPayload = v.InferOutput<typeof commandResultSchema>;
 
@@ -133,7 +133,7 @@ export const commandErrorSchema = v.object({
   error: v.custom<SerializedError>(
     (value) => typeof value === 'object' && value !== null && !Array.isArray(value)
   ),
-  clientId: v.string(),
+  runtimeId: v.string(),
 });
 export type CommandErrorPayload = v.InferOutput<typeof commandErrorSchema>;
 
@@ -144,6 +144,6 @@ export type CommandErrorPayload = v.InferOutput<typeof commandErrorSchema>;
  * that drops a peer's own echoes, and the correlation key matching command replies to their calls.
  * `nanoid` is used (over `Math.random`) so collisions cannot silently break that determinism.
  */
-export function generateClientId(): string {
+export function generateRuntimeId(): string {
   return nanoid();
 }

--- a/code/core/src/shared/open-service/service-command-transport.test.ts
+++ b/code/core/src/shared/open-service/service-command-transport.test.ts
@@ -361,7 +361,6 @@ describe('remote command responder (has local handler)', () => {
         expect.objectContaining({
           serviceId: remoteOnlyServiceDef.id,
           callId: 'call-unhandled',
-          runtimeId: expect.any(String),
         }),
       ],
     ]);
@@ -497,7 +496,6 @@ describe('command-unhandled reporting', () => {
     channel.emitExternal(SERVICE_COMMAND_UNHANDLED, {
       serviceId: remoteOnlyServiceDef.id,
       callId,
-      runtimeId: 'peer-without-handler',
     });
     channel.emitExternal(SERVICE_COMMAND_RESULT, {
       serviceId: remoteOnlyServiceDef.id,
@@ -532,6 +530,7 @@ describe('command-unhandled reporting', () => {
         }),
       ],
     ]);
+    expect(emittedCalls(channel, SERVICE_COMMAND_UNHANDLED)[0][1]).not.toHaveProperty('runtimeId');
   });
 });
 

--- a/code/core/src/shared/open-service/service-command-transport.test.ts
+++ b/code/core/src/shared/open-service/service-command-transport.test.ts
@@ -111,7 +111,7 @@ describe('remote command requester (no local handler)', () => {
       commandName: 'doThing',
       input: { value: 'hi' },
       callId: expect.any(String),
-      clientId: expect.any(String),
+      runtimeId: expect.any(String),
     });
 
     unregisterService(remoteOnlyServiceDef.id);
@@ -129,7 +129,7 @@ describe('remote command requester (no local handler)', () => {
       serviceId: remoteOnlyServiceDef.id,
       callId,
       result: 'done',
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
 
     await expect(promise).resolves.toBe('done');
@@ -146,7 +146,7 @@ describe('remote command requester (no local handler)', () => {
     channel.emitExternal(SERVICE_COMMAND_ERROR, {
       serviceId: remoteOnlyServiceDef.id,
       callId,
-      clientId: 'peer',
+      runtimeId: 'peer',
       error: {
         __openServiceError__: true,
         name: 'OpenServiceValidationError',
@@ -174,7 +174,7 @@ describe('remote command requester (no local handler)', () => {
       serviceId: remoteOnlyServiceDef.id,
       callId,
       result: 'first',
-      clientId: 'peer-1',
+      runtimeId: 'peer-1',
     });
     // A later reply for the same call (a second implementer) must be ignored, not throw.
     expect(() =>
@@ -182,7 +182,7 @@ describe('remote command requester (no local handler)', () => {
         serviceId: remoteOnlyServiceDef.id,
         callId,
         result: 'second',
-        clientId: 'peer-2',
+        runtimeId: 'peer-2',
       })
     ).not.toThrow();
 
@@ -201,19 +201,19 @@ describe('remote command requester (no local handler)', () => {
       serviceId: 'some/other-service',
       callId,
       result: 'wrong-service',
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
     channel.emitExternal(SERVICE_COMMAND_RESULT, {
       serviceId: remoteOnlyServiceDef.id,
       callId: 'unknown-call',
       result: 'wrong-call',
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
     channel.emitExternal(SERVICE_COMMAND_RESULT, {
       serviceId: remoteOnlyServiceDef.id,
       callId,
       result: 'correct',
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
 
     await expect(promise).resolves.toBe('correct');
@@ -248,7 +248,7 @@ describe('remote command requester (no local handler)', () => {
     channel.emitExternal(SERVICE_COMMAND_ACK, {
       serviceId: remoteOnlyServiceDef.id,
       callId,
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
 
     await vi.advanceTimersByTimeAsync(REMOTE_COMMAND_ACK_TIMEOUT_MS);
@@ -257,7 +257,7 @@ describe('remote command requester (no local handler)', () => {
       serviceId: remoteOnlyServiceDef.id,
       callId,
       result: 'done',
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
 
     await expect(promise).resolves.toBe('done');
@@ -288,7 +288,7 @@ describe('remote command responder (has local handler)', () => {
       commandName: 'assignRecordField',
       input: { entryId: 'a', fieldKey: 'k', fieldValue: 'v' },
       callId: 'call-1',
-      clientId: 'requester',
+      runtimeId: 'requester',
     });
 
     // The ack is emitted synchronously on receipt, before the command runs.
@@ -297,7 +297,7 @@ describe('remote command responder (has local handler)', () => {
       expect.objectContaining({
         serviceId: mutableRecordLookupServiceDef.id,
         callId: 'call-1',
-        clientId: expect.any(String),
+        runtimeId: expect.any(String),
       })
     );
 
@@ -323,7 +323,7 @@ describe('remote command responder (has local handler)', () => {
       commandName: 'boom',
       input: {},
       callId: 'call-err',
-      clientId: 'requester',
+      runtimeId: 'requester',
     });
 
     await vi.waitFor(() => expect(emittedCalls(channel, SERVICE_COMMAND_ERROR)).toHaveLength(1));
@@ -348,7 +348,7 @@ describe('remote command responder (has local handler)', () => {
       commandName: 'doThing',
       input: { value: 'hi' },
       callId: 'call-unhandled',
-      clientId: 'requester',
+      runtimeId: 'requester',
     });
 
     await new Promise<void>((resolve) => setTimeout(resolve, 10));
@@ -361,7 +361,7 @@ describe('remote command responder (has local handler)', () => {
         expect.objectContaining({
           serviceId: remoteOnlyServiceDef.id,
           callId: 'call-unhandled',
-          clientId: expect.any(String),
+          runtimeId: expect.any(String),
         }),
       ],
     ]);
@@ -401,7 +401,7 @@ describe('ack delivery with a busy responder', () => {
 
       const requester = connectCommandTransport({
         serviceId,
-        ownClientId: 'requester',
+        ownRuntimeId: 'requester',
         channel,
         localCommands: {},
         implementedCommandNames: new Set(),
@@ -410,7 +410,7 @@ describe('ack delivery with a busy responder', () => {
       });
       const responder = connectCommandTransport({
         serviceId,
-        ownClientId: 'responder',
+        ownRuntimeId: 'responder',
         channel,
         localCommands: {
           fanOut: async (input) => {
@@ -442,7 +442,7 @@ describe('command-unhandled reporting', () => {
 
     const requester = connectCommandTransport({
       serviceId,
-      ownClientId: 'requester',
+      ownRuntimeId: 'requester',
       channel,
       localCommands: {},
       implementedCommandNames: new Set(),
@@ -451,7 +451,7 @@ describe('command-unhandled reporting', () => {
     });
     const responder = connectCommandTransport({
       serviceId,
-      ownClientId: 'responder',
+      ownRuntimeId: 'responder',
       channel,
       localCommands: {},
       implementedCommandNames: new Set(),
@@ -480,7 +480,7 @@ describe('command-unhandled reporting', () => {
       commandName: 'doThing',
       input: { value: 'hi' },
       callId: 'call-mid-hmr',
-      clientId: 'requester',
+      runtimeId: 'requester',
     });
 
     expect(emittedCalls(channel, SERVICE_COMMAND_UNHANDLED)).toHaveLength(0);
@@ -497,13 +497,13 @@ describe('command-unhandled reporting', () => {
     channel.emitExternal(SERVICE_COMMAND_UNHANDLED, {
       serviceId: remoteOnlyServiceDef.id,
       callId,
-      clientId: 'peer-without-handler',
+      runtimeId: 'peer-without-handler',
     });
     channel.emitExternal(SERVICE_COMMAND_RESULT, {
       serviceId: remoteOnlyServiceDef.id,
       callId,
       result: 'done',
-      clientId: 'peer-with-handler',
+      runtimeId: 'peer-with-handler',
     });
 
     await expect(promise).resolves.toBe('done');
@@ -520,7 +520,7 @@ describe('command-unhandled reporting', () => {
       commandName: 'doThing',
       input: {},
       callId: 'call-unknown-service',
-      clientId: 'requester',
+      runtimeId: 'requester',
     });
 
     expect(emittedCalls(channel, SERVICE_COMMAND_UNHANDLED)).toEqual([
@@ -568,7 +568,7 @@ describe('load bodies and command routing', () => {
       commandName: 'preloadValue',
       input: { entryId: 'entry-a' },
       callId: expect.any(String),
-      clientId: expect.any(String),
+      runtimeId: expect.any(String),
     });
 
     const { callId } = emittedCalls(
@@ -579,7 +579,7 @@ describe('load bodies and command routing', () => {
       serviceId: loadInvokesRemoteCommandServiceDef.id,
       callId,
       result: undefined,
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
 
     await expect(promise).resolves.toBeNull();

--- a/code/core/src/shared/open-service/service-delegated-mode.test.ts
+++ b/code/core/src/shared/open-service/service-delegated-mode.test.ts
@@ -143,19 +143,19 @@ describe('delegated command dispatch', () => {
     channel.emitExternal(SERVICE_COMMAND_ACK, {
       serviceId: mutableRecordLookupServiceDef.id,
       callId,
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
     channel.emitExternal(SERVICE_PATCHES, {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { a: { k: 'v' } },
       version: 1,
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
     channel.emitExternal(SERVICE_COMMAND_RESULT, {
       serviceId: mutableRecordLookupServiceDef.id,
       callId,
       result: undefined,
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
 
     await expect(promise).resolves.toBeUndefined();
@@ -182,7 +182,7 @@ describe('delegated command dispatch', () => {
       commandName: 'assignRecordField',
       input: { entryId: 'a', fieldKey: 'k', fieldValue: 'v' },
       callId: 'call-1',
-      clientId: 'requester',
+      runtimeId: 'requester',
     });
 
     await new Promise<void>((resolve) => setTimeout(resolve, 10));
@@ -206,7 +206,7 @@ describe('delegated command dispatch', () => {
     channel.emitExternal(SERVICE_COMMAND_UNHANDLED, {
       serviceId: locallyImplementedServiceDef.id,
       callId,
-      clientId: 'instance',
+      runtimeId: 'instance',
     });
 
     const error = await promise.catch((caught: unknown) => caught);
@@ -282,19 +282,19 @@ describe('delegated thin loads', () => {
     channel.emitExternal(SERVICE_COMMAND_ACK, {
       serviceId: thinLoadServiceDef.id,
       callId: invoke.callId,
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
     channel.emitExternal(SERVICE_PATCHES, {
       serviceId: thinLoadServiceDef.id,
       state: { components: { button: 'extracted-on-peer' } },
       version: 1,
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
     channel.emitExternal(SERVICE_COMMAND_RESULT, {
       serviceId: thinLoadServiceDef.id,
       callId: invoke.callId,
       result: 'extracted-on-peer',
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
 
     await expect(promise).resolves.toBe('extracted-on-peer');

--- a/code/core/src/shared/open-service/service-delegated-mode.test.ts
+++ b/code/core/src/shared/open-service/service-delegated-mode.test.ts
@@ -206,7 +206,6 @@ describe('delegated command dispatch', () => {
     channel.emitExternal(SERVICE_COMMAND_UNHANDLED, {
       serviceId: locallyImplementedServiceDef.id,
       callId,
-      runtimeId: 'instance',
     });
 
     const error = await promise.catch((caught: unknown) => caught);

--- a/code/core/src/shared/open-service/service-registration-sync.test.ts
+++ b/code/core/src/shared/open-service/service-registration-sync.test.ts
@@ -63,13 +63,13 @@ describe('server: command push', () => {
         serviceId: recordServiceId,
         state: expect.objectContaining({ a: { k: 'v' } }),
         version: 1,
-        clientId: expect.any(String),
+        runtimeId: expect.any(String),
       })
     );
     expect(service.queries.recordFields.get({ entryId: 'a' })).toEqual({ k: 'v' });
   });
 
-  it('advances the version on each subsequent command, keeping a stable clientId', async () => {
+  it('advances the version on each subsequent command, keeping a stable runtimeId', async () => {
     const channel = createMockChannel();
     installChannel(channel);
 
@@ -80,8 +80,8 @@ describe('server: command push', () => {
 
     const patches = channel.emit.mock.calls.filter(([event]) => event === SERVICE_PATCHES);
     expect(patches.map(([, p]) => (p as { version: number }).version)).toEqual([1, 2]);
-    expect((patches[1][1] as { clientId: string }).clientId).toBe(
-      (patches[0][1] as { clientId: string }).clientId
+    expect((patches[1][1] as { runtimeId: string }).runtimeId).toBe(
+      (patches[0][1] as { runtimeId: string }).runtimeId
     );
     expect(service.queries.recordFields.get({ entryId: 'a' })).toEqual({ k: '2' });
   });
@@ -95,20 +95,20 @@ describe('server: sync-start initialization', () => {
     const service = registerService(mutableRecordLookupServiceDef);
 
     // Server adopts a peer patch: this both populates state and advances the server's stamp to the
-    // peer's (version, clientId).
+    // peer's (version, runtimeId).
     channel.emitExternal(SERVICE_PATCHES, {
       serviceId: recordServiceId,
       state: { a: { k: 'v' } },
       version: 1,
-      clientId: 'peer-1',
+      runtimeId: 'peer-1',
     });
     expect(service.queries.recordFields.get({ entryId: 'a' })).toEqual({ k: 'v' });
 
     // A different peer comes online and asks for current state; the server answers with the snapshot
-    // it now holds, stamped with the version/clientId it adopted (not its own initial clientId).
+    // it now holds, stamped with the version/runtimeId it adopted (not its own initial runtimeId).
     channel.emitExternal(SERVICE_SYNC_START, {
       serviceId: recordServiceId,
-      clientId: 'peer-2',
+      runtimeId: 'peer-2',
     });
 
     expect(channel.emit).toHaveBeenCalledWith(
@@ -117,7 +117,7 @@ describe('server: sync-start initialization', () => {
         serviceId: recordServiceId,
         state: expect.objectContaining({ a: { k: 'v' } }),
         version: 1,
-        clientId: 'peer-1',
+        runtimeId: 'peer-1',
       })
     );
   });
@@ -130,7 +130,7 @@ describe('server: sync-start initialization', () => {
 
     channel.emitExternal(SERVICE_SYNC_START, {
       serviceId: 'some-other-service',
-      clientId: 'peer-2',
+      runtimeId: 'peer-2',
     });
 
     const replyCalls = channel.emit.mock.calls.filter(
@@ -151,7 +151,7 @@ describe('server: patch application', () => {
       serviceId: recordServiceId,
       state: { entry: { marker: 'set' } },
       version: 1,
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
 
     expect(service.queries.recordFields.get({ entryId: 'entry' })).toEqual({ marker: 'set' });
@@ -167,13 +167,13 @@ describe('server: patch application', () => {
       serviceId: recordServiceId,
       state: { entry: { marker: 'new' } },
       version: 2,
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
     channel.emitExternal(SERVICE_PATCHES, {
       serviceId: recordServiceId,
       state: { entry: { marker: 'stale' } },
       version: 1,
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
 
     expect(service.queries.recordFields.get({ entryId: 'entry' })).toEqual({ marker: 'new' });
@@ -189,7 +189,7 @@ describe('server: patch application', () => {
       serviceId: 'some-other-service',
       state: { entry: { x: '1' } },
       version: 1,
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
 
     expect(service.queries.recordFields.get({ entryId: 'entry' })).toBeNull();
@@ -204,8 +204,8 @@ describe('server: patch application', () => {
     const malformed: unknown[] = [
       null,
       {},
-      { serviceId: recordServiceId, state: { a: { k: 'v' } }, clientId: 'p' },
-      { serviceId: recordServiceId, state: 'nope', version: 1, clientId: 'p' },
+      { serviceId: recordServiceId, state: { a: { k: 'v' } }, runtimeId: 'p' },
+      { serviceId: recordServiceId, state: 'nope', version: 1, runtimeId: 'p' },
     ];
 
     for (const payload of malformed) {
@@ -227,7 +227,7 @@ describe('server: teardown via clearRegistry', () => {
       serviceId: recordServiceId,
       state: { entry: { marker: 'set' } },
       version: 1,
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
     expect(service.queries.recordFields.get({ entryId: 'entry' })).toEqual({ marker: 'set' });
 
@@ -242,7 +242,7 @@ describe('server: teardown via clearRegistry', () => {
       serviceId: recordServiceId,
       state: { entry: { marker: 'after' } },
       version: 2,
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
     expect(service.queries.recordFields.get({ entryId: 'entry' })).toEqual({ marker: 'set' });
   });
@@ -272,7 +272,7 @@ describe('server: bootstrap on registration', () => {
       serviceId: recordServiceId,
       state: { a: { k: 'v' } },
       version: 3,
-      clientId: 'peer-1',
+      runtimeId: 'peer-1',
     });
 
     expect(service.queries.recordFields.get({ entryId: 'a' })).toEqual({ k: 'v' });
@@ -312,7 +312,7 @@ describe('server: relay role', () => {
       serviceId: recordServiceId,
       state: { entry: { marker: 'set' } },
       version: 1,
-      clientId: 'peer-1',
+      runtimeId: 'peer-1',
     });
 
     const relays = patchEmits(channel);
@@ -322,7 +322,7 @@ describe('server: relay role', () => {
         serviceId: recordServiceId,
         state: expect.objectContaining({ entry: { marker: 'set' } }),
         version: 1,
-        clientId: 'peer-1',
+        runtimeId: 'peer-1',
       })
     );
   });
@@ -337,7 +337,7 @@ describe('server: relay role', () => {
       serviceId: recordServiceId,
       state: { entry: { marker: 'boot' } },
       version: 4,
-      clientId: 'peer-1',
+      runtimeId: 'peer-1',
     });
 
     const relays = patchEmits(channel);
@@ -351,7 +351,7 @@ describe('server: relay role', () => {
 
     registerService(mutableRecordLookupServiceDef);
 
-    const base = { serviceId: recordServiceId, clientId: 'peer-1' };
+    const base = { serviceId: recordServiceId, runtimeId: 'peer-1' };
     channel.emitExternal(SERVICE_PATCHES, {
       ...base,
       state: { entry: { marker: 'new' } },

--- a/code/core/src/shared/open-service/service-registry.ts
+++ b/code/core/src/shared/open-service/service-registry.ts
@@ -22,7 +22,7 @@ import {
   OpenServiceMissingServiceError,
   OpenServiceOperationNameCollisionError,
 } from '../../server-errors.ts';
-import { type ServiceChannel, generateClientId } from './service-channel.ts';
+import { type ServiceChannel, generateRuntimeId } from './service-channel.ts';
 import { createServiceRuntime } from './service-runtime.ts';
 import { createSnapshotReconciler } from './service-sync.ts';
 import { connectServiceToChannel, connectUnknownServiceReporter } from './service-transport.ts';
@@ -304,7 +304,7 @@ export function registerService<
       ServiceRegistryApi;
   }
 
-  const ownClientId = generateClientId();
+  const ownRuntimeId = generateRuntimeId();
   const resolvedDefinition = applyRegistration(definition, registration);
 
   // The runtime mutates its state object in place, so give it a copy rather than the definition's
@@ -321,7 +321,7 @@ export function registerService<
   const reconciler = createSnapshotReconciler({
     setState: (mutate) =>
       runtime.commandSelf.setState((state) => mutate(state as Record<string, unknown>)),
-    initialStamp: { version: 0, clientId: ownClientId },
+    initialStamp: { version: 0, runtimeId: ownRuntimeId },
   });
 
   const getSnapshot = (): Record<string, unknown> =>
@@ -351,7 +351,7 @@ export function registerService<
   // commands, run the remote-command protocol, and attach the sync-start + patch listeners.
   const { commands, disconnect } = connectServiceToChannel({
     serviceId: definition.id,
-    ownClientId,
+    ownRuntimeId,
     reconciler,
     getSnapshot,
     channel,

--- a/code/core/src/shared/open-service/service-runtime.ts
+++ b/code/core/src/shared/open-service/service-runtime.ts
@@ -72,7 +72,7 @@ import {
   inFlightLoads,
   makeInFlightKey,
   makeLoadKey,
-  nextRuntimeId,
+  nextLoadScopeId,
   runLoadBody,
 } from './query-runtime.ts';
 import type { QueryRuntimeRefs, RuntimeQueryDefinition } from './query-runtime.ts';
@@ -381,11 +381,11 @@ export function createServiceRuntime<
     return routed as CommandSelf<TState>['commands'];
   };
 
-  const runtimeId = nextRuntimeId();
+  const loadScopeId = nextLoadScopeId();
 
   const refs: QueryRuntimeRefs<TState> = {
     serviceId: def.id,
-    runtimeId,
+    loadScopeId,
     commandSelf,
     state,
     registryApi,
@@ -441,7 +441,7 @@ export function createServiceRuntime<
 
     const loadKey = makeLoadKey(def.id, queryName, validatedInput);
     const ancestorChain = new Set<string>([loadKey]) as ReadonlySet<string>;
-    const inFlightKey = makeInFlightKey(runtimeId, loadKey);
+    const inFlightKey = makeInFlightKey(loadScopeId, loadKey);
 
     const promise = Promise.resolve()
       .then(() => runLoadBody(refs, queryName, queryDef, validatedInput, ancestorChain))

--- a/code/core/src/shared/open-service/service-sync.ts
+++ b/code/core/src/shared/open-service/service-sync.ts
@@ -10,10 +10,10 @@
  *
  * ## 1. `isNewer` — last-write-wins ordering
  *
- * Each synced snapshot carries a `(version, clientId)` stamp. `version` is a logical clock for the
+ * Each synced snapshot carries a `(version, runtimeId)` stamp. `version` is a logical clock for the
  * state lineage: a runtime bumps it on every local command and adopts the incoming value when it
  * accepts a peer's snapshot. Equal versions mean concurrent writes; the lexicographically greater
- * `clientId` wins so every runtime independently converges on the same snapshot regardless of the
+ * `runtimeId` wins so every runtime independently converges on the same snapshot regardless of the
  * order events arrive in.
  *
  * Crucially, an *equal* stamp is **not** newer. That single fact is what makes the protocol
@@ -40,14 +40,14 @@ export type SyncStamp = {
   /** Logical clock for the state lineage. Bumped on every local command, adopted on accept. */
   version: number;
   /** Id of the runtime that produced this version; the deterministic tiebreak for equal versions. */
-  clientId: string;
+  runtimeId: string;
 };
 
 /**
  * Returns whether `incoming` should replace `local` under last-write-wins ordering.
  *
  * Higher `version` always wins. At an equal version (concurrent writes) the lexicographically
- * greater `clientId` wins so every runtime picks the same winner. An equal stamp is **not** newer —
+ * greater `runtimeId` wins so every runtime picks the same winner. An equal stamp is **not** newer —
  * that is precisely what makes echoes and relayed re-broadcasts terminate rather than loop.
  */
 export function isNewer(incoming: SyncStamp, local: SyncStamp): boolean {
@@ -55,7 +55,7 @@ export function isNewer(incoming: SyncStamp, local: SyncStamp): boolean {
     return incoming.version > local.version;
   }
 
-  return incoming.clientId > local.clientId;
+  return incoming.runtimeId > local.runtimeId;
 }
 
 /** Keys never copied from an untrusted payload, to block prototype-pollution. */
@@ -135,10 +135,10 @@ export type SnapshotReconciler = {
   /** The current local stamp (read for sync-start-reply / broadcast envelopes). */
   readonly stamp: SyncStamp;
   /**
-   * Records a locally authored change: bumps `version` and re-stamps with `clientId`. Call this
+   * Records a locally authored change: bumps `version` and re-stamps with `runtimeId`. Call this
    * before broadcasting so the broadcast's own echo is recognized as not-newer and dropped.
    */
-  advanceLocal(clientId: string): SyncStamp;
+  advanceLocal(runtimeId: string): SyncStamp;
   /**
    * Adopts an incoming snapshot iff it is strictly newer (LWW). Returns whether it was adopted, so
    * relay hubs can re-broadcast only on a real advance.
@@ -152,7 +152,7 @@ export type SnapshotReconciler = {
  * @param setState - The runtime's batched in-place mutator (`commandSelf.setState`), adapted to a
  *   plain record. Adopting goes through this rather than the wrapped commands so it never triggers
  *   a re-broadcast.
- * @param initialStamp - Starting stamp, typically `{ version: 0, clientId: <own id> }`.
+ * @param initialStamp - Starting stamp, typically `{ version: 0, runtimeId: <own id> }`.
  */
 export function createSnapshotReconciler(options: {
   setState: (mutate: StateMutator) => void;
@@ -166,8 +166,8 @@ export function createSnapshotReconciler(options: {
       return localStamp;
     },
 
-    advanceLocal(clientId: string): SyncStamp {
-      localStamp = { version: localStamp.version + 1, clientId };
+    advanceLocal(runtimeId: string): SyncStamp {
+      localStamp = { version: localStamp.version + 1, runtimeId };
       return localStamp;
     },
 
@@ -176,7 +176,7 @@ export function createSnapshotReconciler(options: {
         return false;
       }
 
-      localStamp = { version: incoming.version, clientId: incoming.clientId };
+      localStamp = { version: incoming.version, runtimeId: incoming.runtimeId };
       setState((current) => applyStatePatch(current, state, { preserveMissingKeys: false }));
 
       return true;

--- a/code/core/src/shared/open-service/service-transport-leaf.test.ts
+++ b/code/core/src/shared/open-service/service-transport-leaf.test.ts
@@ -52,7 +52,7 @@ describe('channel: sync-start initialization (leaf)', () => {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { 'entry-late': { marker: 'synced' } },
       version: 1,
-      clientId: 'manager-hub',
+      runtimeId: 'manager-hub',
     });
 
     expect(preview.queries.recordFields.get({ entryId: 'entry-late' })).toEqual({
@@ -76,14 +76,14 @@ describe('channel: sync-start initialization (leaf)', () => {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { 'entry-stale': { marker: 'v0' } },
       version: 0,
-      clientId: 'early-hub',
+      runtimeId: 'early-hub',
     });
 
     channel.emitExternal(SERVICE_PATCHES, {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { 'entry-stale': { marker: 'v1' } },
       version: 1,
-      clientId: 'early-hub',
+      runtimeId: 'early-hub',
     });
 
     expect(preview.queries.recordFields.get({ entryId: 'entry-stale' })).toEqual({
@@ -113,7 +113,7 @@ describe('channel: patch broadcast (leaf)', () => {
 });
 
 describe('channel: last-write-wins convergence', () => {
-  it('converges on the higher clientId for concurrent (equal-version) writes', async () => {
+  it('converges on the higher runtimeId for concurrent (equal-version) writes', async () => {
     const channel = createMockChannel();
     installChannel(channel);
 
@@ -123,13 +123,13 @@ describe('channel: last-write-wins convergence', () => {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { item: { color: 'red' } },
       version: 1,
-      clientId: 'aaa',
+      runtimeId: 'aaa',
     });
     channel.emitExternal(SERVICE_PATCHES, {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { item: { color: 'blue' } },
       version: 1,
-      clientId: 'zzz',
+      runtimeId: 'zzz',
     });
 
     await vi.waitFor(() =>
@@ -147,20 +147,20 @@ describe('channel: last-write-wins convergence', () => {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { item: { color: 'blue' } },
       version: 1,
-      clientId: 'zzz',
+      runtimeId: 'zzz',
     });
     channel.emitExternal(SERVICE_PATCHES, {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { item: { color: 'red' } },
       version: 1,
-      clientId: 'aaa',
+      runtimeId: 'aaa',
     });
 
     await new Promise<void>((resolve) => setTimeout(resolve, 10));
     expect(service.queries.recordFields.get({ entryId: 'item' })).toEqual({ color: 'blue' });
   });
 
-  it('a higher version wins even against a greater clientId', async () => {
+  it('a higher version wins even against a greater runtimeId', async () => {
     const channel = createMockChannel();
     installChannel(channel);
 
@@ -170,13 +170,13 @@ describe('channel: last-write-wins convergence', () => {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { item: { color: 'blue' } },
       version: 1,
-      clientId: 'zzz',
+      runtimeId: 'zzz',
     });
     channel.emitExternal(SERVICE_PATCHES, {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { item: { color: 'green' } },
       version: 2,
-      clientId: 'aaa',
+      runtimeId: 'aaa',
     });
 
     await vi.waitFor(() =>
@@ -194,13 +194,13 @@ describe('channel: last-write-wins convergence', () => {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { item: { color: 'green' } },
       version: 2,
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
     channel.emitExternal(SERVICE_PATCHES, {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { item: { color: 'red' } },
       version: 1,
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
 
     await new Promise<void>((resolve) => setTimeout(resolve, 10));
@@ -219,19 +219,19 @@ describe('channel: multi-peer sync-start bootstrap', () => {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { item: { v: '1' } },
       version: 1,
-      clientId: 'p1',
+      runtimeId: 'p1',
     });
     channel.emitExternal(SERVICE_SYNC_START_REPLY, {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { item: { v: '3' } },
       version: 3,
-      clientId: 'p3',
+      runtimeId: 'p3',
     });
     channel.emitExternal(SERVICE_SYNC_START_REPLY, {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { item: { v: '2' } },
       version: 2,
-      clientId: 'p2',
+      runtimeId: 'p2',
     });
 
     await vi.waitFor(() =>
@@ -251,7 +251,7 @@ describe('channel: deletion propagation', () => {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { a: { k: 'v' }, b: { k: 'w' } },
       version: 1,
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
     await vi.waitFor(() =>
       expect(service.queries.recordFields.get({ entryId: 'b' })).toEqual({ k: 'w' })
@@ -261,7 +261,7 @@ describe('channel: deletion propagation', () => {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { a: { k: 'v' } },
       version: 2,
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
 
     await vi.waitFor(() => expect(service.queries.recordFields.get({ entryId: 'b' })).toBeNull());
@@ -285,7 +285,7 @@ describe('channel: untrusted payloads', () => {
         serviceId: mutableRecordLookupServiceDef.id,
         state: hostileState,
         version: 1,
-        clientId: 'attacker',
+        runtimeId: 'attacker',
       })
     ).not.toThrow();
 
@@ -305,12 +305,12 @@ describe('channel: untrusted payloads', () => {
     const malformed: unknown[] = [
       null,
       {},
-      { serviceId: mutableRecordLookupServiceDef.id, state: { a: { k: 'v' } }, clientId: 'p' },
+      { serviceId: mutableRecordLookupServiceDef.id, state: { a: { k: 'v' } }, runtimeId: 'p' },
       {
         serviceId: mutableRecordLookupServiceDef.id,
         state: 'not-an-object',
         version: 1,
-        clientId: 'p',
+        runtimeId: 'p',
       },
     ];
 
@@ -339,7 +339,7 @@ describe('channel: relay role (leaf)', () => {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { item: { color: 'red' } },
       version: 1,
-      clientId: 'peer-1',
+      runtimeId: 'peer-1',
     });
 
     expect(service.queries.recordFields.get({ entryId: 'item' })).toEqual({ color: 'red' });
@@ -358,7 +358,7 @@ describe('channel: disconnect on unregister', () => {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { entry: { marker: 'before' } },
       version: 1,
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
     await vi.waitFor(() =>
       expect(service.queries.recordFields.get({ entryId: 'entry' })).toEqual({
@@ -376,7 +376,7 @@ describe('channel: disconnect on unregister', () => {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { entry: { marker: 'after' } },
       version: 2,
-      clientId: 'peer',
+      runtimeId: 'peer',
     });
 
     expect(service.queries.recordFields.get({ entryId: 'entry' })).toEqual({ marker: 'before' });

--- a/code/core/src/shared/open-service/service-transport.ts
+++ b/code/core/src/shared/open-service/service-transport.ts
@@ -56,7 +56,7 @@ import {
   commandInvokeSchema,
   commandResultSchema,
   commandUnhandledSchema,
-  generateRuntimeId,
+  generateCallId,
   stampedSnapshotSchema,
   syncStartSchema,
 } from './service-channel.ts';
@@ -374,7 +374,6 @@ export function connectCommandTransport(context: {
         channel.emit(SERVICE_COMMAND_UNHANDLED, {
           serviceId,
           callId: invoke.callId,
-          runtimeId: ownRuntimeId,
         } satisfies CommandUnhandledPayload);
       }
       return;
@@ -472,7 +471,7 @@ export function connectCommandTransport(context: {
   channel.on(SERVICE_COMMAND_UNHANDLED, onUnhandled);
 
   const requestRemote = (commandName: string, input: unknown): Promise<unknown> => {
-    const callId = generateRuntimeId();
+    const callId = generateCallId();
 
     return new Promise<unknown>((resolve, reject) => {
       // Reject if no peer acknowledges in time. See REMOTE_COMMAND_ACK_TIMEOUT_MS for the
@@ -544,7 +543,6 @@ export function connectUnknownServiceReporter(context: {
   isDelegated: () => boolean;
 }): () => void {
   const { channel, isServiceRegistered, isDelegated } = context;
-  const ownRuntimeId = generateRuntimeId();
 
   const onInvoke = (payload: unknown): void => {
     const parsed = v.safeParse(commandInvokeSchema, payload);
@@ -555,7 +553,6 @@ export function connectUnknownServiceReporter(context: {
     channel.emit(SERVICE_COMMAND_UNHANDLED, {
       serviceId: parsed.output.serviceId,
       callId: parsed.output.callId,
-      runtimeId: ownRuntimeId,
     } satisfies CommandUnhandledPayload);
   };
 

--- a/code/core/src/shared/open-service/service-transport.ts
+++ b/code/core/src/shared/open-service/service-transport.ts
@@ -56,7 +56,7 @@ import {
   commandInvokeSchema,
   commandResultSchema,
   commandUnhandledSchema,
-  generateClientId,
+  generateRuntimeId,
   stampedSnapshotSchema,
   syncStartSchema,
 } from './service-channel.ts';
@@ -100,7 +100,7 @@ interface RuntimeTransportContext {
   /** Id of the service these helpers act for; stamped on every emitted envelope. */
   serviceId: ServiceId;
   /** This runtime's stable id, used to drop its own bootstrap request and its own echoes. */
-  ownClientId: string;
+  ownRuntimeId: string;
   /** The reconciler owning this runtime's LWW stamp and its adopt/advance transitions. */
   reconciler: SnapshotReconciler;
   /** Reads the runtime's current live state at emit time. */
@@ -120,7 +120,7 @@ export function wrapCommandsForBroadcast(
   commands: Record<string, RuntimeCommand>,
   context: RuntimeTransportContext & { channel: ServiceChannel }
 ): Record<string, RuntimeCommand> {
-  const { serviceId, ownClientId, reconciler, getSnapshot, channel } = context;
+  const { serviceId, ownRuntimeId, reconciler, getSnapshot, channel } = context;
 
   return Object.fromEntries(
     Object.entries(commands).map(([name, cmd]) => [
@@ -130,13 +130,13 @@ export function wrapCommandsForBroadcast(
 
         // A local command makes this runtime the new author: advance the stamp BEFORE emitting so the
         // broadcast bouncing back to us is recognized as not-newer (equal stamp) and dropped.
-        const stamp = reconciler.advanceLocal(ownClientId);
+        const stamp = reconciler.advanceLocal(ownRuntimeId);
 
         channel.emit(SERVICE_PATCHES, {
           serviceId,
           state: getSnapshot(),
           version: stamp.version,
-          clientId: stamp.clientId,
+          runtimeId: stamp.runtimeId,
         } satisfies PatchesPayload);
 
         return result;
@@ -160,12 +160,12 @@ export function wrapCommandsForBroadcast(
 export function connectRuntimeToChannel(
   context: RuntimeTransportContext & { channel: ServiceChannel; relay: boolean }
 ): () => void {
-  const { serviceId, ownClientId, reconciler, getSnapshot, channel, relay } = context;
+  const { serviceId, ownRuntimeId, reconciler, getSnapshot, channel, relay } = context;
 
   const emitSyncStart = (): void => {
     channel.emit(SERVICE_SYNC_START, {
       serviceId,
-      clientId: ownClientId,
+      runtimeId: ownRuntimeId,
     } satisfies SyncStartPayload);
   };
 
@@ -177,17 +177,17 @@ export function connectRuntimeToChannel(
       serviceId,
       state: getSnapshot(),
       version: reconciler.stamp.version,
-      clientId: reconciler.stamp.clientId,
+      runtimeId: reconciler.stamp.runtimeId,
     } satisfies PatchesPayload);
   };
 
   const adoptPeerSnapshot = (snapshot: {
     version: number;
-    clientId: string;
+    runtimeId: string;
     state: Record<string, unknown>;
   }): boolean => {
     const adopted = reconciler.tryAdopt(
-      { version: snapshot.version, clientId: snapshot.clientId },
+      { version: snapshot.version, runtimeId: snapshot.runtimeId },
       snapshot.state
     );
 
@@ -199,13 +199,13 @@ export function connectRuntimeToChannel(
   };
 
   // Reply to a peer's sync-start with our current snapshot+stamp (which may be one we adopted from yet
-  // another peer, not necessarily our own clientId). Skip our own bootstrap request.
+  // another peer, not necessarily our own runtimeId). Skip our own bootstrap request.
   const onSyncStart = (payload: unknown): void => {
     const request = v.safeParse(syncStartSchema, payload);
     if (
       !request.success ||
       request.output.serviceId !== serviceId ||
-      request.output.clientId === ownClientId
+      request.output.runtimeId === ownRuntimeId
     ) {
       return;
     }
@@ -214,7 +214,7 @@ export function connectRuntimeToChannel(
       serviceId,
       state: getSnapshot(),
       version: reconciler.stamp.version,
-      clientId: reconciler.stamp.clientId,
+      runtimeId: reconciler.stamp.runtimeId,
     } satisfies SyncStartReplyPayload);
   };
 
@@ -229,7 +229,7 @@ export function connectRuntimeToChannel(
   };
 
   // Apply patches from peers. The version gate drops echoes of our own broadcast and any
-  // already-applied snapshot, so no explicit self-clientId check is needed here.
+  // already-applied snapshot, so no explicit self-runtimeId check is needed here.
   const onPatches = (payload: unknown): void => {
     const snapshot = v.safeParse(stampedSnapshotSchema, payload);
     if (!snapshot.success || snapshot.output.serviceId !== serviceId) {
@@ -316,7 +316,7 @@ export function connectCommandTransport(context: {
   /** Id of the service these commands belong to; stamped on every emitted envelope. */
   serviceId: ServiceId;
   /** This runtime's stable id, stamped on replies so peers know who answered. */
-  ownClientId: string;
+  ownRuntimeId: string;
   channel: ServiceChannel;
   /**
    * Broadcast-wrapped local commands keyed by name. Only entries in {@link implementedCommandNames}
@@ -332,7 +332,7 @@ export function connectCommandTransport(context: {
 }): { commands: Record<string, RuntimeCommand>; disconnect: () => void } {
   const {
     serviceId,
-    ownClientId,
+    ownRuntimeId,
     channel,
     localCommands,
     implementedCommandNames,
@@ -370,11 +370,11 @@ export function connectCommandTransport(context: {
       // A hosted service without this command's handler is a positive config-drift signal for a
       // delegated caller. A delegated runtime answers no invokes, and a runtime that requested a
       // command remotely must not report its own echo.
-      if (!delegated && invoke.clientId !== ownClientId) {
+      if (!delegated && invoke.runtimeId !== ownRuntimeId) {
         channel.emit(SERVICE_COMMAND_UNHANDLED, {
           serviceId,
           callId: invoke.callId,
-          clientId: ownClientId,
+          runtimeId: ownRuntimeId,
         } satisfies CommandUnhandledPayload);
       }
       return;
@@ -383,7 +383,7 @@ export function connectCommandTransport(context: {
     channel.emit(SERVICE_COMMAND_ACK, {
       serviceId,
       callId: invoke.callId,
-      clientId: ownClientId,
+      runtimeId: ownRuntimeId,
     } satisfies CommandAckPayload);
 
     // On an async channel the emitted ack still needs an event-loop turn to reach the wire, so the
@@ -401,7 +401,7 @@ export function connectCommandTransport(context: {
               serviceId,
               callId: invoke.callId,
               result,
-              clientId: ownClientId,
+              runtimeId: ownRuntimeId,
             } satisfies CommandResultPayload);
           },
           (error: unknown) => {
@@ -409,7 +409,7 @@ export function connectCommandTransport(context: {
               serviceId,
               callId: invoke.callId,
               error: serializeError(error),
-              clientId: ownClientId,
+              runtimeId: ownRuntimeId,
             } satisfies CommandErrorPayload);
           }
         );
@@ -472,7 +472,7 @@ export function connectCommandTransport(context: {
   channel.on(SERVICE_COMMAND_UNHANDLED, onUnhandled);
 
   const requestRemote = (commandName: string, input: unknown): Promise<unknown> => {
-    const callId = generateClientId();
+    const callId = generateRuntimeId();
 
     return new Promise<unknown>((resolve, reject) => {
       // Reject if no peer acknowledges in time. See REMOTE_COMMAND_ACK_TIMEOUT_MS for the
@@ -495,7 +495,7 @@ export function connectCommandTransport(context: {
         commandName,
         input,
         callId,
-        clientId: ownClientId,
+        runtimeId: ownRuntimeId,
       } satisfies CommandInvokePayload);
     });
   };
@@ -544,7 +544,7 @@ export function connectUnknownServiceReporter(context: {
   isDelegated: () => boolean;
 }): () => void {
   const { channel, isServiceRegistered, isDelegated } = context;
-  const ownClientId = generateClientId();
+  const ownRuntimeId = generateRuntimeId();
 
   const onInvoke = (payload: unknown): void => {
     const parsed = v.safeParse(commandInvokeSchema, payload);
@@ -555,7 +555,7 @@ export function connectUnknownServiceReporter(context: {
     channel.emit(SERVICE_COMMAND_UNHANDLED, {
       serviceId: parsed.output.serviceId,
       callId: parsed.output.callId,
-      clientId: ownClientId,
+      runtimeId: ownRuntimeId,
     } satisfies CommandUnhandledPayload);
   };
 
@@ -601,7 +601,7 @@ export function connectServiceToChannel(
 ): { commands: Record<string, RuntimeCommand>; disconnect: () => void } {
   const {
     serviceId,
-    ownClientId,
+    ownRuntimeId,
     reconciler,
     getSnapshot,
     channel,
@@ -617,7 +617,7 @@ export function connectServiceToChannel(
   // flows through the reconciler's `setState`, never these wrappers, so it never re-broadcasts.
   const broadcastCommands = wrapCommandsForBroadcast(commands, {
     serviceId,
-    ownClientId,
+    ownRuntimeId,
     reconciler,
     getSnapshot,
     channel,
@@ -627,7 +627,7 @@ export function connectServiceToChannel(
   // does not, the returned command routes the call to a peer that implements it.
   const commandTransport = connectCommandTransport({
     serviceId,
-    ownClientId,
+    ownRuntimeId,
     channel,
     localCommands: broadcastCommands,
     implementedCommandNames,
@@ -637,7 +637,7 @@ export function connectServiceToChannel(
 
   const disconnectSync = connectRuntimeToChannel({
     serviceId,
-    ownClientId,
+    ownRuntimeId,
     reconciler,
     getSnapshot,
     channel,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

PR 1 of the OSA ordered-patch sync sequence ([SB-2048](https://linear.app/chromaui/issue/SB-2048/pr-1-rename-clientid-to-runtimeid-across-the-open-service-sync)). Targets `delta-open-service-sync`, not `next`.

Rename only. Behavior is unchanged.

- Stamp field: `clientId` → `runtimeId`
- Every channel envelope, including the four `services:command-*` events
- Transport own-id: `ownClientId` → `ownRuntimeId`
- Id helper: `generateClientId` → `generateRuntimeId`
- Open-service unit tests and README sync sections

No `clientId` remains under `code/core/src/shared/open-service/`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.
-->

No UI or authoring-API change. Confirm the rename and that existing tests still pass:

1. From the repo root: `rg clientId code/core/src/shared/open-service` — expect no matches.
2. From the repo root: `yarn test open-service` — existing open-service unit tests pass.
3. Optional protocol check: `cd code && yarn storybook:ui`, then run `yarn task e2e-tests-dev --start-from auto` is not required for this rename; the eight checks in `code/e2e-internal/open-service-sync.spec.ts` still apply if you want extra confidence on manager/preview/reload/two-tab sync.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc5e6431-6920-469e-a197-bbc18006e381?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc5e6431-6920-469e-a197-bbc18006e381&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

