### PR TITLE
Docs: Fix QueryClient imports in TanStack React setup snippets

### DIFF
--- a/docs/_snippets/tanstack-react-query-setup.md
+++ b/docs/_snippets/tanstack-react-query-setup.md
@@ -1,5 +1,5 @@
 ```tsx filename=".storybook/preview.tsx" renderer="react" language="tsx" tabTitle="CSF 3"
-import { type QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { Preview } from '@storybook/tanstack-react';
 
 // 👇 Create a new QueryClient
@@ -40,7 +40,7 @@ export default preview;
 
 ```tsx filename=".storybook/preview.tsx" renderer="react" language="tsx" tabTitle="CSF Next 🧪"
 import { definePreview } from '@storybook/tanstack-react';
-import { type QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // 👇 Create a new QueryClient
 const queryClient = new QueryClient({


### PR DESCRIPTION
## What I did

Fixed both TanStack React Query setup snippets to import `QueryClient` as a runtime value. The snippets instantiate `new QueryClient(...)`, but the type-only import caused TS1361 and a runtime failure.

AI assistance: Codex assisted with investigation and validation.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

No permanent test suite changes were needed. Both CSF 3 and CSF Next snippets pass TypeScript and runtime validation. Docs check, oxfmt, and `git diff --check` pass. The full repository test suite was not run because this is a two-line documentation fix.

#### Manual testing

1. Copy each snippet from `docs/_snippets/tanstack-react-query-setup.md` into a TypeScript Storybook project.
2. Run the project's typecheck and start Storybook.
3. Confirm there is no TS1361 or undefined `QueryClient` error.

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
