### PR TITLE
Docs: Remove comments from copyable shell snippets

### DIFF
--- a/docs/_snippets/angular-builder-production.md
+++ b/docs/_snippets/angular-builder-production.md
@@ -1,7 +1,4 @@
 ```shell renderer="angular" tabTitle="with-builder"
-# Builds Storybook with Angular's custom builder
-# See https://storybook.js.org/docs/get-started/frameworks/angular#how-do-i-migrate-to-an-angular-storybook-builder
-# to learn how to create the custom builder
 ng run my-project:build-storybook
 ```
 

--- a/docs/_snippets/build-storybook-production-mode.md
+++ b/docs/_snippets/build-storybook-production-mode.md
@@ -1,7 +1,4 @@
 ```shell renderer="angular" language="js" tabTitle="with-builder"
-# Builds Storybook with Angular's custom builder
-# See https://storybook.js.org/docs/get-started/angular
-# to learn how to create the custom builder
 ng run my-project:build-storybook
 ```
 

--- a/docs/_snippets/storybook-migrate-csf-2-to-3.md
+++ b/docs/_snippets/storybook-migrate-csf-2-to-3.md
@@ -1,14 +1,11 @@
 ```sh renderer="common" packageManager="npm"
-# Convert CSF 2 to CSF 3
 npx storybook@latest migrate csf-2-to-3 --glob="**/*.stories.tsx" --parser=tsx
 ```
 
 ```sh renderer="common" packageManager="pnpm"
-# Convert CSF 2 to CSF 3
 pnpm dlx storybook@latest migrate csf-2-to-3 --glob="**/*.stories.tsx" --parser=tsx
 ```
 
 ```sh renderer="common" packageManager="yarn"
-# Convert CSF 2 to CSF 3
 yarn dlx storybook@latest migrate csf-2-to-3 --glob="**/*.stories.tsx" --parser=tsx
 ```

--- a/docs/_snippets/storybook-migrate-mdx-to-csf.md
+++ b/docs/_snippets/storybook-migrate-mdx-to-csf.md
@@ -1,14 +1,11 @@
 ```shell renderer="common" packageManager="npm"
-# Convert stories in MDX to CSF
 npx storybook@latest migrate mdx-to-csf --glob "src/**/*.stories.mdx"
 ```
 
 ```sh renderer="common" packageManager="pnpm"
-# Convert stories in MDX to CSF
 pnpm dlx storybook@latest migrate mdx-to-csf --glob "src/**/*.stories.mdx"
 ```
 
 ```sh renderer="common" packageManager="yarn"
-# Convert stories in MDX to CSF
 yarn dlx storybook@latest migrate mdx-to-csf --glob "src/**/*.stories.mdx"
 ```

--- a/docs/_snippets/storybook-migrate-stories-of-to-csf.md
+++ b/docs/_snippets/storybook-migrate-stories-of-to-csf.md
@@ -1,14 +1,11 @@
 ```sh renderer="common" packageManager="npm"
-# Convert storiesOf to CSF 1
 npx storybook@latest migrate storiesof-to-csf --glob="**/*.stories.tsx" --parser=tsx
 ```
 
 ```sh renderer="common" packageManager="pnpm"
-# Convert storiesOf to CSF 1
 pnpm dlx storybook@latest migrate storiesof-to-csf --glob="**/*.stories.tsx" --parser=tsx
 ```
 
 ```sh renderer="common" packageManager="yarn"
-# Convert storiesOf to CSF 1
 yarn dlx storybook@latest migrate storiesof-to-csf --glob="**/*.stories.tsx" --parser=tsx
 ```

--- a/docs/_snippets/vitest-plugin-install-coverage-istanbul.md
+++ b/docs/_snippets/vitest-plugin-install-coverage-istanbul.md
@@ -1,0 +1,11 @@
+```shell renderer="common" packageManager="npm"
+npm install --save-dev @vitest/coverage-istanbul
+```
+
+```shell renderer="common" packageManager="pnpm"
+pnpm add --save-dev @vitest/coverage-istanbul
+```
+
+```shell renderer="common" packageManager="yarn"
+yarn add --dev @vitest/coverage-istanbul
+```

