### PR TITLE
Addon Vitest: Support Vitest 5 browser tests

### DIFF
--- a/code/addons/vitest/package.json
+++ b/code/addons/vitest/package.json
@@ -107,11 +107,11 @@
     "vitest": "^4.1.6"
   },
   "peerDependencies": {
-    "@vitest/browser": "^3.0.0 || ^4.0.0",
-    "@vitest/browser-playwright": "^4.0.0",
-    "@vitest/runner": "^3.0.0 || ^4.0.0",
+    "@vitest/browser": "^3.0.0 || ^4.0.0 || ^5.0.0",
+    "@vitest/browser-playwright": "^4.0.0 || ^5.0.0",
+    "@vitest/runner": "^3.0.0 || ^4.0.0 || ^5.0.0",
     "storybook": "workspace:^",
-    "vitest": "^3.0.0 || ^4.0.0"
+    "vitest": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "@vitest/browser": {

--- a/code/addons/vitest/src/constants.ts
+++ b/code/addons/vitest/src/constants.ts
@@ -71,6 +71,7 @@ export const STORYBOOK_TEST_PROVIDE_KEY = 'storybook/test-provided';
 export const STORYBOOK_CORE_GHOST_STORIES_PROVIDE_KEY = 'storybook/core-ghost-stories';
 export const STORYBOOK_CORE_RENDER_ANALYSIS_PROVIDE_KEY = 'storybook/core-render-analysis';
 export const STORYBOOK_TEST_INITIAL_GLOBALS_PROVIDE_KEY = 'storybook/test-initial-globals';
+export const STORYBOOK_TEST_FEATURES_PROVIDE_KEY = 'storybook/test-features';
 
 // Channel event names for programmatic test triggering
 export const TRIGGER_TEST_RUN_REQUEST = `${ADDON_ID}/trigger-test-run-request`;

--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -44,6 +44,7 @@ import { withoutVitePlugins } from '../../../../builders/builder-vite/src/utils/
 import {
   STORYBOOK_CORE_GHOST_STORIES_PROVIDE_KEY,
   STORYBOOK_CORE_RENDER_ANALYSIS_PROVIDE_KEY,
+  STORYBOOK_TEST_FEATURES_PROVIDE_KEY,
   STORYBOOK_TEST_INITIAL_GLOBALS_PROVIDE_KEY,
 } from '../constants.ts';
 import type { InternalOptions, UserOptions } from './types.ts';
@@ -391,6 +392,7 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
           },
 
           provide: {
+            [STORYBOOK_TEST_FEATURES_PROVIDE_KEY]: features,
             [STORYBOOK_CORE_GHOST_STORIES_PROVIDE_KEY]: !!process.env.STORYBOOK_COMPONENT_PATHS,
             [STORYBOOK_CORE_RENDER_ANALYSIS_PROVIDE_KEY]:
               !!process.env.STORYBOOK_COMPONENT_PATHS || withinAgenticSetupSession,

--- a/code/addons/vitest/src/vitest-plugin/setup-file.ts
+++ b/code/addons/vitest/src/vitest-plugin/setup-file.ts
@@ -1,10 +1,17 @@
-import { afterEach, beforeAll, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, inject, vi } from 'vitest';
 import type { RunnerTask } from 'vitest';
 
 import { Channel } from 'storybook/internal/channels';
 import { getChannel, setChannel } from 'storybook/internal/channels';
 
-import { COMPONENT_TESTING_PANEL_ID } from '../constants.ts';
+import { COMPONENT_TESTING_PANEL_ID, STORYBOOK_TEST_FEATURES_PROVIDE_KEY } from '../constants.ts';
+
+// Vitest 5 replaces the Vite define without exposing it on the runtime global.
+const features = inject(STORYBOOK_TEST_FEATURES_PROVIDE_KEY);
+if (features) {
+  vi.stubGlobal('FEATURES', features);
+  beforeEach(() => vi.stubGlobal('FEATURES', features));
+}
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/code/addons/vitest/src/vitest-provided-context.d.ts
+++ b/code/addons/vitest/src/vitest-provided-context.d.ts
@@ -1,14 +1,18 @@
 import 'vitest';
 
+import type { StorybookConfigRaw } from 'storybook/internal/types';
+
 import type {
   STORYBOOK_CORE_GHOST_STORIES_PROVIDE_KEY,
   STORYBOOK_CORE_RENDER_ANALYSIS_PROVIDE_KEY,
+  STORYBOOK_TEST_FEATURES_PROVIDE_KEY,
   STORYBOOK_TEST_INITIAL_GLOBALS_PROVIDE_KEY,
   STORYBOOK_TEST_PROVIDE_KEY,
 } from './constants.ts';
 
 declare module 'vitest' {
   interface ProvidedContext {
+    [STORYBOOK_TEST_FEATURES_PROVIDE_KEY]: StorybookConfigRaw['features'];
     [STORYBOOK_TEST_PROVIDE_KEY]: Record<string, unknown>;
     [STORYBOOK_CORE_GHOST_STORIES_PROVIDE_KEY]: boolean;
     [STORYBOOK_CORE_RENDER_ANALYSIS_PROVIDE_KEY]: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11168,11 +11168,11 @@ __metadata:
     typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.6"
   peerDependencies:
-    "@vitest/browser": ^3.0.0 || ^4.0.0
-    "@vitest/browser-playwright": ^4.0.0
-    "@vitest/runner": ^3.0.0 || ^4.0.0
+    "@vitest/browser": ^3.0.0 || ^4.0.0 || ^5.0.0
+    "@vitest/browser-playwright": ^4.0.0 || ^5.0.0
+    "@vitest/runner": ^3.0.0 || ^4.0.0 || ^5.0.0
     storybook: "workspace:^"
-    vitest: ^3.0.0 || ^4.0.0
+    vitest: ^3.0.0 || ^4.0.0 || ^5.0.0
   peerDependenciesMeta:
     "@vitest/browser":
       optional: true


### PR DESCRIPTION


<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Vitest 5 no longer exposes the `FEATURES` Vite define on the runtime global. React's experimental `.test()` stories therefore fail even when `experimentalTestSyntax: true` is configured in `main.ts`.

Pass the configured flags through Vitest's `provide`/`inject` API and initialize `FEATURES` in the test setup. Restore it before each test so `unstubGlobals: true` works too.

Also allow Vitest 5 in `@storybook/addon-vitest` peer ranges (`vitest`, `@vitest/browser`, `@vitest/browser-playwright`, `@vitest/runner`). That was the only published package that listed `vitest` as a peer.

Verified the same `test-fn` stories in Chromium:

| Version | Before | After |
| --- | --- | --- |
| Vitest 4.1.5 | 7 passed | 7 passed |
| Vitest 5.0.0 | 5 failed, 2 passed | 7 passed |

Also passed 54 plugin unit tests, the addon typecheck, and lint with no errors.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Generate the React Vite sandbox with `yarn task sandbox --template react-vite/default-ts --start-from auto`.
2. In the sandbox, install matching `vitest@5.0.0` and `@vitest/browser-playwright@5.0.0` versions. Keep `features.experimentalTestSyntax: true` in `.storybook/main.ts`.
3. Run `yarn vitest run src/stories/renderers/react/test-fn.stories.tsx`. All seven tests should pass.
4. Repeat with `test.unstubGlobals: true` in the Vitest config.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->