### PR TITLE
Open Service: Ordered log with undo/redo and concurrent sync

### DIFF
--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -79,8 +79,9 @@ Internal tests and implementation code may import from the individual modules di
 - [service-error-serialization.ts](./service-error-serialization.ts): transport-safe (de)serialization of thrown errors and their `cause` chains, used by remote command replies
 - [channel-slot.ts](../../channels/channel-slot.ts): `getChannel` / `setChannel` — the shared channel install surface
 - [service-transport.ts](./service-transport.ts): shared channel transport — wraps commands to emit `services:entry`, wires the sync-start initialization + entry listeners (hub or leaf), and runs the remote-command-execution protocol
-- [json-patch.ts](./json-patch.ts): RFC 6902 apply-by-path used only by the reconciler (`add`/`replace` upsert, `remove` of missing is a no-op)
-- [service-sync.ts](./service-sync.ts): last-write-wins snapshot ordering, Vector + seen-stamp entry dedup, `applyStatePatch` for bootstrap/static snapshots, and the per-service reconciler
+- [json-patch.ts](./json-patch.ts): RFC 6902 apply-by-path; inverses are reverse apply order (`add`/`replace` upsert, `remove` of missing is a no-op). `parentAfterChild` orders recorder ops only.
+- [service-sync.ts](./service-sync.ts): last-write-wins snapshot ordering, Lamport Clock, Vector, ordered Log with undo/redo, `applyStatePatch` for bootstrap/static snapshots, and the per-service reconciler
+- [sync-simulation.test.ts](./sync-simulation.test.ts): deterministic topology and fault simulation over real channels and service runtimes (`sync-simulation/`).
 - [use-service-query.ts](./use-service-query.ts): `useServiceQuery` React hook backed by `useSyncExternalStore`
 - [use-service-command.ts](./use-service-command.ts): `useServiceCommand` React hook returning a stable command reference
 - [fixtures.ts](./fixtures.ts): scenario fixtures used by the test suite
@@ -657,8 +658,28 @@ Creates a local `ServiceRuntime` from the service definition (identical across r
 
 1. **On registration** — emits `services:sync-start` so any existing peer can reply with its current snapshot.
 2. **On sync-start-reply** — applies the received snapshot into the local runtime so the new peer bootstraps from existing state.
-3. **After each local command that writes** — emits `services:entry` `{ serviceId, stamp: { runtimeId, counter }, command, patch }` where `patch` is an RFC 6902 document of the paths that command touched. A command that touches nothing emits nothing.
-4. **On incoming entries** — applies the patch by path via `commandSelf.setState`, which triggers fine-grained signal updates and re-renders subscribed components.
+3. **After each local command that writes** — emits `services:entry` `{ serviceId, stamp: { seq, runtimeId, counter }, command, patch }` where `patch` is an RFC 6902 document of the paths that command touched. A command that touches nothing emits nothing.
+4. **On incoming entries** — places the entry in the ordered Log (duplicate / later / earlier / gap / beyond-window) via `commandSelf.setState`, which triggers fine-grained signal updates and re-renders subscribed components.
+
+### Replay contract
+
+A `setState` recipe runs exactly once, on the runtime that called the command, against that runtime's state at that moment. What peers receive is the values it wrote, never the recipe. Peers place those writes in the shared canonical order, so when two runtimes write the same path concurrently, the canonically later write is what every runtime ends up holding. Read-modify-write inside a recipe (`state.n += 1`) is therefore safe only while one runtime writes that path; under concurrent writers one increment is lost, by design.
+
+The two escape hatches: make the server the sole writer of that path, or derive the value from other state.
+
+### Glossary
+
+- **Entry** — one stamp plus the forward ops it recorded plus the inverse ops computed locally when applied here. Inverses never leave the runtime.
+- **Log** — applied entries in canonical order, bounded by the window. An adopted bootstrap snapshot retires the Log. Incoming `seq` at or below that snapshot's `version` is treated as already folded in.
+- **Vector** — per `runtimeId`, the highest contiguous `counter` applied.
+- **Clock** — the Lamport high-water mark. It moves on incoming stamps (including duplicates and echoes), on local authoring, and on every observed bootstrap stamp (including snapshots that lose last-write-wins). After an accepted entry, snapshot `version` is at least the Clock.
+- **Frontier** — `{ vector, clock }`. Bootstrap replies will carry this in a later PR; today they still use `(version, runtimeId)`. After an accepted entry, `version` is at least the Clock; a joiner raises its Clock from that `version`.
+
+Canonical order is ascending `seq`, then ascending `runtimeId` with plain string comparison. The canonical stamp string is `${seq}:${runtimeId}:${counter}`.
+
+### History window
+
+An entry is retained while it is younger than 15 seconds **or** among the newest 256, whichever keeps it longer. Eviction is lazy on append. There is no byte cap. Bounds are a runtime option with those defaults; peers never need to agree on the window. The Vector never evicts. An incoming entry that sorts before the oldest retained entry is dropped and warned.
 
 ### Loop prevention
 
@@ -666,7 +687,7 @@ Every channel event that names a writer carries a `runtimeId` generated per `reg
 Loop prevention is not a single self-id check:
 
 - `services:sync-start` is ignored when its `runtimeId` matches the listener's own, so a runtime does not reply to itself.
-- `services:entry` drops a stamp that was already seen, or whose `counter` is at or below that writer's Vector (the highest contiguous counter applied). A hub that accepted the entry forwards the original payload object in receipt order; duplicates and entries it could not apply are not forwarded. The server websocket transport still echoes the author's own entry back once as one small frame, which the Vector drops.
+- `services:entry` drops a stamp that is already in the Log, or whose `counter` is at or below that writer's Vector. A hub that appended the entry to its Log forwards the original payload object in receipt order; duplicates and entries it could not place are not forwarded. The server websocket transport still echoes the author's own entry back once as one small frame, which the Log drops.
 - `services:sync-start-reply` drops echoes through last-write-wins stamp ordering (`isNewer`). A relay hub that adopts a bootstrap snapshot forwards the original reply payload.
 - Command replies correlate on `callId`, not on `runtimeId`.
 
@@ -676,7 +697,7 @@ Incoming state (from sync-start-reply or entries) is applied via `serviceRuntime
 
 ### `applyJsonPatch` and `applyStatePatch`
 
-Command entries apply through `applyJsonPatch` (in [json-patch.ts](./json-patch.ts)), which walks RFC 6901 pointers on the live state object. Documented deviations from RFC 6902: `add` and `replace` both upsert; `remove` of a missing key is a no-op with a debug log; a missing parent rolls the entry back inside its batch and warns, naming the service, stamp, path, and command. Incoming values are cloned. The schema accepts only `add` / `replace` / `remove` and rejects `move` / `copy` / `test`, malformed `~` escapes, `$`-prefixed segments (deepsignal-reserved), and the pointer segments `__proto__`, `constructor`, and `prototype`. The applier treats those same pointers as a missing parent so a schema bypass cannot throw or leave a partial apply. Unknown envelope fields are ignored.
+Command entries apply through `applyJsonPatch` (in [json-patch.ts](./json-patch.ts)), which walks RFC 6901 pointers on the live state object. Documented deviations from RFC 6902: `add` and `replace` both upsert; `remove` of a missing key is a no-op with a debug log; a missing parent rolls the entry back inside its batch and warns, naming the service, stamp, path, and command. Incoming values are cloned. Successful inverses are reverse apply order so nested removes restore the parent before the child. The schema accepts only `add` / `replace` / `remove` and rejects `move` / `copy` / `test`, malformed `~` escapes, `$`-prefixed segments (deepsignal-reserved), and the pointer segments `__proto__`, `constructor`, and `prototype`. The applier treats those same pointers as a missing parent so a schema bypass cannot throw or leave a partial apply. Unknown envelope fields are ignored.
 
 Bootstrap snapshots and static JSON still use `applyStatePatch` (in [service-sync.ts](./service-sync.ts)): it recursively merges plain-object values in place so subscriptions stay attached. Arrays and primitives are replaced directly, `__proto__`/`constructor`/`prototype` are skipped, and `preserveMissingKeys` controls whether missing keys are deleted. Cross-peer snapshot replies pass `false` so deletions propagate; static JSON loading passes `true` because each static file is a partial snapshot. Static snapshot loading never touches the entry reconciler.
 
@@ -702,7 +723,7 @@ service.commands.foo()
 
 ### Server participation
 
-The dev server is a full peer, not a passive observer. `registerService` on the server registers as a relay hub (`relay: true`): it wraps commands to emit `services:entry`, responds to sync-starts, applies incoming entries by path, and forwards every accepted entry (original payload, receipt order) so peers on its other transports converge. A relay hub forwards, unchanged and in receipt order, every `services:entry` it accepts; duplicates and entries it could not apply are not forwarded. This is wired automatically at registration once the `services` preset has installed the channel — there is no separate connect step.
+The dev server is a full peer, not a passive observer. `registerService` on the server registers as a relay hub (`relay: true`): it wraps commands to emit `services:entry`, responds to sync-starts, applies incoming entries by path, and forwards every accepted entry (original payload, receipt order) so peers on its other transports converge. A relay hub forwards, unchanged and in receipt order, every `services:entry` it appends to its own log; duplicates and entries it could not place are not forwarded. This is wired automatically at registration once the `services` preset has installed the channel — there is no separate connect step.
 
 ## Remote Command Execution
 

--- a/code/core/src/shared/open-service/json-patch.test.ts
+++ b/code/core/src/shared/open-service/json-patch.test.ts
@@ -104,7 +104,7 @@ describe('applyJsonPatch', () => {
     const target = copy(before);
     const operation = { op, path, value } as JsonPatchOperation;
 
-    expect(applyJsonPatch(target, [operation], failOnUnexpectedMissingRemove)).toEqual({
+    expect(applyJsonPatch(target, [operation], failOnUnexpectedMissingRemove)).toMatchObject({
       ok: true,
     });
     expect(target).toEqual(after);
@@ -114,7 +114,9 @@ describe('applyJsonPatch', () => {
     const target: Record<string, unknown> = { n: 1 };
     const onMissingRemove = vi.fn();
 
-    expect(applyJsonPatch(target, [{ op: 'remove', path: '/missing' }], onMissingRemove)).toEqual({
+    expect(
+      applyJsonPatch(target, [{ op: 'remove', path: '/missing' }], onMissingRemove)
+    ).toMatchObject({
       ok: true,
     });
     expect(onMissingRemove).toHaveBeenCalledWith('/missing');
@@ -126,7 +128,7 @@ describe('applyJsonPatch', () => {
 
     expect(
       applyJsonPatch(target, [{ op: 'remove', path: '/a/n' }], failOnUnexpectedMissingRemove)
-    ).toEqual({ ok: true });
+    ).toMatchObject({ ok: true });
     expect(target).toEqual({ a: { m: 2 }, keep: true });
   });
 
@@ -331,11 +333,87 @@ describe('applyJsonPatch on a live deepsignal store', () => {
         ],
         failOnUnexpectedMissingRemove
       )
-    ).toEqual({ ok: true });
+    ).toMatchObject({ ok: true });
 
     const components = state.components as Record<string, { argTypes: Record<string, unknown> }>;
     expect(components['button-component'].argTypes.e2eDocgenHotUpdateProp).toEqual({
       name: 'e2eDocgenHotUpdateProp',
+    });
+  });
+});
+
+describe('applyJsonPatch inverses', () => {
+  it('inverts add to remove and replace to replace with the previous value', () => {
+    const target: Record<string, unknown> = { n: 1 };
+
+    const result = applyJsonPatch(
+      target,
+      [
+        { op: 'replace', path: '/n', value: 2 },
+        { op: 'add', path: '/m', value: 3 },
+      ],
+      failOnUnexpectedMissingRemove
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      inverse: [
+        { op: 'remove', path: '/m' },
+        { op: 'replace', path: '/n', value: 1 },
+      ],
+    });
+  });
+
+  it('inverts nested removes so the parent is restored before the child', () => {
+    const target: Record<string, unknown> = { a: { b: 1 } };
+
+    const result = applyJsonPatch(
+      target,
+      [
+        { op: 'remove', path: '/a/b' },
+        { op: 'remove', path: '/a' },
+      ],
+      failOnUnexpectedMissingRemove
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      inverse: [
+        { op: 'add', path: '/a', value: {} },
+        { op: 'add', path: '/a/b', value: 1 },
+      ],
+    });
+    expect(target).toEqual({});
+    expect(
+      applyJsonPatch(target, result.ok ? result.inverse : [], failOnUnexpectedMissingRemove)
+    ).toEqual({
+      ok: true,
+      inverse: [
+        { op: 'remove', path: '/a/b' },
+        { op: 'remove', path: '/a' },
+      ],
+    });
+    expect(target).toEqual({ a: { b: 1 } });
+  });
+
+  it('orders inverse ops so children run before parents', () => {
+    const target: Record<string, unknown> = {};
+
+    const result = applyJsonPatch(
+      target,
+      [
+        { op: 'add', path: '/a', value: {} },
+        { op: 'add', path: '/a/b', value: 1 },
+      ],
+      failOnUnexpectedMissingRemove
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      inverse: [
+        { op: 'remove', path: '/a/b' },
+        { op: 'remove', path: '/a' },
+      ],
     });
   });
 });

--- a/code/core/src/shared/open-service/json-patch.ts
+++ b/code/core/src/shared/open-service/json-patch.ts
@@ -1,7 +1,17 @@
 import { clonePlain, hasOwn, isPlainObject, isReservedKey } from './plain-object.ts';
 import { decodePointer, isRfc6901Pointer, type JsonPatchOperation } from './service-channel.ts';
 
