### PR TITLE
Manager: Add toolbar URL query param to show or hide the toolbar

### DIFF
--- a/code/core/src/manager-api/modules/url.ts
+++ b/code/core/src/manager-api/modules/url.ts
@@ -5,8 +5,8 @@ import {
   STORY_ARGS_UPDATED,
   UPDATE_QUERY_PARAMS,
 } from 'storybook/internal/core-events';
-import { buildArgsParam, queryFromLocation } from 'storybook/internal/router';
 import type { NavigateOptions } from 'storybook/internal/router';
+import { buildArgsParam, queryFromLocation } from 'storybook/internal/router';
 import type { API_Layout, API_UI, API_ViewMode, Args } from 'storybook/internal/types';
 
 import { global } from '@storybook/global';
@@ -60,7 +60,16 @@ const mergeSerializedParams = (params: string, extraParams: string) => {
 // URL query params the manager consumes for layout/navigation. Everything else is a custom param
 // passed through to the preview iframe. Listing the boundary once keeps customQueryParams derived
 // identically at init (initialUrlSupport) and on every navigation (root.tsx), so they can't diverge.
-const LAYOUT_QUERY_PARAM_KEYS = ['full', 'panel', 'nav', 'shortcuts', 'addonPanel', 'tabs', 'path'];
+const LAYOUT_QUERY_PARAM_KEYS = [
+  'full',
+  'panel',
+  'nav',
+  'shortcuts',
+  'addonPanel',
+  'tabs',
+  'toolbar',
+  'path',
+];
 
 /** Single source of truth for the custom (non-layout) query params derived from the URL. */
 export const getCustomQueryParams = (
@@ -74,6 +83,7 @@ export const getCustomQueryParams = (
 //     - full: 0/1 -- show fullscreen
 //     - panel: bottom/right/0 -- set addons panel position (or hide)
 //     - nav: 0/1 -- show or hide the story list
+//     - toolbar: 0/1 -- show or hide the toolbar
 //
 //   We also support legacy URLs from storybook <5
 let prevParams: QueryParams;
@@ -81,7 +91,7 @@ const initialUrlSupport = ({
   state: { location, path, viewMode, storyId: storyIdFromUrl },
   singleStory,
 }: ModuleArgs) => {
-  const { full, panel, nav, shortcuts, addonPanel, tabs } = queryFromLocation(location);
+  const { full, panel, nav, shortcuts, addonPanel, tabs, toolbar } = queryFromLocation(location);
 
   let navSize;
   let bottomPanelHeight;
@@ -118,6 +128,7 @@ const initialUrlSupport = ({
     rightPanelWidth,
     panelPosition: ['right', 'bottom'].includes(panel) ? panel : undefined,
     showTabs: parseBoolean(tabs),
+    showToolbar: parseBoolean(toolbar),
   };
   const ui: Partial<API_UI> = {
     enableShortcuts: parseBoolean(shortcuts),

--- a/code/core/src/manager-api/tests/url.test.js
+++ b/code/core/src/manager-api/tests/url.test.js
@@ -73,6 +73,28 @@ describe('initial state', () => {
       expect(layout).toMatchObject({ navSize: 0 });
     });
 
+    it('handles toolbar parameter, hidden', () => {
+      const navigate = vi.fn();
+      const location = { search: '?' + new URLSearchParams({ toolbar: '0' }).toString() };
+
+      const {
+        state: { layout },
+      } = initURL({ navigate, state: { location }, provider: { channel: new EventEmitter() } });
+
+      expect(layout).toMatchObject({ showToolbar: false });
+    });
+
+    it('handles toolbar parameter, shown', () => {
+      const navigate = vi.fn();
+      const location = { search: '?' + new URLSearchParams({ toolbar: '1' }).toString() };
+
+      const {
+        state: { layout },
+      } = initURL({ navigate, state: { location }, provider: { channel: new EventEmitter() } });
+
+      expect(layout).toMatchObject({ showToolbar: true });
+    });
+
     it('handles shortcuts parameter', () => {
       const navigate = vi.fn();
       const location = { search: '?' + new URLSearchParams({ shortcuts: '0' }).toString() };
@@ -133,6 +155,7 @@ describe('initial state', () => {
             shortcuts: '0',
             addonPanel: 'controls',
             tabs: '0',
+            toolbar: '0',
             path: '/story/button--primary',
             // genuinely custom params that must survive
             collection: '2',

--- a/docs/sharing/embed.mdx
+++ b/docs/sharing/embed.mdx
@@ -57,6 +57,8 @@ To embed a plain story without Storybook's toolbar, click the "open canvas in ne
   height="200"
 />
 
+The `iframe.html` URL renders only the story, without Storybook's addon panels. To hide just the toolbar while keeping the sidebar and panels, use the manager URL with `toolbar=false`, the same way as `nav`, `panel` and `tabs`. For example: `?path=/story/shadowboxcta--default&toolbar=false`.
+
 ## Embed documentation
 
 Embed a documentation page by replacing `viewMode=story` with the uniquely auto-generated documentation entry for the story.


### PR DESCRIPTION
Closes #19617 

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

Adds a `toolbar` URL query param that shows or hides the toolbar, wired up the same way as `nav`, `panel` and `tabs` in `manager-api/modules/url.ts`. `?toolbar=0` hides it, `?toolbar=1` forces it on, no param keeps the default.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

`url.test.js`: hidden and shown cases for `toolbar`, plus it is added to the existing "layout params don't leak into customQueryParams" test.

#### Manual testing

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

1. Open a story with `?path=/story/...`
2. Add `&toolbar=0`, the toolbar is hidden and the sidebar and panels stay
3. `&toolbar=1` shows it, no param keeps the default

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

Added a line to `docs/sharing/embed.mdx` in the "Embed a story without the toolbar" section, pointing at `toolbar=false` for keeping the panels while hiding the toolbar.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
