### PR TITLE
Core: Limit onboarding checklist rainbow animation

### DIFF
--- a/code/core/src/components/components/Card/Card.tsx
+++ b/code/core/src/components/components/Card/Card.tsx
@@ -37,9 +37,9 @@ const getOpaqueBackground = (theme: StorybookTheme, color?: ThemeColor): string 
 
 const fadeInOut = keyframes({
   '0%': { opacity: 0 },
-  '5%': { opacity: 1 },
-  '25%': { opacity: 1 },
-  '30%': { opacity: 0 },
+  '10%': { opacity: 1 },
+  '80%': { opacity: 1 },
+  '100%': { opacity: 0 },
 });
 
 const spin = keyframes({
@@ -100,10 +100,15 @@ const CardOutline = styled.div<{
     opacity: 1,
 
     ...(animation === 'rainbow' && {
-      animation: `${slide} 10s infinite linear, ${fadeInOut} 60s infinite linear`,
+      animation: `${slide} 10s linear forwards, ${fadeInOut} 10s linear forwards`,
       backgroundImage: `linear-gradient(45deg,rgb(234, 0, 0),rgb(255, 157, 0),rgb(255, 208, 0),rgb(0, 172, 0),rgb(0, 166, 255),rgb(181, 0, 181), rgb(234, 0, 0),rgb(255, 157, 0),rgb(255, 208, 0),rgb(0, 172, 0),rgb(0, 166, 255),rgb(181, 0, 181))`,
       backgroundSize: '1000%',
       backgroundPositionX: '100%',
+
+      '@media (prefers-reduced-motion: reduce)': {
+        animation: 'none',
+        opacity: 0,
+      },
     }),
 
     ...(animation === 'spin' && {

--- a/code/core/src/manager/components/sidebar/ChecklistWidget.stories.tsx
+++ b/code/core/src/manager/components/sidebar/ChecklistWidget.stories.tsx
@@ -1,7 +1,7 @@
 import type { PlayFunction } from 'storybook/internal/csf';
 
 import { ManagerContext } from 'storybook/manager-api';
-import { fn } from 'storybook/test';
+import { expect, fn } from 'storybook/test';
 
 import preview from '../../../../../.storybook/preview.tsx';
 import { initialState } from '../../../shared/checklist-store/checklistData.state.ts';
@@ -49,8 +49,21 @@ const meta = preview.meta({
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-const play: PlayFunction = async ({ step }) => {
+const play: PlayFunction = async ({ canvasElement, step }) => {
   await wait(3000);
+
+  await step('Verify the outline animation is finite', async () => {
+    const cardContent = canvasElement.querySelector('#storybook-checklist-widget');
+    await expect(cardContent).not.toBeNull();
+
+    const cardOutline = cardContent?.parentElement;
+    await expect(cardOutline).not.toBeNull();
+
+    const styles = window.getComputedStyle(cardOutline!, '::before');
+    await expect(styles.animationIterationCount).toBe('1, 1');
+    await expect(styles.animationFillMode).toBe('forwards, forwards');
+  });
+
   await step('Complete viewports task', () => {
     mockStore.setState({
       loaded: true,

--- a/code/core/src/manager/components/sidebar/ChecklistWidget.tsx
+++ b/code/core/src/manager/components/sidebar/ChecklistWidget.tsx
@@ -21,12 +21,12 @@ import { type TransitionMapOptions, useTransitionMap } from 'react-transition-st
 import { useStorybookApi } from 'storybook/manager-api';
 import { keyframes, styled } from 'storybook/theming';
 
+import { useCopyButton } from '../../../shared/useCopyButton.ts';
 import { Optional } from '../Optional/Optional.tsx';
 import { Particles } from '../Particles/Particles.tsx';
 import { TextFlip } from '../TextFlip.tsx';
 import type { ChecklistItem } from './useChecklist.ts';
 import { useChecklist } from './useChecklist.ts';
-import { useCopyButton } from '../../../shared/useCopyButton.ts';
 
 const fadeScaleIn = keyframes`
   from {
@@ -255,7 +255,7 @@ export const ChecklistWidget = () => {
 
   return (
     <CollapsibleWithMargin collapsed={!hasItems || !loaded}>
-      <HoverCard id="storybook-checklist-widget" outlineAnimation="rainbow">
+      <HoverCard id="storybook-checklist-widget" outlineAnimation={animated ? 'rainbow' : 'none'}>
         <Collapsible
           storageKey="checklist-widget"
           initialCollapsed={!hasItems}


### PR DESCRIPTION
Closes #36118

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

The checklist widget's rainbow outline ran two infinite CSS animations for as long
as the widget was mounted, which kept the compositor busy on an idle Storybook.

- The outline now starts only after the checklist has settled.
- It runs one 10 second cycle instead of repeating indefinitely.
- It does not run at all under `prefers-reduced-motion: reduce`. The existing media
  query only suppressed the `transition`, not the animations on the `::before`.
- A story assertion covers that both outline animations run once and keep their
  final state.

On the hardware I used to confirm the issue (AMD Radeon 660M, Zorin OS 18.1,
GNOME on Wayland), `radeontop` reads 0.00% on every engine once the animation has
finished, with the sidebar still visible.

The outline after the change:

<img width="400" height="243" alt="stopping-animation" src="https://github.com/user-attachments/assets/18c24d4b-ebd8-40ae-8e1f-1f3d5f6eca36" />

I saw this is fast-laned and nobody seemed to have picked it up. Happy to close this if you already have a fix in progress.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

This mirrors the reproduction steps in #36118.

1. Run a sandbox:

```shell
   yarn task sandbox --template react-vite/default-ts --start-from auto
```

2. Open Storybook and leave it idle, with the onboarding checklist visible at the
   top of the sidebar. Watch GPU load next to it (`radeontop` on AMD,
   `intel_gpu_top` on Intel, `nvtop` for either).

3. The rainbow outline around the checklist card animates once and then holds its
   final state. GPU load returns to the same level it has with the sidebar hidden,
   instead of staying elevated.

4. Toggle the sidebar off and on with Alt+S. The outline animation restarts when the checklist remounts, but it should stop again after about 10 seconds and must not loop continuously.

5. Collapse and expand the checklist card. The outline still does not restart.

6. Emulate `prefers-reduced-motion: reduce` (DevTools rendering panel, or the
   system setting). No outline animation runs at all.

7. Story assertions:

```shell
   yarn storybook:vitest --run code/core/src/manager/components/sidebar/ChecklistWidget.stories.tsx
```

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No documentation changes are needed, this only changes the behavior of an internal
manager UI animation.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->

## 🦋 Canary Release - 🚫 Not run

<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->