-export type ApplyJsonPatchResult = { ok: true } | { ok: false; path: string };
+export type ApplyJsonPatchResult =
+  | { ok: true; inverse: JsonPatchOperation[] }
+  | { ok: false; path: string };
+
+function pathDepth(pointer: string): number {
+  return decodePointer(pointer).length;
+}
+
+export function parentAfterChild(ops: readonly JsonPatchOperation[]): JsonPatchOperation[] {
+  return ops.toSorted((left, right) => pathDepth(right.path) - pathDepth(left.path));
+}
 
 function parentAt(
   root: Record<string, unknown>,
@@ -42,9 +52,9 @@ class MissingParentError extends Error {
  * Apply an RFC 6902 document onto `target` in place.
  *
  * `add` and `replace` both upsert. `remove` of a missing key calls `onMissingRemove` and continues.
- * Incoming values are cloned. A missing parent, reserved key, or invalid pointer rolls back every
- * op already applied in this call and returns `{ ok: false, path }` for that pointer. Any other
- * throw also rolls back, then rethrows.
+ * Incoming values are cloned. On success, `inverse` is reverse apply order. A missing parent, reserved
+ * key, or invalid pointer rolls back every op already applied in this call and returns
+ * `{ ok: false, path }` for that pointer. Any other throw also rolls back, then rethrows.
  */
 export function applyJsonPatch(
   target: Record<string, unknown>,
@@ -52,14 +62,15 @@ export function applyJsonPatch(
   onMissingRemove: (path: string) => void
 ): ApplyJsonPatchResult {
   const undo: Array<() => void> = [];
+  const inverse: JsonPatchOperation[] = [];
 
   try {
     for (const operation of patch) {
-      applyOne(target, operation, undo, onMissingRemove);
+      applyOne(target, operation, undo, inverse, onMissingRemove);
     }
-    return { ok: true };
+    return { ok: true, inverse: inverse.toReversed() };
   } catch (error) {
-    for (const revert of undo.reverse()) {
+    for (const revert of undo.toReversed()) {
       revert();
     }
     if (error instanceof MissingParentError) {
@@ -73,6 +84,7 @@ function applyOne(
   target: Record<string, unknown>,
   operation: JsonPatchOperation,
   undo: Array<() => void>,
+  inverse: JsonPatchOperation[],
   onMissingRemove: (path: string) => void
 ): void {
   if (!isRfc6901Pointer(operation.path)) {
@@ -102,6 +114,11 @@ function applyOne(
           delete parent[key];
         }
       });
+      if (existed) {
+        inverse.push({ op: 'replace', path: operation.path, value: previous });
+      } else {
+        inverse.push({ op: 'remove', path: operation.path });
+      }
       return;
     }
     case 'remove': {
@@ -114,6 +131,7 @@ function applyOne(
       undo.push(() => {
         parent[key] = previous;
       });
+      inverse.push({ op: 'add', path: operation.path, value: previous });
       return;
     }
     default: {

--- a/code/core/src/shared/open-service/patch-recorder.test.ts
+++ b/code/core/src/shared/open-service/patch-recorder.test.ts
@@ -1,6 +1,7 @@
 import { deepSignal } from 'deepsignal/core';
 import { describe, expect, it } from 'vitest';
 
+import { applyJsonPatch } from './json-patch.ts';
 import { createPatchCollector } from './patch-recorder.ts';
 
 function record<T extends object>(initial: T, mutate: (state: T) => void) {
@@ -380,5 +381,44 @@ describe('patch recorder', () => {
 
     expect(restored.flush()).toEqual([{ op: 'add', path: '/x', value: 1 }]);
     expect(removed.flush()).toEqual([]);
+  });
+
+  it('computes inverses from first-touch values with children before parents', () => {
+    const state = deepSignal({ n: 0, child: { x: 1 } });
+    const collector = createPatchCollector();
+    collector.record(state, (s) => {
+      s.n = 1;
+      delete (s as { child?: { x: number } }).child;
+    });
+
+    expect(collector.flushRecorded()).toEqual({
+      ops: [
+        { op: 'replace', path: '/n', value: 1 },
+        { op: 'remove', path: '/child' },
+      ],
+      inverse: [
+        { op: 'replace', path: '/n', value: 0 },
+        { op: 'add', path: '/child', value: { x: 1 } },
+      ],
+    });
+  });
+
+  it('restores the pre-command ancestor subtree when a later ancestor delete subsumes a child delete', () => {
+    const state = deepSignal({ a: { b: { x: 0 } } });
+    const collector = createPatchCollector();
+    collector.record(state, (s) => {
+      delete (s.a as { b?: { x: number } }).b;
+      delete (s as { a?: { b?: { x: number } } }).a;
+    });
+
+    const recorded = collector.flushRecorded();
+    expect(recorded).toEqual({
+      ops: [{ op: 'remove', path: '/a' }],
+      inverse: [{ op: 'add', path: '/a', value: { b: { x: 0 } } }],
+    });
+
+    const restored: Record<string, unknown> = {};
+    expect(applyJsonPatch(restored, recorded.inverse, () => undefined).ok).toBe(true);
+    expect(restored).toEqual({ a: { b: { x: 0 } } });
   });
 });

--- a/code/core/src/shared/open-service/patch-recorder.ts
+++ b/code/core/src/shared/open-service/patch-recorder.ts
@@ -15,6 +15,7 @@
 import { batch } from '@preact/signals-core';
 import { peek } from 'deepsignal/core';
 
+import { parentAfterChild } from './json-patch.ts';
 import { clonePlain, hasOwn, isReservedKey } from './plain-object.ts';
 import { encodePointer, type JsonPatchOperation } from './service-channel.ts';
 
@@ -23,6 +24,7 @@ export type RecordedOp = JsonPatchOperation;
 export type PatchCollector = {
   record<T extends object>(state: T, mutate: (state: T) => void): void;
   flush(): RecordedOp[];
+  flushRecorded(): { ops: RecordedOp[]; inverse: RecordedOp[] };
 };
 
 type Touch = {
@@ -45,10 +47,10 @@ function isPrimitive(value: unknown): boolean {
 }
 
 function firstTouchValue(existed: boolean, current: unknown): unknown {
-  if (!existed || !isPrimitive(current)) {
+  if (!existed) {
     return undefined;
   }
-  return current;
+  return clonePlain(current);
 }
 
 function readPath(root: object, segments: readonly string[]): { found: boolean; value: unknown } {
@@ -77,25 +79,56 @@ function readPath(root: object, segments: readonly string[]): { found: boolean; 
  */
 export function createPatchCollector(): PatchCollector {
   const touches = new Map<string, Touch>();
+  const ancestorFirst = new Map<string, { firstValue: unknown; existed: boolean }>();
   const order: string[] = [];
   // One wrapper per target so draft identity (`draft.x === draft.x`, `indexOf`) matches deepsignal.
   const wrapperByTarget = new WeakMap<object, object>();
   const targetByWrapper = new WeakMap<object, object>();
   let root: object | undefined;
 
+  // Child mutations run first; a later ancestor touch must invert the pre-recipe subtree.
+  const captureAncestorSnapshots = (segments: readonly string[]): void => {
+    if (!root) {
+      return;
+    }
+    for (let index = 1; index < segments.length; index += 1) {
+      const ancestorSegments = segments.slice(0, index);
+      const pointer = encodePointer(ancestorSegments);
+      if (touches.has(pointer) || ancestorFirst.has(pointer)) {
+        continue;
+      }
+      const { found, value } = readPath(root, ancestorSegments);
+      ancestorFirst.set(pointer, {
+        firstValue: found ? clonePlain(value) : undefined,
+        existed: found,
+      });
+    }
+  };
+
   const note = (touch: Touch): void => {
+    captureAncestorSnapshots(touch.segments);
     const pointer = encodePointer(touch.segments);
     if (touches.has(pointer)) {
       return;
     }
-    touches.set(pointer, touch);
+    const shadow = ancestorFirst.get(pointer);
+    touches.set(
+      pointer,
+      shadow
+        ? { segments: touch.segments, firstValue: shadow.firstValue, existed: shadow.existed }
+        : touch
+    );
     order.push(pointer);
   };
 
   const noteArray = (arrayRoot: ArrayRoot): void => {
+    const pointer = encodePointer(arrayRoot.path);
+    if (touches.has(pointer)) {
+      return;
+    }
     note({
       segments: arrayRoot.path,
-      firstValue: undefined,
+      firstValue: clonePlain(arrayRoot.target),
       existed: true,
     });
   };
@@ -224,6 +257,64 @@ export function createPatchCollector(): PatchCollector {
     return proxy;
   };
 
+  const flushRecorded = (): { ops: RecordedOp[]; inverse: RecordedOp[] } => {
+    if (!root) {
+      return { ops: [], inverse: [] };
+    }
+
+    const touched = new Set(order);
+    const ops: RecordedOp[] = [];
+    const inverse: RecordedOp[] = [];
+
+    for (const pointer of order) {
+      const touch = touches.get(pointer);
+      if (!touch) {
+        continue;
+      }
+
+      // `/a` covers `/a/b`; `/a` does not cover `/ab`.
+      const hasTouchedAncestor = touch.segments.some((_, index) => {
+        if (index === 0) {
+          return false;
+        }
+        return touched.has(encodePointer(touch.segments.slice(0, index)));
+      });
+      if (hasTouchedAncestor) {
+        continue;
+      }
+
+      // Final value comes from live state, so overlapping collectors cannot emit a stale remove.
+      const { found, value } = readPath(root, touch.segments);
+      if (!found) {
+        if (touch.existed) {
+          ops.push({ op: 'remove', path: pointer });
+          inverse.push({ op: 'add', path: pointer, value: clonePlain(touch.firstValue) });
+        }
+        continue;
+      }
+      // Same-value primitives (including net-out) are not ops; objects are never deep-compared.
+      if (isPrimitive(value) && Object.is(value, touch.firstValue)) {
+        continue;
+      }
+      ops.push({
+        op: touch.existed ? 'replace' : 'add',
+        path: pointer,
+        value: clonePlain(value),
+      });
+      if (touch.existed) {
+        inverse.push({ op: 'replace', path: pointer, value: clonePlain(touch.firstValue) });
+      } else {
+        inverse.push({ op: 'remove', path: pointer });
+      }
+    }
+
+    touches.clear();
+    ancestorFirst.clear();
+    order.length = 0;
+    root = undefined;
+    return { ops, inverse: parentAfterChild(inverse) };
+  };
+
   return {
     record(state, mutate) {
       root = state;
@@ -233,53 +324,9 @@ export function createPatchCollector(): PatchCollector {
     },
 
     flush() {
-      if (!root) {
-        return [];
-      }
-
-      const touched = new Set(order);
-      const ops: RecordedOp[] = [];
-
-      for (const pointer of order) {
-        const touch = touches.get(pointer);
-        if (!touch) {
-          continue;
-        }
-
-        // `/a` covers `/a/b`; `/a` does not cover `/ab`.
-        const hasTouchedAncestor = touch.segments.some((_, index) => {
-          if (index === 0) {
-            return false;
-          }
-          return touched.has(encodePointer(touch.segments.slice(0, index)));
-        });
-        if (hasTouchedAncestor) {
-          continue;
-        }
-
-        // Final value comes from live state, so overlapping collectors cannot emit a stale remove.
-        const { found, value } = readPath(root, touch.segments);
-        if (!found) {
-          if (touch.existed) {
-            ops.push({ op: 'remove', path: pointer });
-          }
-          continue;
-        }
-        // Same-value primitives (including net-out) are not ops; objects are never deep-compared.
-        if (isPrimitive(value) && Object.is(value, touch.firstValue)) {
-          continue;
-        }
-        ops.push({
-          op: touch.existed ? 'replace' : 'add',
-          path: pointer,
-          value: clonePlain(value),
-        });
-      }
-
-      touches.clear();
-      order.length = 0;
-      root = undefined;
-      return ops;
+      return flushRecorded().ops;
     },
+
+    flushRecorded,
   };
 }

--- a/code/core/src/shared/open-service/service-channel.test.ts
+++ b/code/core/src/shared/open-service/service-channel.test.ts
@@ -11,7 +11,7 @@ import {
 
 const validEntry = {
   serviceId: 'svc',
-  stamp: { runtimeId: 'writer', counter: 1 },
+  stamp: { seq: 1, runtimeId: 'writer', counter: 1 },
   command: 'setValue',
   patch: [{ op: 'replace' as const, path: '/n', value: 1 }],
 };
@@ -77,8 +77,16 @@ describe('entrySchema', () => {
   it('rejects an empty patch, counter 0, and a missing stamp', () => {
     expect(v.safeParse(entrySchema, { ...validEntry, patch: [] }).success).toBe(false);
     expect(
-      v.safeParse(entrySchema, { ...validEntry, stamp: { runtimeId: 'writer', counter: 0 } })
-        .success
+      v.safeParse(entrySchema, {
+        ...validEntry,
+        stamp: { seq: 1, runtimeId: 'writer', counter: 0 },
+      }).success
+    ).toBe(false);
+    expect(
+      v.safeParse(entrySchema, {
+        ...validEntry,
+        stamp: { seq: 0, runtimeId: 'writer', counter: 1 },
+      }).success
     ).toBe(false);
     expect(
       v.safeParse(entrySchema, { serviceId: 'svc', command: 'setValue', patch: validEntry.patch })

--- a/code/core/src/shared/open-service/service-channel.ts
+++ b/code/core/src/shared/open-service/service-channel.ts
@@ -40,7 +40,7 @@ export const SERVICE_COMMAND_UNHANDLED = 'services:command-unhandled' as const;
  * - `state` must be a *plain* object: `v.record` accepts arrays, so a custom check rejects them
  *   (an array snapshot would corrupt the structural merge in `service-sync.ts`).
  * - `version` is a non-negative safe integer — the last-write-wins logical clock for bootstrap
- *   snapshots. Command broadcasts use `services:entry` and `{ runtimeId, counter }` instead.
+ *   snapshots. Command broadcasts use `services:entry` and `{ seq, runtimeId, counter }` instead.
  * - `input` / `result` are optional: a `void` command input or output serializes to `undefined`,
  *   which JSON / telejson transports drop entirely, so the key is legitimately absent on the wire.
  * - Unknown fields on `services:entry` are ignored so a later envelope field is not a protocol break.
@@ -97,14 +97,15 @@ export const jsonPatchOperationSchema = v.variant('op', [
 export type JsonPatchOperation = v.InferOutput<typeof jsonPatchOperationSchema>;
 
 export const entryStampSchema = v.object({
+  seq: v.pipe(nonNegativeSafeInteger, v.minValue(1)),
   runtimeId: v.string(),
   counter: v.pipe(nonNegativeSafeInteger, v.minValue(1)),
 });
 export type EntryStamp = v.InferOutput<typeof entryStampSchema>;
 
-/** Canonical key for the seen-stamp set. */
+/** Canonical log key and warning label: `seq:runtimeId:counter`. */
 export function entryStampKey(stamp: EntryStamp): string {
-  return `${stamp.runtimeId}:${stamp.counter}`;
+  return `${stamp.seq}:${stamp.runtimeId}:${stamp.counter}`;
 }
 
 /** `services:entry` — one per outer command invocation, never empty. */

--- a/code/core/src/shared/open-service/service-delegated-mode.test.ts
+++ b/code/core/src/shared/open-service/service-delegated-mode.test.ts
@@ -147,7 +147,7 @@ describe('delegated command dispatch', () => {
     });
     channel.emitExternal(SERVICE_ENTRY, {
       serviceId: mutableRecordLookupServiceDef.id,
-      stamp: { runtimeId: 'peer', counter: 1 },
+      stamp: { seq: 1, runtimeId: 'peer', counter: 1 },
       command: 'assignRecordField',
       patch: [{ op: 'add', path: '/a', value: { k: 'v' } }],
     });
@@ -285,7 +285,7 @@ describe('delegated thin loads', () => {
     });
     channel.emitExternal(SERVICE_ENTRY, {
       serviceId: thinLoadServiceDef.id,
-      stamp: { runtimeId: 'peer', counter: 1 },
+      stamp: { seq: 1, runtimeId: 'peer', counter: 1 },
       command: 'extractDocgen',
       patch: [{ op: 'add', path: '/components/button', value: 'extracted-on-peer' }],
     });

--- a/code/core/src/shared/open-service/service-registration-sync.test.ts
+++ b/code/core/src/shared/open-service/service-registration-sync.test.ts
@@ -87,12 +87,12 @@ function peerEntry(
   patch: Array<
     { op: 'add' | 'replace'; path: string; value: unknown } | { op: 'remove'; path: string }
   >,
-  stamp: { runtimeId: string; counter: number },
+  stamp: { runtimeId: string; counter: number; seq?: number },
   extras: Record<string, unknown> = {}
 ) {
   return {
     serviceId,
-    stamp,
+    stamp: { seq: stamp.seq ?? stamp.counter, runtimeId: stamp.runtimeId, counter: stamp.counter },
     command: 'assignRecordField',
     patch,
     ...extras,

--- a/code/core/src/shared/open-service/service-registry.ts
+++ b/code/core/src/shared/open-service/service-registry.ts
@@ -317,9 +317,9 @@ export function registerService<
     structuredClone(resolvedDefinition.initialState)
   );
 
-  // Owns the per-service stamp, Vector, and adopt/advance logic. Adopting an entry or a bootstrap
-  // snapshot goes through `commandSelf.setState` — not the wrapped commands below — which is how the
-  // broadcast loop is prevented.
+  // Owns the per-service stamp, Vector, Clock, ordered Log, and adopt/advance logic. Adopting an
+  // entry or a bootstrap snapshot goes through `commandSelf.setState` — not the wrapped commands
+  // below — which is how the broadcast loop is prevented.
   const reconciler = createSnapshotReconciler({
     setState: (mutate) =>
       runtime.commandSelf.setState((state) => mutate(state as Record<string, unknown>)),

--- a/code/core/src/shared/open-service/service-sync.test.ts
+++ b/code/core/src/shared/open-service/service-sync.test.ts
@@ -1,9 +1,30 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { batch, effect } from '@preact/signals-core';
+import { deepSignal } from 'deepsignal/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { logger } from 'storybook/internal/client-logger';
 
-import { applyStatePatch, createSnapshotReconciler } from './service-sync.ts';
+import type { EntryStamp, JsonPatchOperation } from './service-channel.ts';
+import {
+  applyStatePatch,
+  compareStamps,
+  createSnapshotReconciler,
+  DEFAULT_LOG_MAX_ENTRIES,
+  type AuthoredEntry,
+} from './service-sync.ts';
 
 vi.mock('storybook/internal/client-logger', { spy: true });
+
+function stamp(runtimeId: string, counter: number, seq = counter): EntryStamp {
+  return { seq, runtimeId, counter };
+}
+
+function authored(
+  command: string,
+  patch: JsonPatchOperation[],
+  inverse: JsonPatchOperation[]
+): AuthoredEntry {
+  return { command, patch, inverse };
+}
 
 describe('applyStatePatch', () => {
   it('merges nested objects without deleting sibling keys', () => {
@@ -67,6 +88,22 @@ describe('applyStatePatch', () => {
   });
 });
 
+describe('compareStamps', () => {
+  it('orders by seq first, then by plain string runtimeId', () => {
+    expect(compareStamps(stamp('zzz', 1, 1), stamp('aaa', 1, 2))).toBeLessThan(0);
+    expect(compareStamps(stamp('aaa', 1, 2), stamp('zzz', 1, 1))).toBeGreaterThan(0);
+    expect(compareStamps(stamp('aaa', 1, 1), stamp('zzz', 1, 1))).toBeLessThan(0);
+    expect(compareStamps(stamp('zzz', 1, 1), stamp('aaa', 1, 1))).toBeGreaterThan(0);
+    expect(compareStamps(stamp('same', 1, 1), stamp('same', 2, 1))).toBe(0);
+  });
+
+  it('breaks runtimeId ties with plain string order, not localeCompare', () => {
+    expect('A' < 'a').toBe(true);
+    expect(compareStamps(stamp('A', 1, 1), stamp('a', 1, 1))).toBeLessThan(0);
+    expect(compareStamps(stamp('a', 1, 1), stamp('A', 1, 1))).toBeGreaterThan(0);
+  });
+});
+
 describe('createSnapshotReconciler entries', () => {
   beforeEach(() => {
     vi.mocked(logger.debug).mockReset();
@@ -75,31 +112,279 @@ describe('createSnapshotReconciler entries', () => {
     vi.mocked(logger.warn).mockImplementation(() => undefined);
   });
 
-  function createReconciler(initial: Record<string, unknown> = {}) {
+  function createReconciler(
+    initial: Record<string, unknown> = {},
+    window?: { maxAgeMs?: number; maxEntries?: number }
+  ) {
     const state = initial;
     const reconciler = createSnapshotReconciler({
       setState: (mutate) => {
         mutate(state);
       },
       initialStamp: { version: 0, runtimeId: 'self' },
+      window,
     });
     return { state, reconciler };
   }
 
-  it('drops a duplicate stamp including the local echo', () => {
+  it('stamps a local write with seq = clock + 1 and advances the clock', () => {
+    const { reconciler } = createReconciler({ n: 0 });
+    const first = reconciler.advanceLocal(
+      'self',
+      authored(
+        'setN',
+        [{ op: 'replace', path: '/n', value: 1 }],
+        [{ op: 'replace', path: '/n', value: 0 }]
+      )
+    );
+    expect(first).toEqual({ seq: 1, runtimeId: 'self', counter: 1 });
+    expect(reconciler.clock).toBe(1);
+
+    const second = reconciler.advanceLocal(
+      'self',
+      authored(
+        'setN',
+        [{ op: 'replace', path: '/n', value: 2 }],
+        [{ op: 'replace', path: '/n', value: 1 }]
+      )
+    );
+    expect(second).toEqual({ seq: 2, runtimeId: 'self', counter: 2 });
+    expect(reconciler.clock).toBe(2);
+  });
+
+  it('does not replay retained log entries across an adopted snapshot', () => {
+    const { state, reconciler } = createReconciler({ n: 0, extra: 0 });
+    expect(
+      reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: stamp('writer', 1, 2),
+        command: 'setN',
+        patch: [{ op: 'replace', path: '/n', value: 2 }],
+      })
+    ).toBe(true);
+    expect(state.n).toBe(2);
+
+    expect(reconciler.tryAdopt({ version: 10, runtimeId: 'peer' }, { n: 99, extra: 0 })).toBe(true);
+    expect(state).toEqual({ n: 99, extra: 0 });
+    expect(reconciler.log).toEqual([]);
+
+    expect(
+      reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: stamp('other', 1, 1),
+        command: 'setExtra',
+        patch: [{ op: 'replace', path: '/extra', value: 1 }],
+      })
+    ).toBe(false);
+    expect(state).toEqual({ n: 99, extra: 0 });
+    expect(reconciler.log).toEqual([]);
+  });
+
+  it('still places an entry later than an adopted snapshot', () => {
     const { state, reconciler } = createReconciler({ n: 0 });
-    const stamp = reconciler.advanceLocal('self');
+    expect(reconciler.tryAdopt({ version: 10, runtimeId: 'peer' }, { n: 99 })).toBe(true);
+
+    expect(
+      reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: stamp('writer', 1, 11),
+        command: 'setN',
+        patch: [{ op: 'replace', path: '/n', value: 11 }],
+      })
+    ).toBe(true);
+    expect(state.n).toBe(11);
+    expect(reconciler.log).toHaveLength(1);
+  });
+
+  it('keeps the log when a bootstrap snapshot loses last-write-wins', () => {
+    const { state, reconciler } = createReconciler({ n: 0 });
+    expect(
+      reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: stamp('writer', 1, 1),
+        command: 'setN',
+        patch: [{ op: 'replace', path: '/n', value: 1 }],
+      })
+    ).toBe(true);
+    expect(reconciler.log).toHaveLength(1);
+
+    expect(reconciler.tryAdopt({ version: 0, runtimeId: 'stale' }, { n: 99 })).toBe(false);
+    expect(state.n).toBe(1);
+    expect(reconciler.log).toHaveLength(1);
+  });
+
+  it('raises the clock to an adopted snapshot version so the next local seq is later', () => {
+    const { reconciler } = createReconciler({ value: '' });
+    expect(reconciler.tryAdopt({ version: 3, runtimeId: 'peer' }, { value: '' })).toBe(true);
+    expect(reconciler.clock).toBe(3);
+
+    const local = reconciler.advanceLocal(
+      'self',
+      authored(
+        'setValue',
+        [{ op: 'replace', path: '/value', value: 'after join' }],
+        [{ op: 'replace', path: '/value', value: '' }]
+      )
+    );
+    expect(local).toEqual({ seq: 4, runtimeId: 'self', counter: 1 });
+    expect(reconciler.clock).toBe(4);
+  });
+
+  it('does not let leftover later log entries clobber a post-bootstrap local write', () => {
+    const server = createReconciler({ value: '' });
+    expect(
+      server.reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: stamp('old-manager', 1, 1),
+        command: 'setValue',
+        patch: [{ op: 'replace', path: '/value', value: 'from panel' }],
+      })
+    ).toBe(true);
+    expect(
+      server.reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: stamp('old-preview', 1, 2),
+        command: 'setValue',
+        patch: [{ op: 'replace', path: '/value', value: 'from story' }],
+      })
+    ).toBe(true);
+    expect(
+      server.reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: stamp('old-manager', 2, 3),
+        command: 'setValue',
+        patch: [{ op: 'replace', path: '/value', value: '' }],
+      })
+    ).toBe(true);
+    expect(server.state.value).toBe('');
+
+    const joining = createReconciler({ value: '' });
+    expect(
+      joining.reconciler.tryAdopt(server.reconciler.stamp, { value: server.state.value })
+    ).toBe(true);
+
+    const local = joining.reconciler.advanceLocal(
+      'new-preview',
+      authored(
+        'setValue',
+        [{ op: 'replace', path: '/value', value: 'before reload' }],
+        [{ op: 'replace', path: '/value', value: '' }]
+      )
+    );
+    expect(local.seq).toBe(4);
+
+    expect(
+      server.reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: local,
+        command: 'setValue',
+        patch: [{ op: 'replace', path: '/value', value: 'before reload' }],
+      })
+    ).toBe(true);
+    expect(server.state.value).toBe('before reload');
+  });
+
+  it('keeps snapshot version at least the clock after a gapped seq so a joiner writes later', () => {
+    const server = createReconciler({ n: 0 });
+    expect(
+      server.reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: stamp('w', 1, 100),
+        command: 'setN',
+        patch: [{ op: 'replace', path: '/n', value: 1 }],
+      })
+    ).toBe(true);
+    expect(server.reconciler.clock).toBe(100);
+    expect(server.reconciler.stamp.version).toBeGreaterThanOrEqual(100);
+
+    const joining = createReconciler({ n: 0 });
+    expect(joining.reconciler.tryAdopt(server.reconciler.stamp, { n: server.state.n })).toBe(true);
+    expect(joining.reconciler.clock).toBeGreaterThanOrEqual(100);
+
+    const local = joining.reconciler.advanceLocal(
+      'joiner',
+      authored(
+        'setN',
+        [{ op: 'replace', path: '/n', value: 2 }],
+        [{ op: 'replace', path: '/n', value: 1 }]
+      )
+    );
+    expect(local.seq).toBeGreaterThan(100);
+
+    expect(
+      server.reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: local,
+        command: 'setN',
+        patch: [{ op: 'replace', path: '/n', value: 2 }],
+      })
+    ).toBe(true);
+    expect(server.state.n).toBe(2);
+  });
+
+  it('advances the clock from a rejected older bootstrap stamp', () => {
+    const { reconciler } = createReconciler({ n: 0 });
+    for (const runtimeId of ['aaa', 'mmm', 'zzz']) {
+      expect(
+        reconciler.tryAdoptEntry({
+          serviceId: 'svc',
+          stamp: stamp(runtimeId, 1, 1),
+          command: 'setN',
+          patch: [{ op: 'replace', path: '/n', value: runtimeId }],
+        })
+      ).toBe(true);
+    }
+    expect(reconciler.clock).toBe(1);
+    expect(reconciler.stamp.version).toBe(3);
+
+    expect(reconciler.tryAdopt({ version: 2, runtimeId: 'peer' }, { n: 'stale' })).toBe(false);
+    expect(reconciler.clock).toBe(2);
+    expect(reconciler.stamp.version).toBe(3);
+
+    const local = reconciler.advanceLocal(
+      'self',
+      authored(
+        'setN',
+        [{ op: 'replace', path: '/n', value: 'local' }],
+        [{ op: 'replace', path: '/n', value: 'zzz' }]
+      )
+    );
+    expect(local.seq).toBe(3);
+  });
+
+  it('drops a duplicate stamp including the local echo, and still advances the clock', () => {
+    const { state, reconciler } = createReconciler({ n: 0 });
+    const local = reconciler.advanceLocal(
+      'self',
+      authored(
+        'setN',
+        [{ op: 'replace', path: '/n', value: 1 }],
+        [{ op: 'replace', path: '/n', value: 0 }]
+      )
+    );
     state.n = 1;
 
     expect(
       reconciler.tryAdoptEntry({
         serviceId: 'svc',
-        stamp,
+        stamp: local,
         command: 'setN',
         patch: [{ op: 'replace', path: '/n', value: 99 }],
       })
     ).toBe(false);
     expect(state.n).toBe(1);
+    expect(reconciler.clock).toBe(1);
+
+    expect(
+      reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: stamp('self', 1, 9),
+        command: 'setN',
+        patch: [{ op: 'replace', path: '/n', value: 99 }],
+      })
+    ).toBe(false);
+    expect(state.n).toBe(1);
+    expect(reconciler.clock).toBe(9);
   });
 
   it('drops a counter at or below the vector', () => {
@@ -107,7 +392,7 @@ describe('createSnapshotReconciler entries', () => {
     expect(
       reconciler.tryAdoptEntry({
         serviceId: 'svc',
-        stamp: { runtimeId: 'w', counter: 1 },
+        stamp: stamp('w', 1),
         command: 'setA',
         patch: [{ op: 'add', path: '/a', value: 1 }],
       })
@@ -115,12 +400,98 @@ describe('createSnapshotReconciler entries', () => {
     expect(
       reconciler.tryAdoptEntry({
         serviceId: 'svc',
-        stamp: { runtimeId: 'w', counter: 1 },
+        stamp: stamp('w', 1),
         command: 'setA',
         patch: [{ op: 'add', path: '/a', value: 9 }],
       })
     ).toBe(false);
     expect(state).toEqual({ a: 1 });
+  });
+
+  it('appends a later entry and records it in the log', () => {
+    const { state, reconciler } = createReconciler();
+    expect(
+      reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: stamp('w', 1, 1),
+        command: 'setA',
+        patch: [{ op: 'add', path: '/a', value: 1 }],
+      })
+    ).toBe(true);
+    expect(state).toEqual({ a: 1 });
+    expect(reconciler.log.map((entry) => entry.stamp)).toEqual([stamp('w', 1, 1)]);
+    expect(reconciler.clock).toBe(1);
+    expect(reconciler.vector).toEqual({ w: 1 });
+  });
+
+  it('places an earlier entry with undo/redo inside one subscriber transition', () => {
+    const state = deepSignal({ a: '', b: '' }) as Record<string, unknown> & {
+      a: string;
+      b: string;
+    };
+    const reconciler = createSnapshotReconciler({
+      setState: (mutate) => {
+        batch(() => {
+          mutate(state);
+        });
+      },
+      initialStamp: { version: 0, runtimeId: 'self' },
+    });
+
+    let transitions = 0;
+    const stop = effect(() => {
+      void state.a;
+      void state.b;
+      transitions += 1;
+    });
+    const afterSubscribe = transitions;
+
+    expect(
+      reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: stamp('zzz', 1, 1),
+        command: 'setB',
+        patch: [{ op: 'replace', path: '/b', value: 'B' }],
+      })
+    ).toBe(true);
+    expect(transitions - afterSubscribe).toBe(1);
+
+    expect(
+      reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: stamp('aaa', 1, 1),
+        command: 'setA',
+        patch: [{ op: 'replace', path: '/a', value: 'A' }],
+      })
+    ).toBe(true);
+
+    expect(transitions - afterSubscribe).toBe(2);
+    expect({ a: state.a, b: state.b }).toEqual({ a: 'A', b: 'B' });
+    expect(reconciler.log.map((entry) => entry.stamp.runtimeId)).toEqual(['aaa', 'zzz']);
+    stop();
+  });
+
+  it('replays earlier same-path writes so the later stamp wins', () => {
+    const { state, reconciler } = createReconciler({ n: 0 });
+
+    expect(
+      reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: stamp('zzz', 1, 1),
+        command: 'setN',
+        patch: [{ op: 'replace', path: '/n', value: 'later' }],
+      })
+    ).toBe(true);
+    expect(
+      reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: stamp('aaa', 1, 1),
+        command: 'setN',
+        patch: [{ op: 'replace', path: '/n', value: 'earlier' }],
+      })
+    ).toBe(true);
+
+    expect(state.n).toBe('later');
   });
 
   it('applies a gap without advancing the vector so the skipped counter still applies', () => {
@@ -129,22 +500,25 @@ describe('createSnapshotReconciler entries', () => {
     expect(
       reconciler.tryAdoptEntry({
         serviceId: 'svc',
-        stamp: { runtimeId: 'w', counter: 2 },
+        stamp: stamp('w', 2, 2),
         command: 'setB',
         patch: [{ op: 'add', path: '/b', value: 2 }],
       })
     ).toBe(true);
     expect(state).toEqual({ b: 2 });
+    expect(reconciler.vector).toEqual({});
+    expect(vi.mocked(logger.warn)).not.toHaveBeenCalled();
 
     expect(
       reconciler.tryAdoptEntry({
         serviceId: 'svc',
-        stamp: { runtimeId: 'w', counter: 1 },
+        stamp: stamp('w', 1, 1),
         command: 'setA',
         patch: [{ op: 'add', path: '/a', value: 1 }],
       })
     ).toBe(true);
     expect(state).toEqual({ b: 2, a: 1 });
+    expect(reconciler.vector).toEqual({ w: 2 });
     expect(vi.mocked(logger.warn)).not.toHaveBeenCalled();
   });
 
@@ -154,14 +528,15 @@ describe('createSnapshotReconciler entries', () => {
     expect(
       reconciler.tryAdoptEntry({
         serviceId: 'demo',
-        stamp: { runtimeId: 'writer', counter: 1 },
+        stamp: stamp('writer', 1),
         command: 'setNested',
         patch: [{ op: 'add', path: '/missing/y', value: 3 }],
       })
     ).toBe(false);
     expect(state).toEqual({ a: 1 });
+    expect(reconciler.has(stamp('writer', 1))).toBe(false);
     expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
-      expect.stringContaining('service=demo stamp=writer:1 path=/missing/y command=setNested')
+      expect.stringContaining('service=demo stamp=1:writer:1 path=/missing/y command=setNested')
     );
   });
 
@@ -171,14 +546,119 @@ describe('createSnapshotReconciler entries', () => {
     expect(
       reconciler.tryAdoptEntry({
         serviceId: 'demo',
-        stamp: { runtimeId: 'writer', counter: 1 },
+        stamp: stamp('writer', 1),
         command: 'clearM',
         patch: [{ op: 'remove', path: '/m' }],
       })
     ).toBe(true);
     expect(state).toEqual({ n: 1 });
     expect(vi.mocked(logger.debug)).toHaveBeenCalledWith(
-      expect.stringContaining('service=demo stamp=writer:1 path=/m command=clearM')
+      expect.stringContaining('service=demo stamp=1:writer:1 path=/m command=clearM')
     );
+  });
+
+  it('drops a beyond-window entry and warns with service, stamps, paths, and command', () => {
+    const { state, reconciler } = createReconciler({}, { maxAgeMs: 0, maxEntries: 2 });
+
+    expect(
+      reconciler.tryAdoptEntry({
+        serviceId: 'demo',
+        stamp: stamp('w', 1, 1),
+        command: 'setA',
+        patch: [{ op: 'add', path: '/a', value: 1 }],
+      })
+    ).toBe(true);
+    expect(
+      reconciler.tryAdoptEntry({
+        serviceId: 'demo',
+        stamp: stamp('w', 2, 2),
+        command: 'setB',
+        patch: [{ op: 'add', path: '/b', value: 2 }],
+      })
+    ).toBe(true);
+    expect(
+      reconciler.tryAdoptEntry({
+        serviceId: 'demo',
+        stamp: stamp('w', 3, 3),
+        command: 'setC',
+        patch: [{ op: 'add', path: '/c', value: 3 }],
+      })
+    ).toBe(true);
+
+    expect(reconciler.log.map((entry) => entry.stamp.seq)).toEqual([2, 3]);
+
+    expect(
+      reconciler.tryAdoptEntry({
+        serviceId: 'demo',
+        stamp: stamp('other', 1, 1),
+        command: 'setZ',
+        patch: [{ op: 'add', path: '/z', value: 9 }],
+      })
+    ).toBe(false);
+    expect(state).toEqual({ a: 1, b: 2, c: 3 });
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.stringContaining('service=demo stamps=1:other:1,2:w:2 paths=/z command=setZ')
+    );
+  });
+});
+
+describe('log window eviction', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(logger.warn).mockReset();
+    vi.mocked(logger.warn).mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('keeps entries younger than the age bound even past the count floor', () => {
+    const state: Record<string, unknown> = { n: 0 };
+    const reconciler = createSnapshotReconciler({
+      setState: (mutate) => mutate(state),
+      initialStamp: { version: 0, runtimeId: 'self' },
+      window: { maxAgeMs: 15_000, maxEntries: 2 },
+    });
+
+    for (let counter = 1; counter <= 5; counter += 1) {
+      reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: stamp('w', counter, counter),
+        command: 'setN',
+        patch: [{ op: 'replace', path: '/n', value: counter }],
+      });
+    }
+
+    expect(reconciler.log).toHaveLength(5);
+  });
+
+  it('evicts entries that are both older than the age bound and outside the newest N', () => {
+    const state: Record<string, unknown> = { n: 0 };
+    const reconciler = createSnapshotReconciler({
+      setState: (mutate) => mutate(state),
+      initialStamp: { version: 0, runtimeId: 'self' },
+      window: { maxAgeMs: 15_000, maxEntries: 2 },
+    });
+
+    for (let counter = 1; counter <= 5; counter += 1) {
+      reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: stamp('w', counter, counter),
+        command: 'setN',
+        patch: [{ op: 'replace', path: '/n', value: counter }],
+      });
+    }
+
+    vi.advanceTimersByTime(15_001);
+    reconciler.tryAdoptEntry({
+      serviceId: 'svc',
+      stamp: stamp('w', 6, 6),
+      command: 'setN',
+      patch: [{ op: 'replace', path: '/n', value: 6 }],
+    });
+
+    expect(reconciler.log.map((entry) => entry.stamp.seq)).toEqual([5, 6]);
+    expect(DEFAULT_LOG_MAX_ENTRIES).toBe(256);
   });
 });