--- a/docs/_snippets/vitest-plugin-install-coverage-v8.md
+++ b/docs/_snippets/vitest-plugin-install-coverage-v8.md
@@ -1,23 +1,11 @@
 ```shell renderer="common" packageManager="npm"
-# For v8
 npm install --save-dev @vitest/coverage-v8
-
-# For istanbul
-npm install --save-dev @vitest/coverage-istanbul
 ```
 
 ```shell renderer="common" packageManager="pnpm"
-# For v8
 pnpm add --save-dev @vitest/coverage-v8
-
-# For istanbul
-pnpm add --save-dev @vitest/coverage-istanbul
 ```
 
 ```shell renderer="common" packageManager="yarn"
-# For v8
 yarn add --dev @vitest/coverage-v8
-
-# For istanbul
-yarn add --dev @vitest/coverage-istanbul
 ```

--- a/docs/writing-tests/test-coverage.mdx
+++ b/docs/writing-tests/test-coverage.mdx
@@ -29,9 +29,13 @@ Coverage is included in the [Vitest addon](./integrations/vitest-addon/index.mdx
 
 ![Screenshot of testing widget, expanded, showing coverage toggle](../_assets/writing-tests/test-widget-coverage-enabled.png)
 
-Before coverage can be calculated, you may need to install a support package corresponding to your [coverage provider](#coverage-provider):
+Before coverage can be calculated, you may need to install the support package for your [coverage provider](#coverage-provider). For v8 (the default), install `@vitest/coverage-v8`:
 
-<CodeSnippets path="vitest-plugin-install-coverage-support-packages.md" />
+<CodeSnippets path="vitest-plugin-install-coverage-v8.md" />
+
+For Istanbul, install `@vitest/coverage-istanbul`:
+
+<CodeSnippets path="vitest-plugin-install-coverage-istanbul.md" />
 
 ## Usage
 


### PR DESCRIPTION
Closes #20845

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The Copy button on storybook.js.org copies a snippet's raw code block, so any `#` comment line inside a shell snippet ends up in the user's terminal along with the command. The install-page example from the original report is gone, but the same thing still happens on the pages mentioned in the [latest comment](https://github.com/storybookjs/storybook/issues/20845#issuecomment-5523095282), among others.

On `next`, 14 shell blocks in 6 snippet files had comment lines. This PR removes all of them:

- **Codemod commands** (`storybook-migrate-csf-2-to-3.md`, `storybook-migrate-mdx-to-csf.md`, `storybook-migrate-stories-of-to-csf.md`): dropped the `# Convert …` line. The text above each snippet already says what the codemod does. The last two aren't referenced from any page right now; I changed them anyway so they don't bring the problem back if they're used again.
- **Angular builder** (`angular-builder-production.md`, `build-storybook-production-mode.md`): dropped the three-line comment. The pages already link to the Angular builder section right next to the snippet, and the link in one of the comments used an outdated path (`/docs/get-started/angular`).
- **Coverage support packages** (`test-coverage.mdx`): the single block listed both providers, so copying it installed `@vitest/coverage-v8` *and* `@vitest/coverage-istanbul`. I split it into `vitest-plugin-install-coverage-v8.md` and `vitest-plugin-install-coverage-istanbul.md`, each introduced by its own sentence. I used separate files rather than tabs because [new-snippets.mdx](https://github.com/storybookjs/storybook/blob/next/docs/contribute/documentation/new-snippets.mdx#code-snippets-not-displaying) warns against combining `packageManager` with other examples in one file. The old combined snippet had no other references, so I removed it.

After this, no shell block in `docs/_snippets` contains a `#` line.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Docs-only change, so there are no automated tests. `yarn docs:check` passes (relative links and `<CodeSnippets path>` targets).

#### Manual testing

1. In a clone of [storybookjs/web](https://github.com/storybookjs/web), sync this branch's `docs/` folder (`npm run sync-docs`) and start the site (`npm run dev`).
2. Open **Releases → Migration guide from older versions → CSF 2 to CSF 3**, click Copy, and paste. You should get only the `migrate csf-2-to-3` command, for npm, pnpm, and Yarn.
3. Open **Writing tests → Test coverage → Set up**. There should be two snippets, one for v8 and one for Istanbul, and each Copy should give a single install command for the selected package manager.
4. Switch the renderer to Angular and open **Sharing → Publish Storybook**. In the Angular builder snippet, the `with-builder` tab should copy only `ng run my-project:build-storybook`.

I did this locally with a script that clicks every affected Copy button in Chromium for npm, pnpm, and Yarn. On `next`, 0 of 12 copies were a single command, since each included comment lines or both coverage installs. With this branch, all 12 are.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

AI disclosure: I used Claude Code (Claude) to help find the affected snippets, make the edits, and write the local Copy-button check. I reviewed the changes and checked the results myself.

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