--- a/code/core/src/shared/open-service/service-sync.ts
+++ b/code/core/src/shared/open-service/service-sync.ts
@@ -2,23 +2,33 @@
  * Shared sync primitives for the open-service multi-master protocol.
  *
  * Every runtime — server (Node), manager (top window), preview (iframe) — runs a full
- * `ServiceRuntime` and reconciles incoming state here. Command broadcasts apply RFC 6902 patches
- * by path and dedup with a per-writer Vector. Bootstrap still uses last-write-wins snapshot
- * replies. The transport that moves entries and snapshots lives in `service-transport.ts`.
+ * `ServiceRuntime` and reconciles incoming state here. Command broadcasts carry a Lamport stamp
+ * `{ seq, runtimeId, counter }` and an RFC 6902 patch. Each replica keeps an ordered Log, a
+ * per-writer Vector, and a Clock. Bootstrap still uses last-write-wins snapshot replies. The
+ * transport that moves entries and snapshots lives in `service-transport.ts`.
  *
  * ## 1. `isNewer` — last-write-wins ordering for bootstrap snapshots
  *
- * Each bootstrap snapshot carries a `(version, runtimeId)` stamp. `version` is a logical clock
- * bumped on every accepted local or remote change. Equal versions mean concurrent snapshot
- * replies; the lexicographically greater `runtimeId` wins. An *equal* stamp is **not** newer,
- * which drops snapshot echoes.
+ * Each bootstrap snapshot carries a `(version, runtimeId)` stamp. `version` stays at least the
+ * Lamport Clock after each accepted entry, so a joiner that raises its Clock from `version` cannot
+ * author a `seq` into retained history. Equal versions mean concurrent snapshot replies; the
+ * lexicographically greater `runtimeId` wins. An *equal* stamp is **not** newer, which drops
+ * snapshot echoes. The Clock still moves on every observed snapshot stamp, including those that
+ * lose last-write-wins.
  *
- * ## 2. Entries — Vector, seen stamps, apply by path
+ * ## 2. Entries — Clock, Vector, ordered Log
  *
- * Each `services:entry` carries `{ runtimeId, counter }`. A stamp already seen, or with a
- * counter at or below the Vector, is a duplicate and is dropped. Anything else is applied in
- * arrival order. The Vector stores, per writer, the highest *contiguous* counter applied. A gap
- * is applied but does not advance the Vector.
+ * Each `services:entry` carries `{ seq, runtimeId, counter }`. `seq` is the Lamport order key.
+ * One comparator orders the Log ascending on `seq`, then on `runtimeId` by plain string
+ * comparison. Incoming cases, in order: duplicate (in the Log, counter at or below the Vector, or
+ * `seq` at or below an adopted snapshot `version`) drops but still advances the Clock; later
+ * appends; earlier undoes newest-first, applies, and redoes from stored forward ops inside one
+ * `setState` batch; a gap still places but does not advance the Vector; beyond-window (sorts before
+ * the oldest retained entry) drops and warns. Adopting a bootstrap snapshot raises the Clock to at
+ * least that snapshot's `version`, so a late joiner's next `seq` is later than the peer's accepted
+ * history, and retires the Log so old inverses cannot replay across the new state. The Vector stays,
+ * so later echoes still drop. The Vector never evicts. Log eviction is lazy on append: an entry is
+ * retained while younger than 15 s or among the newest 256.
  *
  * ## 3. `applyStatePatch` — structural merge for snapshots
  *
@@ -35,9 +45,17 @@ import { applyJsonPatch } from './json-patch.ts';
 import { FORBIDDEN_KEYS, hasOwn, isPlainObject } from './plain-object.ts';
 import { entryStampKey, type EntryStamp, type JsonPatchOperation } from './service-channel.ts';
 
+export const DEFAULT_LOG_MAX_AGE_MS = 15_000;
+export const DEFAULT_LOG_MAX_ENTRIES = 256;
+
+export type LogWindow = {
+  maxAgeMs: number;
+  maxEntries: number;
+};
+
 /** Per-service last-write-wins stamp carried on bootstrap snapshot replies. */
 export type SyncStamp = {
-  /** Logical clock for the state lineage. Bumped on every accepted change, adopted on snapshot accept. */
+  /** Logical clock for the state lineage. At least the Lamport Clock after each accepted entry. */
   version: number;
   /** Id of the runtime that produced this version; the deterministic tiebreak for equal versions. */
   runtimeId: string;
@@ -56,6 +74,22 @@ export function isNewer(incoming: SyncStamp, local: SyncStamp): boolean {
   }
 
   return incoming.runtimeId > local.runtimeId;
+}
+
+/**
+ * Canonical entry order: ascending `seq`, then ascending `runtimeId` with plain string comparison.
+ *
+ * "Later in the log", "greater stamp", and "wins the path" coincide. Greater `runtimeId` is later,
+ * matching last-write-wins snapshot ties.
+ */
+export function compareStamps(left: EntryStamp, right: EntryStamp): number {
+  if (left.seq !== right.seq) {
+    return left.seq < right.seq ? -1 : 1;
+  }
+  if (left.runtimeId !== right.runtimeId) {
+    return left.runtimeId < right.runtimeId ? -1 : 1;
+  }
+  return 0;
 }
 
 /**
@@ -123,11 +157,28 @@ export type AdoptEntryInput = {
   patch: readonly JsonPatchOperation[];
 };
 
+export type AuthoredEntry = {
+  command: string;
+  patch: readonly JsonPatchOperation[];
+  inverse: readonly JsonPatchOperation[];
+};
+
+export type ReconcilerLogEntry = {
+  stamp: EntryStamp;
+  command: string;
+  patch: readonly JsonPatchOperation[];
+};
+
+type StoredLogEntry = ReconcilerLogEntry & {
+  inverse: JsonPatchOperation[];
+  appliedAt: number;
+};
+
 /**
  * The per-service reconciler shared by every runtime's channel integration.
  *
- * It owns the bootstrap snapshot stamp, the per-writer Vector, and the seen-stamp set. Local
- * commands call {@link SnapshotReconciler.advanceLocal} before emitting. Incoming entries go
+ * It owns the bootstrap snapshot stamp, the Clock, the per-writer Vector, and the ordered Log.
+ * Local commands call {@link SnapshotReconciler.advanceLocal} before emitting. Incoming entries go
  * through {@link SnapshotReconciler.tryAdoptEntry}. Incoming bootstrap snapshots go through
  * {@link SnapshotReconciler.tryAdopt}.
  */
@@ -135,19 +186,33 @@ export type SnapshotReconciler = {
   /** The current local snapshot stamp (read for sync-start-reply envelopes). */
   readonly stamp: SyncStamp;
   /**
-   * Records a locally authored change: bumps the snapshot version, increments this writer's
-   * counter, records the stamp as seen, and advances the Vector. Call this before emitting so
-   * the broadcast's own echo is recognized as a duplicate and dropped.
+   * Lamport high-water mark. Moves on incoming stamps (including duplicates), local authoring,
+   * observed bootstrap stamps (including LWW rejects), and adopted snapshot `version`.
    */
-  advanceLocal(runtimeId: string): EntryStamp;
+  readonly clock: number;
+  /** Per-writer highest contiguous counter applied. */
+  readonly vector: Readonly<Record<string, number>>;
+  /** Applied entries in canonical order, after window eviction. */
+  readonly log: readonly ReconcilerLogEntry[];
+  /** Whether this stamp is in the retained Log. */
+  has(stamp: EntryStamp): boolean;
   /**
-   * Adopts an incoming snapshot iff it is strictly newer (LWW). Returns whether it was adopted, so
-   * relay hubs can re-broadcast only on a real advance.
+   * Records a locally authored change: assigns `seq = clock + 1`, increments this writer's
+   * counter, appends to the Log with the supplied inverse, and advances the Clock. Call this
+   * before emitting so the broadcast's own echo is recognized as a duplicate and dropped.
+   */
+  advanceLocal(runtimeId: string, authored: AuthoredEntry): EntryStamp;
+  /**
+   * Adopts an incoming snapshot iff it is strictly newer (LWW). Always raises the Clock to at least
+   * `incoming.version`, including when the snapshot loses last-write-wins. An accepted snapshot
+   * retires the Log and ignores later arrivals with `seq` at or below that `version`. Returns
+   * whether state was adopted, so relay hubs can re-broadcast only on a real advance.
    */
   tryAdopt(incoming: SyncStamp, state: Record<string, unknown>): boolean;
   /**
-   * Applies an incoming entry iff it is not a duplicate. Returns whether it was accepted, so a
-   * hub forwards the original payload only then. A gap is accepted without advancing the Vector.
+   * Places an incoming entry into the Log. Returns whether it was accepted, so a hub forwards the
+   * original payload only then. Duplicates, entries at or below the last adopted snapshot `version`,
+   * and beyond-window entries return false; a gap is accepted without advancing the Vector.
    */
   tryAdoptEntry(incoming: AdoptEntryInput): boolean;
 };
@@ -163,27 +228,163 @@ export type SnapshotReconciler = {
 export function createSnapshotReconciler(options: {
   setState: (mutate: StateMutator) => void;
   initialStamp: SyncStamp;
+  window?: Partial<LogWindow>;
 }): SnapshotReconciler {
   const { setState, initialStamp } = options;
+  const window: LogWindow = {
+    maxAgeMs: options.window?.maxAgeMs ?? DEFAULT_LOG_MAX_AGE_MS,
+    maxEntries: options.window?.maxEntries ?? DEFAULT_LOG_MAX_ENTRIES,
+  };
   let localStamp = initialStamp;
+  let clock = 0;
+  let snapshotSeq = 0;
   const vector = new Map<string, number>();
-  const seen = new Set<string>();
+  const log: StoredLogEntry[] = [];
+  const logKeys = new Set<string>();
+  let truncated = false;
 
   const vectorOf = (runtimeId: string): number => vector.get(runtimeId) ?? 0;
 
-  // Remember a stamp we authored or applied. Advance this writer's vector only when the counter is
-  // contiguous, then absorb later stamps that already arrived as gaps. Bump the snapshot stamp so
-  // bootstrap replies stay newer.
-  const recordAccepted = (stamp: EntryStamp): void => {
-    seen.add(entryStampKey(stamp));
-    if (stamp.counter === vectorOf(stamp.runtimeId) + 1) {
-      let next = stamp.counter;
-      while (seen.has(entryStampKey({ runtimeId: stamp.runtimeId, counter: next + 1 }))) {
-        next += 1;
-      }
-      vector.set(stamp.runtimeId, next);
+  const hasStamp = (stamp: EntryStamp): boolean => logKeys.has(entryStampKey(stamp));
+
+  const silentMissingRemove = (): void => undefined;
+
+  const patchPaths = (patch: readonly JsonPatchOperation[]): string =>
+    patch.map((operation) => operation.path).join(',');
+
+  const applyOps = (
+    current: Record<string, unknown>,
+    patch: readonly JsonPatchOperation[],
+    onMissingRemove: (path: string) => void
+  ) => applyJsonPatch(current, patch, onMissingRemove);
+
+  const undoEntry = (
+    current: Record<string, unknown>,
+    entry: StoredLogEntry,
+    serviceId: string
+  ): void => {
+    const result = applyOps(current, entry.inverse, silentMissingRemove);
+    if (!result.ok) {
+      logger.warn(
+        `Open-service sync: undo failed. service=${serviceId} stamp=${entryStampKey(entry.stamp)} path=${result.path} command=${entry.command}`
+      );
     }
-    localStamp = { version: localStamp.version + 1, runtimeId: stamp.runtimeId };
+  };
+
+  const redoEntry = (
+    current: Record<string, unknown>,
+    entry: StoredLogEntry,
+    serviceId: string
+  ): void => {
+    const result = applyOps(current, entry.patch, silentMissingRemove);
+    if (!result.ok) {
+      logger.warn(
+        `Open-service sync: replay failed. service=${serviceId} stamp=${entryStampKey(entry.stamp)} path=${result.path} command=${entry.command}`
+      );
+      return;
+    }
+    entry.inverse = result.inverse;
+  };
+
+  // Inclusive of `index`: those entries sit after the incoming stamp and are replayed after it.
+  const undoToIndex = (
+    current: Record<string, unknown>,
+    index: number,
+    serviceId: string
+  ): StoredLogEntry[] => {
+    const undone: StoredLogEntry[] = [];
+    for (let cursor = log.length - 1; cursor >= index; cursor -= 1) {
+      const entry = log[cursor];
+      undoEntry(current, entry, serviceId);
+      undone.push(entry);
+    }
+    return undone;
+  };
+
+  const redoUndone = (
+    current: Record<string, unknown>,
+    undone: StoredLogEntry[],
+    serviceId: string
+  ): void => {
+    for (let cursor = undone.length - 1; cursor >= 0; cursor -= 1) {
+      redoEntry(current, undone[cursor], serviceId);
+    }
+  };
+
+  const insertIndexFor = (stamp: EntryStamp): number => {
+    let index = 0;
+    while (index < log.length && compareStamps(log[index].stamp, stamp) < 0) {
+      index += 1;
+    }
+    return index;
+  };
+
+  const tryAdvanceVector = (stamp: EntryStamp): void => {
+    if (stamp.counter !== vectorOf(stamp.runtimeId) + 1) {
+      return;
+    }
+    const counters = new Set<number>();
+    for (const entry of log) {
+      if (entry.stamp.runtimeId === stamp.runtimeId) {
+        counters.add(entry.stamp.counter);
+      }
+    }
+    let next = stamp.counter;
+    while (counters.has(next + 1)) {
+      next += 1;
+    }
+    vector.set(stamp.runtimeId, next);
+  };
+
+  const evict = (now: number): void => {
+    if (log.length === 0) {
+      return;
+    }
+    const minKeepIndex = Math.max(0, log.length - window.maxEntries);
+    const kept: StoredLogEntry[] = [];
+    for (let index = 0; index < log.length; index += 1) {
+      const entry = log[index];
+      const amongNewest = index >= minKeepIndex;
+      const young = now - entry.appliedAt < window.maxAgeMs;
+      if (amongNewest || young) {
+        kept.push(entry);
+      } else {
+        logKeys.delete(entryStampKey(entry.stamp));
+      }
+    }
+    if (kept.length === log.length) {
+      return;
+    }
+    truncated = true;
+    log.length = 0;
+    log.push(...kept);
+  };
+
+  const remember = (entry: StoredLogEntry, advanceVector: boolean): void => {
+    logKeys.add(entryStampKey(entry.stamp));
+    if (advanceVector) {
+      tryAdvanceVector(entry.stamp);
+    }
+    localStamp = {
+      version: Math.max(localStamp.version + 1, clock),
+      runtimeId: entry.stamp.runtimeId,
+    };
+    evict(entry.appliedAt);
+  };
+
+  const appendOrInsert = (entry: StoredLogEntry, index: number, advanceVector: boolean): void => {
+    if (index === log.length) {
+      log.push(entry);
+    } else {
+      log.splice(index, 0, entry);
+    }
+    remember(entry, advanceVector);
+  };
+
+  const advanceClock = (seq: number): void => {
+    if (seq > clock) {
+      clock = seq;
+    }
   };
 
   return {
@@ -191,18 +392,52 @@ export function createSnapshotReconciler(options: {
       return localStamp;
     },
 
-    advanceLocal(runtimeId: string): EntryStamp {
-      const stamp = { runtimeId, counter: vectorOf(runtimeId) + 1 };
-      recordAccepted(stamp);
+    get clock(): number {
+      return clock;
+    },
+
+    get vector(): Readonly<Record<string, number>> {
+      return Object.fromEntries(vector);
+    },
+
+    get log(): readonly ReconcilerLogEntry[] {
+      return log.map(({ stamp, command, patch }) => ({ stamp, command, patch }));
+    },
+
+    has(stamp: EntryStamp): boolean {
+      return hasStamp(stamp);
+    },
+
+    advanceLocal(runtimeId: string, authored: AuthoredEntry): EntryStamp {
+      const stamp: EntryStamp = {
+        seq: clock + 1,
+        runtimeId,
+        counter: vectorOf(runtimeId) + 1,
+      };
+      advanceClock(stamp.seq);
+      const now = Date.now();
+      const entry: StoredLogEntry = {
+        stamp,
+        command: authored.command,
+        patch: [...authored.patch],
+        inverse: [...authored.inverse],
+        appliedAt: now,
+      };
+      appendOrInsert(entry, log.length, true);
       return stamp;
     },
 
     tryAdopt(incoming: SyncStamp, state: Record<string, unknown>): boolean {
+      advanceClock(incoming.version);
       if (!isNewer(incoming, localStamp)) {
         return false;
       }
 
       localStamp = { version: incoming.version, runtimeId: incoming.runtimeId };
+      snapshotSeq = incoming.version;
+      logKeys.clear();
+      log.length = 0;
+      truncated = false;
       setState((current) => applyStatePatch(current, state, { preserveMissingKeys: false }));
 
       return true;
@@ -212,20 +447,55 @@ export function createSnapshotReconciler(options: {
       const { serviceId, stamp, command, patch } = incoming;
       const key = entryStampKey(stamp);
 
-      if (seen.has(key) || stamp.counter <= vectorOf(stamp.runtimeId)) {
+      advanceClock(stamp.seq);
+
+      if (
+        hasStamp(stamp) ||
+        stamp.counter <= vectorOf(stamp.runtimeId) ||
+        stamp.seq <= snapshotSeq
+      ) {
         return false;
       }
 
+      // log[0] is a window floor only after eviction; until then an earlier stamp inserts at 0.
+      if (truncated && log.length > 0 && compareStamps(stamp, log[0].stamp) < 0) {
+        logger.warn(
+          `Open-service sync: entry beyond the log window. service=${serviceId} stamps=${key},${entryStampKey(log[0].stamp)} paths=${patchPaths(patch)} command=${command}`
+        );
+        return false;
+      }
+
+      const gap = stamp.counter > vectorOf(stamp.runtimeId) + 1;
+      const index = insertIndexFor(stamp);
+      if (index < log.length && compareStamps(log[index].stamp, stamp) === 0) {
+        return false;
+      }
+
+      const now = Date.now();
       let failedPath: string | undefined;
+      let stored: StoredLogEntry | undefined;
+
       setState((current) => {
-        const result = applyJsonPatch(current, patch, (path) => {
+        const isLater = index === log.length;
+        const undone = isLater ? [] : undoToIndex(current, index, serviceId);
+        const result = applyOps(current, patch, (path) => {
           logger.debug(
             `Open-service sync: remove of missing key. service=${serviceId} stamp=${key} path=${path} command=${command}`
           );
         });
         if (!result.ok) {
           failedPath = result.path;
+          redoUndone(current, undone, serviceId);
+          return;
         }
+        stored = {
+          stamp,
+          command,
+          patch: [...patch],
+          inverse: result.inverse,
+          appliedAt: now,
+        };
+        redoUndone(current, undone, serviceId);
       });
 
       if (failedPath !== undefined) {
@@ -235,7 +505,11 @@ export function createSnapshotReconciler(options: {
         return false;
       }
 
-      recordAccepted(stamp);
+      if (!stored) {
+        return false;
+      }
+
+      appendOrInsert(stored, index, !gap);
       return true;
     },
   };

--- a/code/core/src/shared/open-service/service-transport-leaf.test.ts
+++ b/code/core/src/shared/open-service/service-transport-leaf.test.ts
@@ -20,11 +20,11 @@ function peerEntry(
   patch: Array<
     { op: 'add' | 'replace'; path: string; value: unknown } | { op: 'remove'; path: string }
   >,
-  stamp: { runtimeId: string; counter: number }
+  stamp: { runtimeId: string; counter: number; seq?: number }
 ) {
   return {
     serviceId,
-    stamp,
+    stamp: { seq: stamp.seq ?? stamp.counter, runtimeId: stamp.runtimeId, counter: stamp.counter },
     command: 'assignRecordField',
     patch,
   };
@@ -162,7 +162,7 @@ describe('channel: entry apply', () => {
     });
   });
 
-  it('applies same-path writes in arrival order', async () => {
+  it('applies same-path writes in canonical stamp order, not arrival order', async () => {
     const channel = createMockChannel();
     installChannel(channel);
 
@@ -172,16 +172,16 @@ describe('channel: entry apply', () => {
       SERVICE_ENTRY,
       peerEntry(
         mutableRecordLookupServiceDef.id,
-        [{ op: 'add', path: '/item', value: { color: 'red' } }],
-        { runtimeId: 'aaa', counter: 1 }
+        [{ op: 'add', path: '/item', value: { color: 'blue' } }],
+        { runtimeId: 'zzz', counter: 1, seq: 1 }
       )
     );
     channel.emitExternal(
       SERVICE_ENTRY,
       peerEntry(
         mutableRecordLookupServiceDef.id,
-        [{ op: 'replace', path: '/item', value: { color: 'blue' } }],
-        { runtimeId: 'zzz', counter: 1 }
+        [{ op: 'replace', path: '/item', value: { color: 'red' } }],
+        { runtimeId: 'aaa', counter: 1, seq: 1 }
       )
     );
 
@@ -295,7 +295,7 @@ describe('channel: untrusted payloads', () => {
     expect(() =>
       channel.emitExternal(SERVICE_ENTRY, {
         serviceId: mutableRecordLookupServiceDef.id,
-        stamp: { runtimeId: 'attacker', counter: 1 },
+        stamp: { seq: 1, runtimeId: 'attacker', counter: 1 },
         command: 'assignRecordField',
         patch: [
           { op: 'add', path: '/good', value: { k: 'v' } },

--- a/code/core/src/shared/open-service/service-transport.ts
+++ b/code/core/src/shared/open-service/service-transport.ts
@@ -133,13 +133,17 @@ export function wrapCommandsForBroadcast(
       async (input: unknown): Promise<unknown> => {
         const collector = createPatchCollector();
         const result = await cmd(input, collector);
-        const ops = collector.flush();
+        const { ops, inverse } = collector.flushRecorded();
 
         if (ops.length === 0) {
           return result;
         }
 
-        const stamp = reconciler.advanceLocal(ownRuntimeId);
+        const stamp = reconciler.advanceLocal(ownRuntimeId, {
+          command: name,
+          patch: ops,
+          inverse,
+        });
         channel.emit(SERVICE_ENTRY, {
           serviceId,
           stamp,

--- a/code/core/src/shared/open-service/sync-simulation.test.ts
+++ b/code/core/src/shared/open-service/sync-simulation.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { logger } from 'storybook/internal/client-logger';
+
+import { entryStampKey, SERVICE_ENTRY } from './service-channel.ts';
+import { compareStamps } from './service-sync.ts';
+import { createWorld, topologies, type TopologyKind, type World } from './sync-simulation/world.ts';
+
+vi.mock('storybook/internal/client-logger', { spy: true });
+
+const formatWorld = (world: World) =>
+  `topology=${world.topology.name} replicas=${world.replicas.map((replica) => replica.id).join(',')}`;
+
+const drain = vi.defineHelper((world: World): void => {
+  world.network.drain();
+});
+
+const assertReplicasAgree = vi.defineHelper((world: World): void => {
+  const expected = world.replicas[0];
+  const expectedLog = expected.reconciler.log.map((entry) => entryStampKey(entry.stamp));
+
+  for (const replica of world.replicas) {
+    expect(replica.getState(), `State differs on ${replica.id}. ${formatWorld(world)}`).toEqual(
+      expected.getState()
+    );
+    expect(
+      replica.reconciler.log.map((entry) => entryStampKey(entry.stamp)),
+      `Log differs on ${replica.id}. ${formatWorld(world)}`
+    ).toEqual(expectedLog);
+    expect(
+      replica.reconciler.vector,
+      `Vector differs on ${replica.id}. ${formatWorld(world)}`
+    ).toEqual(expected.reconciler.vector);
+    expect(replica.reconciler.clock, `Clock differs on ${replica.id}. ${formatWorld(world)}`).toBe(
+      expected.reconciler.clock
+    );
+
+    for (let index = 1; index < replica.reconciler.log.length; index += 1) {
+      expect(
+        compareStamps(replica.reconciler.log[index - 1].stamp, replica.reconciler.log[index].stamp),
+        `Log is unordered on ${replica.id}. ${formatWorld(world)}`
+      ).toBeLessThan(0);
+    }
+  }
+});
+
+const assertRelayTermination = vi.defineHelper((world: World): void => {
+  for (const replica of world.replicas) {
+    if (!replica.relay) {
+      continue;
+    }
+    for (const [key, count] of replica.entryEmits) {
+      expect(
+        count,
+        `Hub ${replica.id} emitted stamp ${key} ${count} times. ${formatWorld(world)}`
+      ).toBeLessThanOrEqual(1);
+    }
+  }
+});
+
+const settle = vi.defineHelper((world: World): void => {
+  drain(world);
+  assertReplicasAgree(world);
+});
+
+describe('open-service sync simulation', () => {
+  let world: World | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(logger.debug).mockReset();
+    vi.mocked(logger.warn).mockReset();
+    vi.mocked(logger.debug).mockImplementation(() => undefined);
+    vi.mocked(logger.warn).mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    world?.disconnect();
+    world = undefined;
+    vi.useRealTimers();
+  });
+
+  function boot(kind: TopologyKind): World {
+    world = createWorld(topologies[kind]);
+    drain(world);
+    return world;
+  }
+
+  it('advances Lamport time after receiving before authoring', async () => {
+    const current = boot('dev-triangle');
+    await current.replica('manager').commands.setSlot({ slot: 'a', value: '1' });
+    drain(current);
+    const before = current.replica('server').subscriberNotifications;
+
+    await current.replica('preview').commands.setSlot({ slot: 'b', value: '2' });
+    settle(current);
+
+    expect(current.replica('preview').authored.at(-1)?.seq).toBe(2);
+    expect(current.replica('server').getState().slots).toEqual({ a: '1', b: '2' });
+    expect(current.replica('server').subscriberNotifications - before).toBe(1);
+  });
+
+  it('drops a duplicate echo and still converges', async () => {
+    const current = boot('dev-triangle');
+    current.network.duplicateNext('preview', 'manager');
+    await current.replica('preview').commands.setSlot({ slot: 'a', value: '1' });
+    settle(current);
+    assertRelayTermination(current);
+  });
+
+  it('places a gap then the skipped earlier counter without warning', async () => {
+    const current = boot('dev-triangle');
+    current.network.setDelay('server', 'manager', 20);
+    current.network.dropNext('preview', 'manager');
+    await current.replica('preview').commands.setSlot({ slot: 'a', value: '1' });
+    await current.replica('preview').commands.setSlot({ slot: 'b', value: '2' });
+    settle(current);
+    expect(current.replica('manager').getState().slots).toEqual({ a: '1', b: '2' });
+    expect(vi.mocked(logger.warn)).not.toHaveBeenCalled();
+  });
+
+  it('undoes through a burst past 256 when a concurrent write is placed earlier', async () => {
+    const current = boot('production-fan');
+    current.network.setDelay('p1', 'manager', 5);
+    const burst = Promise.all(
+      Array.from({ length: 260 }, (_, index) =>
+        current.replica('p1').commands.setSlot({ slot: `b${index}`, value: `${index}` })
+      )
+    );
+    const concurrent = current.replica('p2').commands.setSlot({ slot: 'other', value: 'x' });
+    await burst;
+    await concurrent;
+    settle(current);
+    expect(current.replica('manager').getState().slots.other).toBe('x');
+    expect(Object.keys(current.replica('p2').getState().slots)).toHaveLength(261);
+  });
+
+  it('rolls back a missing parent and warns with service, stamp, path, and command', async () => {
+    const current = boot('production-fan');
+    await current.replica('p1').commands.addParent({ parent: 'p' });
+    drain(current);
+    current.network.dropNext('manager', 'p2');
+    await current.replica('p1').commands.addParent({ parent: 'q' });
+    drain(current);
+    await current.replica('p1').commands.setNested({ parent: 'q', key: 'k', value: 'v' });
+    drain(current);
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(expect.stringContaining('missing parent'));
+    expect(vi.mocked(logger.warn).mock.calls[0]?.[0]).toContain('command=setNested');
+    expect(current.replica('p2').getState().nest.q).toBeUndefined();
+  });
+
+  it('attributes two overlapping local commands to separate entries', async () => {
+    const current = boot('dev-triangle');
+    const slow = current.replica('preview').commands.holdThenSetSlot({
+      slot: 'slow',
+      value: 'S',
+      holdMs: 10,
+    });
+    const fast = current.replica('preview').commands.holdThenSetSlot({
+      slot: 'fast',
+      value: 'F',
+      holdMs: 5,
+    });
+    await vi.advanceTimersByTimeAsync(5);
+    await fast;
+    await vi.advanceTimersByTimeAsync(5);
+    await slow;
+    settle(current);
+    expect(current.replica('preview').authored).toHaveLength(2);
+    expect(current.replica('server').getState().slots).toEqual({ fast: 'F', slow: 'S' });
+  });
+
+  it('does not emit one stamp twice from a hub on two tabs', async () => {
+    const current = boot('two-tabs');
+    await current.replica('pa').commands.setSlot({ slot: 'a', value: '1' });
+    settle(current);
+    assertRelayTermination(current);
+    expect(current.replica('pb').getState().slots).toEqual({ a: '1' });
+  });
+
+  it('keeps entry frames within a small constant of the first and does not structuredClone on the entry path', async () => {
+    const current = boot('dev-triangle');
+    vi.spyOn(globalThis, 'structuredClone');
+    const cloneSpy = vi.mocked(globalThis.structuredClone);
+    cloneSpy.mockClear();
+    current.network.frames.length = 0;
+
+    for (let index = 0; index < 20; index += 1) {
+      await current.replica('preview').commands.setSlot({
+        slot: `s${index}`,
+        value: 'v'.repeat(40),
+      });
+    }
+    drain(current);
+
+    const entryFrames = current.network.frames.filter((frame) => frame.type === SERVICE_ENTRY);
+    expect(entryFrames.length).toBeGreaterThan(0);
+    const first = entryFrames[0].bytes;
+    for (const frame of entryFrames) {
+      expect(frame.bytes).toBeLessThan(first + 80);
+    }
+    expect(cloneSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { kind: 'dev-triangle', earlier: 'manager', later: 'preview' },
+    { kind: 'production-fan', earlier: 'p1', later: 'p2' },
+    { kind: 'two-tabs', earlier: 'pa', later: 'pb' },
+  ] as const)('orders concurrent same-path writes on $kind', async ({ kind, earlier, later }) => {
+    const current = boot(kind);
+    await current.replica(earlier).commands.setSlot({ slot: 'shared', value: earlier });
+    await current.replica(later).commands.setSlot({ slot: 'shared', value: later });
+
+    expect(current.replica(earlier).authored[0]?.seq).toBe(1);
+    expect(current.replica(later).authored[0]?.seq).toBe(1);
+    settle(current);
+
+    expect(current.replica(earlier).getState().slots.shared).toBe(later);
+    assertRelayTermination(current);
+  });
+});

--- a/code/core/src/shared/open-service/sync-simulation/network.ts
+++ b/code/core/src/shared/open-service/sync-simulation/network.ts
@@ -1,0 +1,162 @@
+import { Channel } from '../../../channels/main.ts';
+import type { ChannelEvent, ChannelTransport } from '../../../channels/types.ts';
+
+export type NodeId = string;
+
+export type WireFrame = {
+  from: NodeId;
+  to: NodeId;
+  type: string;
+  bytes: number;
+  payload: unknown;
+};
+
+type DirectedLink = {
+  from: NodeId;
+  to: NodeId;
+  delayMs: number;
+  availableAt: number;
+  dropNext: number;
+  duplicateNext: number;
+};
+
+type Delivery = {
+  at: number;
+  order: number;
+  link: DirectedLink;
+  event: ChannelEvent;
+};
+
+function directedKey(from: NodeId, to: NodeId): string {
+  return `${from}->${to}`;
+}
+
+function undirectedKey(a: NodeId, b: NodeId): string {
+  return a < b ? `${a}|${b}` : `${b}|${a}`;
+}
+
+export class VirtualNetwork {
+  readonly frames: WireFrame[] = [];
+  private readonly channels = new Map<NodeId, Channel>();
+  private readonly links = new Map<string, DirectedLink>();
+  private readonly deliveries: Delivery[] = [];
+  private now = 0;
+  private order = 0;
+
+  constructor(nodes: readonly NodeId[], edges: ReadonlyArray<readonly [NodeId, NodeId]>) {
+    const incident = new Map<NodeId, NodeId[]>();
+    for (const id of nodes) {
+      incident.set(id, []);
+    }
+    for (const [left, right] of edges) {
+      incident.get(left)?.push(right);
+      incident.get(right)?.push(left);
+      this.links.set(directedKey(left, right), this.createLink(left, right));
+      this.links.set(directedKey(right, left), this.createLink(right, left));
+    }
+
+    for (const id of nodes) {
+      const peers = incident.get(id) ?? [];
+      const transports: ChannelTransport[] = peers.map((peer) => this.createTransport(id, peer));
+      this.channels.set(id, new Channel({ transports }));
+    }
+  }
+
+  channel(id: NodeId): Channel {
+    const channel = this.channels.get(id);
+    if (!channel) {
+      throw new Error(`Unknown network node ${id}`);
+    }
+    return channel;
+  }
+
+  setDelay(a: NodeId, b: NodeId, delayMs: number): void {
+    const forward = this.links.get(directedKey(a, b));
+    const back = this.links.get(directedKey(b, a));
+    if (!forward || !back) {
+      throw new Error(`No link ${undirectedKey(a, b)}`);
+    }
+    forward.delayMs = delayMs;
+    back.delayMs = delayMs;
+  }
+
+  dropNext(from: NodeId, to: NodeId, count = 1): void {
+    this.link(from, to).dropNext += count;
+  }
+
+  duplicateNext(from: NodeId, to: NodeId, count = 1): void {
+    this.link(from, to).duplicateNext += count;
+  }
+
+  drain(): void {
+    let steps = 0;
+    while (this.deliveries.length > 0) {
+      steps += 1;
+      if (steps > 10_000) {
+        throw new Error('VirtualNetwork drain exceeded 10000 steps');
+      }
+      this.deliverNext();
+    }
+  }
+
+  private createLink(from: NodeId, to: NodeId): DirectedLink {
+    return {
+      from,
+      to,
+      delayMs: 0,
+      availableAt: 0,
+      dropNext: 0,
+      duplicateNext: 0,
+    };
+  }
+
+  private link(from: NodeId, to: NodeId): DirectedLink {
+    const link = this.links.get(directedKey(from, to));
+    if (!link) {
+      throw new Error(`No directed link ${directedKey(from, to)}`);
+    }
+    return link;
+  }
+
+  private createTransport(from: NodeId, to: NodeId): ChannelTransport {
+    return {
+      setHandler: () => undefined,
+      send: (event) => {
+        this.enqueue(from, to, event);
+      },
+    };
+  }
+
+  private enqueue(from: NodeId, to: NodeId, event: ChannelEvent): void {
+    const link = this.link(from, to);
+    if (link.dropNext > 0) {
+      link.dropNext -= 1;
+      return;
+    }
+    const copies = 1 + link.duplicateNext;
+    link.duplicateNext = 0;
+    for (let index = 0; index < copies; index += 1) {
+      const at = Math.max(this.now, link.availableAt) + link.delayMs;
+      link.availableAt = at;
+      this.deliveries.push({ at, order: this.order, link, event });
+      this.order += 1;
+    }
+  }
+
+  private deliverNext(): void {
+    this.deliveries.sort((left, right) => left.at - right.at || left.order - right.order);
+    const delivery = this.deliveries.shift();
+    if (!delivery) {
+      return;
+    }
+    this.now = delivery.at;
+    this.frames.push({
+      from: delivery.link.from,
+      to: delivery.link.to,
+      type: delivery.event.type,
+      bytes: JSON.stringify(delivery.event).length,
+      payload: delivery.event.args[0],
+    });
+    this.channels.get(delivery.link.to)?.receive(delivery.event);
+  }
+}

--- a/code/core/src/shared/open-service/sync-simulation/replicas.ts
+++ b/code/core/src/shared/open-service/sync-simulation/replicas.ts
@@ -1,0 +1,177 @@
+import * as v from 'valibot';
+
+import type { Channel } from '../../../channels/main.ts';
+import { defineService } from '../service-definition.ts';
+import { SERVICE_ENTRY, type EntryPayload } from '../service-channel.ts';
+import { createServiceRuntime } from '../service-runtime.ts';
+import {
+  createSnapshotReconciler,
+  type LogWindow,
+  type SnapshotReconciler,
+} from '../service-sync.ts';
+import { connectServiceToChannel } from '../service-transport.ts';
+import { serviceRegistryApi } from '../service-registry.ts';
+import type { NodeId, VirtualNetwork } from './network.ts';
+
+export type SimState = {
+  slots: Record<string, string>;
+  nest: Record<string, Record<string, string>>;
+};
+
+export const simServiceDef = defineService({
+  id: 'internal-fixture/osa-sim',
+  description: 'Harness service for open-service sync simulation.',
+  initialState: {
+    slots: {} as Record<string, string>,
+    nest: {} as Record<string, Record<string, string>>,
+  } satisfies SimState,
+  queries: {
+    snapshot: {
+      description: 'Full harness state.',
+      input: v.void(),
+      output: v.object({
+        slots: v.record(v.string(), v.string()),
+        nest: v.record(v.string(), v.record(v.string(), v.string())),
+      }),
+      handler: (_input, ctx) => ({
+        slots: { ...ctx.self.state.slots },
+        nest: Object.fromEntries(
+          Object.entries(ctx.self.state.nest).map(([key, value]) => [key, { ...value }])
+        ),
+      }),
+    },
+  },
+  commands: {
+    setSlot: {
+      description: 'Writes one slot.',
+      input: v.object({ slot: v.string(), value: v.string() }),
+      output: v.void(),
+      handler: async (input, ctx) => {
+        ctx.self.setState((state) => {
+          state.slots[input.slot] = input.value;
+        });
+      },
+    },
+    setNested: {
+      description: 'Writes a nested key. The parent object must already exist.',
+      input: v.object({ parent: v.string(), key: v.string(), value: v.string() }),
+      output: v.void(),
+      handler: async (input, ctx) => {
+        ctx.self.setState((state) => {
+          state.nest[input.parent][input.key] = input.value;
+        });
+      },
+    },
+    addParent: {
+      description: 'Creates an empty nested parent object.',
+      input: v.object({ parent: v.string() }),
+      output: v.void(),
+      handler: async (input, ctx) => {
+        ctx.self.setState((state) => {
+          state.nest[input.parent] = {};
+        });
+      },
+    },
+    holdThenSetSlot: {
+      description: 'Waits holdMs, then writes a slot. For overlapping local commands.',
+      input: v.object({ slot: v.string(), value: v.string(), holdMs: v.number() }),
+      output: v.void(),
+      handler: async (input, ctx) => {
+        if (input.holdMs > 0) {
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, input.holdMs);
+          });
+        }
+        ctx.self.setState((state) => {
+          state.slots[input.slot] = input.value;
+        });
+      },
+    },
+  },
+});
+
+export type Replica = {
+  id: NodeId;
+  relay: boolean;
+  runtimeId: string;
+  reconciler: SnapshotReconciler;
+  commands: ReturnType<typeof connectServiceToChannel>['commands'];
+  getState: () => SimState;
+  disconnect: () => void;
+  authored: EntryPayload['stamp'][];
+  entryEmits: Map<string, number>;
+  subscriberNotifications: number;
+};
+
+export function attachReplica(options: {
+  network: VirtualNetwork;
+  id: NodeId;
+  relay: boolean;
+  window?: Partial<LogWindow>;
+}): Replica {
+  const { network, id, relay, window } = options;
+  const channel: Channel = network.channel(id);
+  const runtimeId = id;
+  const runtime = createServiceRuntime(
+    simServiceDef,
+    { registryApi: serviceRegistryApi },
+    structuredClone(simServiceDef.initialState)
+  );
+
+  const reconciler = createSnapshotReconciler({
+    setState: (mutate) =>
+      runtime.commandSelf.setState((state) => mutate(state as Record<string, unknown>)),
+    initialStamp: { version: 0, runtimeId },
+    window,
+  });
+
+  const commandNames = Object.keys(simServiceDef.commands);
+  const { commands, disconnect } = connectServiceToChannel({
+    serviceId: simServiceDef.id,
+    ownRuntimeId: runtimeId,
+    reconciler,
+    getSnapshot: () => runtime.getStateSnapshot() as Record<string, unknown>,
+    channel,
+    relay,
+    commands: runtime.commands as Record<string, (input: unknown) => Promise<unknown>>,
+    implementedCommandNames: new Set(commandNames),
+    commandNames,
+    delegated: false,
+    runtime,
+  });
+
+  const authored: Replica['authored'] = [];
+  const entryEmits = new Map<string, number>();
+  const originalEmit = channel.emit.bind(channel);
+  channel.emit = ((eventName: string, ...args: unknown[]) => {
+    if (eventName === SERVICE_ENTRY) {
+      const payload = args[0] as EntryPayload;
+      const key = `${payload.stamp.seq}:${payload.stamp.runtimeId}:${payload.stamp.counter}`;
+      entryEmits.set(key, (entryEmits.get(key) ?? 0) + 1);
+      if (payload.stamp.runtimeId === runtimeId) {
+        authored.push(payload.stamp);
+      }
+    }
+    return originalEmit(eventName, ...args);
+  }) as Channel['emit'];
+
+  let subscriberNotifications = 0;
+  runtime.queries.snapshot.subscribe(undefined, () => {
+    subscriberNotifications += 1;
+  });
+
+  return {
+    id,
+    relay,
+    runtimeId,
+    reconciler,
+    commands,
+    getState: () => runtime.getStateSnapshot(),
+    disconnect,
+    authored,
+    entryEmits,
+    get subscriberNotifications() {
+      return subscriberNotifications;
+    },
+  };
+}

--- a/code/core/src/shared/open-service/sync-simulation/world.ts
+++ b/code/core/src/shared/open-service/sync-simulation/world.ts
@@ -1,0 +1,93 @@
+import { attachReplica, type Replica } from './replicas.ts';
+import { VirtualNetwork, type NodeId } from './network.ts';
+
+export type TopologyKind = 'dev-triangle' | 'production-fan' | 'two-tabs';
+
+type Topology = {
+  name: TopologyKind;
+  nodes: Array<{ id: NodeId; relay: boolean }>;
+  edges: Array<readonly [NodeId, NodeId]>;
+};
+
+export const topologies: Record<TopologyKind, Topology> = {
+  'dev-triangle': {
+    name: 'dev-triangle',
+    nodes: [
+      { id: 'server', relay: true },
+      { id: 'manager', relay: true },
+      { id: 'preview', relay: false },
+    ],
+    edges: [
+      ['server', 'manager'],
+      ['server', 'preview'],
+      ['manager', 'preview'],
+    ],
+  },
+  'production-fan': {
+    name: 'production-fan',
+    nodes: [
+      { id: 'manager', relay: true },
+      { id: 'p1', relay: false },
+      { id: 'p2', relay: false },
+    ],
+    edges: [
+      ['manager', 'p1'],
+      ['manager', 'p2'],
+    ],
+  },
+  'two-tabs': {
+    name: 'two-tabs',
+    nodes: [
+      { id: 'server', relay: true },
+      { id: 'ma', relay: true },
+      { id: 'pa', relay: false },
+      { id: 'mb', relay: true },
+      { id: 'pb', relay: false },
+    ],
+    edges: [
+      ['server', 'ma'],
+      ['server', 'pa'],
+      ['ma', 'pa'],
+      ['server', 'mb'],
+      ['server', 'pb'],
+      ['mb', 'pb'],
+    ],
+  },
+};
+
+export type World = {
+  topology: Topology;
+  network: VirtualNetwork;
+  replicas: Replica[];
+  replica: (id: NodeId) => Replica;
+  disconnect: () => void;
+};
+
+export function createWorld(topology: Topology): World {
+  const network = new VirtualNetwork(
+    topology.nodes.map((node) => node.id),
+    topology.edges
+  );
+  const replicas = topology.nodes.map((node) =>
+    attachReplica({ network, id: node.id, relay: node.relay })
+  );
+  const byId = new Map(replicas.map((replica) => [replica.id, replica]));
+
+  return {
+    topology,
+    network,
+    replicas,
+    replica: (id) => {
+      const replica = byId.get(id);
+      if (!replica) {
+        throw new Error(`Unknown replica ${id}`);
+      }
+      return replica;
+    },
+    disconnect: () => {
+      for (const replica of replicas) {
+        replica.disconnect();
+      }
+    },
+  };
+}

--- a/code/e2e-internal/open-service-sync.spec.ts
+++ b/code/e2e-internal/open-service-sync.spec.ts
@@ -8,6 +8,10 @@ import { PREVIEW_STORY_TIMEOUT, waitForPreviewReady } from './helpers.ts';
  *
  * Validates local command execution, remote command execution, static JSON loading, unhandled remote
  * commands in static builds, manager/preview sync, dev-server reload bootstrap, and cross-tab relay.
+ *
+ * The two-tab concurrent block sets retries to 0: a passing retry would hide a broken hold. Writes are
+ * forced concurrent by holding outbound `services:entry` frames, so a failure is a protocol bug, not
+ * a timing flake.
  */
 
 /** Internal Storybook UI (`code/.storybook`) — not a sandbox template. */
@@ -28,6 +32,107 @@ async function gotoOpenServiceStory(page: Page, storyPath: string) {
   await page.goto(`${storybookUrl}/?path=/story/${storyPath}`);
   await waitForPreviewReady(page);
   await openOpenServicePanel(page);
+}
+
+function readEntrySeq(message: string | Buffer): number | undefined {
+  const text = typeof message === 'string' ? message : message.toString('utf8');
+  try {
+    const event = JSON.parse(text) as {
+      type?: string;
+      args?: Array<{ stamp?: { seq?: number } }>;
+    };
+    if (event.type !== 'services:entry') {
+      return undefined;
+    }
+    const seq = event.args?.[0]?.stamp?.seq;
+    return typeof seq === 'number' ? seq : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+type EntryHold = {
+  arm: () => void;
+  release: () => void;
+  seqs: () => number[];
+};
+
+// Playwright sits between each tab's manager and the Storybook server websocket
+// (`storybook-server-channel`). Manager and preview in a tab talk over postMessage;
+// only the manager's socket carries `services:entry` to the hub.
+//
+// The hold queues those outbound entry frames instead of forwarding them. Local
+// apply and stamping still happen, so each tab authors `seq = clock + 1` without
+// seeing the other tab's write. Equal seq after both clicks is the proof the
+// writes were concurrent. If the hold leaked, the second author would usually
+// stamp seq 2.
+//
+// Register the route before `goto`: Playwright only wraps sockets opened after
+// `routeWebSocket`. Leave it idle until `arm()` so bootstrap and registration
+// traffic is not queued. Hold only frames that parse as `services:entry`;
+// everything else on this socket (`setCurrentStory`, `stories`, …) must pass or
+// the UI never loads. Incoming server→page frames are not held, so after
+// `release()` the hub can fan placed entries back immediately.
+async function holdOutboundEntries(page: Page): Promise<EntryHold> {
+  let holding = false;
+  const held: Array<{ send: (message: string | Buffer) => void; message: string | Buffer }> = [];
+
+  await page.routeWebSocket(/storybook-server-channel/, (ws) => {
+    const server = ws.connectToServer();
+    ws.onMessage((message) => {
+      if (holding && readEntrySeq(message) !== undefined) {
+        held.push({ send: (payload) => server.send(payload), message });
+        return;
+      }
+      server.send(message);
+    });
+  });
+
+  return {
+    arm: () => {
+      holding = true;
+      held.length = 0;
+    },
+    release: () => {
+      holding = false;
+      const pending = held.splice(0, held.length);
+      for (const item of pending) {
+        item.send(item.message);
+      }
+    },
+    seqs: () =>
+      held
+        .map((item) => readEntrySeq(item.message))
+        .filter((seq): seq is number => seq !== undefined),
+  };
+}
+
+function concurrentWritesControls(page: Page) {
+  const story = page.frameLocator('#storybook-preview-iframe');
+  return {
+    panelSlot: page.getByRole('textbox', {
+      name: 'Concurrent writes manager panel slot input',
+    }),
+    panelValue: page.getByRole('textbox', {
+      name: 'Concurrent writes manager panel value input',
+    }),
+    panelWrite: page.getByRole('button', { name: 'Concurrent writes manager panel write' }),
+    panelClear: page.getByRole('button', {
+      name: 'Concurrent writes manager panel clear slots',
+    }),
+    panelRaw: page.getByTestId('concurrent-writes-manager-panel-raw-service-state-slots'),
+    storyRaw: story.getByTestId('concurrent-writes-raw-service-state-slots'),
+  };
+}
+
+// Manager panel and preview iframe subscribe separately and can lag. Poll the
+// raw JSON text until it matches, rather than reading once after release.
+async function expectSlots(raw: ReturnType<Page['getByTestId']>, expected: Record<string, string>) {
+  await expect
+    .poll(async () => JSON.parse((await raw.textContent()) ?? '{}') as Record<string, string>, {
+      timeout: 10_000,
+    })
+    .toStrictEqual(expected);
 }
 
 test.describe('open-service sync example', () => {
@@ -363,8 +468,6 @@ test.describe('open-service sync example', () => {
     });
   });
 
-  // TODO(SB-2051): writes here are sequential. Overlapping two-tab writes land with the ordered
-  // log; this check only proves both slots survive when written one after the other.
   test('concurrent writes land sequentially in the panel and the story', async ({ page }) => {
     await gotoOpenServiceStory(
       page,
@@ -416,6 +519,141 @@ test.describe('open-service sync example', () => {
       await expect(panelRaw).toHaveText('{}');
       await expect(storyRaw).toHaveText('{}');
     }
+  });
+
+  // Forced-concurrency check for ordered-log placement. Without the websocket hold
+  // the hub is fast enough that tab B often observes tab A's write before B
+  // authors, so the test would only cover sequential seq 1 then 2. A passing
+  // retry can hide a broken hold (writes serialize by luck), so retries stay 0.
+  test.describe('two-tab concurrent writes', () => {
+    test.describe.configure({ retries: 0, mode: 'serial' });
+
+    test('keeps both keys and the same seq when two tabs write under a hold', async ({
+      page,
+      context,
+    }) => {
+      test.skip(
+        !runsAgainstDevServer,
+        'Cross-tab concurrency requires the dev-server relay channel.'
+      );
+
+      const otherPage = await context.newPage();
+      // Route before goto so the storybook-server-channel socket is proxied.
+      const firstHold = await holdOutboundEntries(page);
+      const secondHold = await holdOutboundEntries(otherPage);
+
+      try {
+        await gotoOpenServiceStory(
+          page,
+          'core-shared-open-service-sync-test-concurrent-writes--concurrent-writes-sync'
+        );
+        await gotoOpenServiceStory(
+          otherPage,
+          'core-shared-open-service-sync-test-concurrent-writes--concurrent-writes-sync'
+        );
+
+        const first = concurrentWritesControls(page);
+        const second = concurrentWritesControls(otherPage);
+
+        await expect(first.panelSlot).toBeVisible({ timeout: STORY_READY_TIMEOUT });
+        await expect(second.panelSlot).toBeVisible({ timeout: STORY_READY_TIMEOUT });
+
+        try {
+          await first.panelClear.click();
+          await expect(first.panelRaw).toHaveText('{}', { timeout: 10_000 });
+          await expect(second.panelRaw).toHaveText('{}', { timeout: 10_000 });
+
+          // Three rounds so one lucky delivery order does not pass the suite.
+          for (let round = 0; round < 3; round += 1) {
+            // Fresh keys: clear is a replicated command. Reusing a slot while a
+            // slow clear is in flight looks like a lost write.
+            const leftSlot = `left-${round}-${Date.now()}`;
+            const rightSlot = `right-${round}-${Date.now()}`;
+            const leftValue = `L${round}`;
+            const rightValue = `R${round}`;
+
+            firstHold.arm();
+            secondHold.arm();
+
+            await first.panelSlot.fill(leftSlot);
+            await first.panelValue.fill(leftValue);
+            await first.panelWrite.click();
+            await second.panelSlot.fill(rightSlot);
+            await second.panelValue.fill(rightValue);
+            await second.panelWrite.click();
+
+            // Compare seq while frames are still queued. After release the hub
+            // places both entries and fans them back; seqs() then goes empty.
+            await expect.poll(() => firstHold.seqs().length).toBe(1);
+            await expect.poll(() => secondHold.seqs().length).toBe(1);
+            expect(firstHold.seqs()[0], 'equal seq proves the writes were concurrent').toBe(
+              secondHold.seqs()[0]
+            );
+
+            firstHold.release();
+            secondHold.release();
+
+            const expected = { [leftSlot]: leftValue, [rightSlot]: rightValue };
+            // Manager panel and preview iframe on each tab are four subscribers.
+            await expectSlots(first.panelRaw, expected);
+            await expectSlots(first.storyRaw, expected);
+            await expectSlots(second.panelRaw, expected);
+            await expectSlots(second.storyRaw, expected);
+
+            await first.panelClear.click();
+            await expectSlots(first.panelRaw, {});
+            await expectSlots(second.panelRaw, {});
+          }
+
+          // Same key, same seq: last-write-wins. Either value is correct; all
+          // four surfaces must show the same one.
+          const sharedSlot = `shared-${Date.now()}`;
+          firstHold.arm();
+          secondHold.arm();
+          await first.panelSlot.fill(sharedSlot);
+          await first.panelValue.fill('alpha');
+          await first.panelWrite.click();
+          await second.panelSlot.fill(sharedSlot);
+          await second.panelValue.fill('beta');
+          await second.panelWrite.click();
+          await expect.poll(() => firstHold.seqs().length).toBe(1);
+          await expect.poll(() => secondHold.seqs().length).toBe(1);
+          expect(firstHold.seqs()[0]).toBe(secondHold.seqs()[0]);
+          firstHold.release();
+          secondHold.release();
+
+          await expect
+            .poll(
+              async () => {
+                const surfaces = [first.panelRaw, first.storyRaw, second.panelRaw, second.storyRaw];
+                const values: Array<string | undefined> = [];
+                for (const raw of surfaces) {
+                  const slots = JSON.parse((await raw.textContent()) ?? '{}') as Record<
+                    string,
+                    string
+                  >;
+                  values.push(slots[sharedSlot]);
+                }
+                if (values.some((value) => value !== values[0])) {
+                  return undefined;
+                }
+                return values[0];
+              },
+              { timeout: 10_000 }
+            )
+            .toMatch(/^(alpha|beta)$/);
+        } finally {
+          // A failure mid-hold leaves frames queued; drain them so the next
+          // test does not wait on a socket that never forwards.
+          firstHold.release();
+          secondHold.release();
+          await first.panelClear.click();
+          await expectSlots(first.panelRaw, {});
+        }
+      } finally {
+        await otherPage.close();
+      }
+    });
   });
 
   test('static load reads prebuilt JSON and rejects unbacked commands in a static build', async ({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

Linear: [SB-2051](https://linear.app/chromaui/issue/SB-2051/pr-4-ordered-log-with-undo-and-redo-the-simulation-harness-and-the-e2e) (PR 4 of [SB-2054](https://linear.app/chromaui/issue/SB-2054)). Stacked on [PR 3](https://github.com/storybookjs/storybook/pull/36260). Label `ci: do not merge` until that PR lands.

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR changes the sync engine of open services to _place_ incoming patch changes in the correct order rather than just last-write-wins. It does that using the Log, Vector and a Lamport Clock (see ELI5 section below), and implements correct undo/redo of patches when necessary because of concurrent writes from multiple actors.

A big chunk of this PR is unit tests, integration tests (via a "world simulation") and e2e tests that runs two concurrent browser windows via Playwright. The How to review section is useful to focus only on the important parts.

**Not in this PR:** repairing broken state with full state `sync-request`. Failed undo/redo does not drop log entries

<details>
<summary><h2>ELI5: stamps, clock, vector, log</h2></summary>

Every runtime (server, manager, each preview tab) keeps a **notebook of edits**. That notebook is the **Log**. Each page is one **Entry**: the JSON patch, plus a small label so everyone can put pages in the same order and rewind when a late page shows up.

That label is the **stamp**. It has three fields, and they do different jobs.

```mermaid
flowchart LR
  stamp["Stamp"]
  stamp --> seq["seq: shared when"]
  stamp --> rid["runtimeId: who"]
  stamp --> ctr["counter: which of mine"]
```

- **`seq`** is the shared timeline. “This is change number 4 for this service.” On a local write, `seq = clock + 1`: one past the highest seq you have ever seen. Two tabs that have not heard of each other yet can both pick `seq = 1`. That is fine. Order then uses `runtimeId`.
- **`runtimeId`** is who wrote it. A new id per registration (tab reload = new person). If two entries share a `seq`, the one whose `runtimeId` is later as a plain string is later in the notebook. Same `seq`, different keys: both writes survive. Same `seq`, same key: the later `runtimeId` wins.
- **`counter`** is that writer’s own 1, 2, 3…. Alice’s third command is `counter = 3` even if the shared `seq` is 17. This is **not** used to sort. It answers: “Have I already applied Alice’s #3?” and “Did I miss Alice’s #2?”

So: **`seq` + `runtimeId` = order. `counter` = “did I miss a page from this person?”**

```mermaid
flowchart TB
  subgraph orderBox ["Order: one shared timeline"]
    seq2["seq first"]
    rid2["then runtimeId string compare"]
    seq2 --> rid2
  end
  subgraph memberBox ["This writer's pages"]
    ctr2["counter 1, 2, 3 with no holes"]
    vec["Vector: I have Alice through N"]
    ctr2 --> vec
  end
```

### Clock and Vector: two memories, not two more stamps

The **Clock** is one number: the highest `seq` you have heard of, including duplicates. Next local write uses `clock + 1`, so your new page sorts after history you already know. A reload must raise the Clock from the bootstrap snapshot, or the new tab writes `seq = 1` into a notebook that already has `seq = 3`.

The **Vector** is a map: “Alice 3, Bob 5” means you have Alice’s 1–3 and Bob’s 1–5 with **no holes**. If Alice’s #5 arrives before #4, you still **place** #5 (it has a `seq`, so you know where it goes), but you **do not** move Alice’s vector to 5. The hole stays until #4 shows up. That is a **gap**. This PR places the gap silently. A later PR will ask a peer for a snapshot to fill it.

```mermaid
flowchart LR
  clockMem["Clock: highest seq I have heard"]
  clockMem --> nextSeq["My next write is clock + 1"]
  vectorMem["Vector: per writer, contiguous counters"]
  vectorMem --> dupGap["Duplicates and gaps after the Log forgets"]
  logMem["Log: ordered pages plus inverses"]
  logMem --> rewind["Undo / redo when a late page lands in the middle"]
```

### Why `counter` exists

`seq` is a **shared** timeline. Alice writes, then Bob writes, then Alice writes again. Alice’s stamps might be `seq = 1` then `seq = 7`. The missing 2–6 are other people’s pages, not Alice skipping work. You cannot look at Alice’s `seq` values and ask “did I miss one of **hers**?”

`counter` is Alice’s private 1, 2, 3…. Her writes are always `counter = 1`, then `2`, then `3`, no matter what `seq` the Clock handed her.

```mermaid
flowchart TB
  subgraph aliceWrites ["Alice's three writes"]
    a1["counter 1  /  seq 1"]
    a2["counter 2  /  seq 4"]
    a3["counter 3  /  seq 7"]
    a1 --> a2 --> a3
  end
  others["seq 2, 3, 5, 6 are Bob and others"]
  a1 -.-> others
```

Without `counter` you would fake those checks with `seq`. Both fakes break:

- Treat “older `seq` from Alice” as a duplicate → you **drop a real delayed write** that sat in a hole (you already have her later `seq = 7`; her missing `seq = 4` is not a replay).
- Treat “not in the Log” as new → after the window evicts old pages, **echoes come back to life** and get applied or forwarded again.

The Vector never evicts. `counter` at or below Alice’s vector still means “I already applied that,” even when the Log has thrown the page away.

### What happens when a page arrives

Always bump the Clock from the incoming `seq` first.

```mermaid
flowchart TD
  inEntry["Incoming entry"] --> advClock["Advance Clock"]
  advClock --> dup{"Duplicate?"}
  dup -->|"in Log, or counter at or below Vector, or seq at or below snapshot"| dropNode["Drop. Do not forward"]
  dup -->|no| win{"Beyond window?"}
  win -->|truncated and stamp before oldest retained| warnDrop["Drop and warn"]
  win -->|no| place{"Where in the Log?"}
  place -->|after every retained entry| laterNode["Later: apply, store inverse, append"]
  place -->|before some retained entry| earlierNode["Earlier: undo newer, apply, redo"]
  laterNode --> gapQ{"Hole in this writer's counters?"}
  earlierNode --> gapQ
  gapQ -->|counter skips Vector + 1| gapNode["Place. Leave Vector stuck"]
  gapQ -->|no| vecNode["Place. Advance Vector"]
```

The hub **forwards** an entry only if it actually put it in its Log. Echoes and junk do not bounce forever.

**Earlier insert**, in one `setState` batch so subscribers see one jump:

```mermaid
sequenceDiagram
  participant Log
  participant State
  Note over Log,State: Log holds seq 2, n = 2
  Log->>State: undo seq 2 using stored inverse
  Note over State: n = 0
  Log->>State: apply delayed seq 1 extra = 1
  Log->>State: redo seq 2 from stored forward ops
  Note over Log,State: Log is seq 1 then 2. n = 2, extra = 1
```

### Snapshot, in one sentence

A **snapshot** is still the “here is the whole state” message for join/reload (last-write-wins). After this PR it also **throws away the old Log**. Those inverses belonged to a different story. Incoming `seq` at or below that snapshot’s `version` is treated as already inside the snapshot. The Vector stays, so you still recognize echoes. The fancy “keep my newer local writes while installing a peer’s snapshot” step is the **next** PR (a **Frontier**: Vector + Clock on the wire).

### Tiny story

```mermaid
sequenceDiagram
  participant A as Tab A
  participant B as Tab B
  A->>A: write left = L at seq 1
  B->>B: write right = R at seq 1
  A->>B: entry for left
  B->>A: entry for right
  Note over A,B: Both hold left and right. Same seq, different keys, both survive.
```

If B’s `R` then arrives at A **after** A already applied something at `seq = 2`, A rewinds `seq = 2`, applies B’s page, replays `seq = 2`. Same final notebook everywhere.

One line: **`seq` is when, `runtimeId` is who, `counter` is “which of mine,” Clock is “how late I will write next,” Vector is “how far I have read each person without a hole,” Log is the rewindable notebook.**

</details>

### How to review

History is three commits, oldest first. Walk the **Commits** tab in that order, or use the **Files** tab against this PR’s base for the combined diff.

1. **[Open-service: Add seq stamps, ordered log, and undo/redo](https://github.com/storybookjs/storybook/pull/36265/commits/ae597e98b3a3bfc9b6e415cd9086362b6c7a6f56)** — **read this one.** Core protocol and wiring.

   What to look for: stamp `{ seq, runtimeId, counter }`; comparator is `seq` then plain string `runtimeId` (`counter` is not in the order); placement as duplicate / later / earlier undo-redo / gap / beyond-window; RFC reverse-apply inverses (`inverse.toReversed()`).

   Start in `service-sync.ts` and `service-sync.test.ts`, then `json-patch.ts` and `patch-recorder.ts`. Wiring in `service-channel.ts` and `service-transport.ts` is small.

2. **[Open-service: Add a deterministic sync simulation harness](https://github.com/storybookjs/storybook/pull/36265/commits/4c85a5c6a34b4cae8b50c5ba36ee521f071c2ce7)** — These are elaborate integration tests, that creates a world silmuation with multiple runtimes syncing with each other in different scenarios and asserting that all runtimes eventually agree on the state. Lot's of "red case" testing went in to building this, ie. introducing bugs in the code to then see that the tests failed correctly. Feel free to skip this entirely.

3. **[Open-service: Add two-tab concurrent e2e and log glossary](https://github.com/storybookjs/storybook/pull/36265/commits/f059e2b9ac3d742b0affc3812398a862924c1a49)** — **skippable**. Uses playwright to set up two browser tabs that syncs the same demo open service. To ensure they act concurrently, the test injects itself as a middle-layer in the WebSocket connection, _holding_ all state syncing events, and releasing them all at the same time. It also asserts that the state write indeed uses the same `seq` number, as a proof that this isn't just a false positive that ran sequential, but actualy ran concurrently.
This commit also has the changes to README which you should definitely skip - there is a later task to ensure readme and tests are up-to-date and correct at the end of all of this work.

### Protocol details worth checking

- Comparator is `seq`, then plain string `runtimeId`. `counter` is not in the order.
- Local write: `seq = clock + 1`. Clock moves on incoming stamps (including duplicates), local authoring, and **every observed bootstrap stamp** (including LWW rejects). After an accepted entry, snapshot `version` is `max(version + 1, clock)`.
- An accepted bootstrap snapshot retires the Log and ignores later arrivals with `seq` at or below that snapshot `version`. The Vector stays. Frontier install (drop covered, re-apply uncovered) is the next PR.
- Earlier insert: undo newest-first, apply, redo stored forward ops inside one `setState` batch.
- Gap: place, do not advance the Vector. Beyond-window: only after eviction (`truncated`), and only if the stamp sorts before the oldest retained entry.
- Nested `delete a.b` then `delete a` must restore `{ a: { b: … } }`, not `{ a: {} }`.
- Hub forwards the original payload iff it appended to its log.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in the browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

Primary proof is automated. Optional UI check of the two-tab path:

1. From the repo root: `yarn nx compile core`
2. `cd code && yarn storybook:ui`
3. Open two tabs to `http://localhost:6006/?path=/story/core-shared-open-service-sync-test-concurrent-writes--concurrent-writes-sync`
5. Open the Open Service panel. Clear slots on one tab. Both tabs should show `{}`
6. Tab A: write slot `left` value `L`. Tab B: write slot `right` value `R`. Both keys should appear in the panel and the story on both tabs
7. Write the same slot from both tabs with different values. Both tabs should show one of those two values, and they should match
8. Focused checks:

```bash
yarn test service-sync.test.ts json-patch.test.ts patch-recorder.test.ts service-channel.test.ts service-registration-sync.test.ts service-transport-leaf.test.ts service-delegated-mode.test.ts sync-wire.test.ts sync-simulation.test.ts
```

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34372d38-5f67-4446-99dc-eca7a92de070?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34372d38-5f67-4446-99dc-eca7a92de070&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

