### PR TITLE
Open Service: Bootstrap and repair through snapshot request/reply

### DIFF
--- a/code/core/src/channels/postmessage/index.ts
+++ b/code/core/src/channels/postmessage/index.ts
@@ -232,7 +232,7 @@ export class PostMessageTransport implements ChannelTransport {
         invariant(this.handler, 'ChannelHandler should be set');
 
         // Preview channel bootstraps after the iframe document loads. When the preview sends its
-        // first postMessage (e.g. open-service sync-start), flush any outbound events that
+        // first postMessage (e.g. open-service sync-request), flush any outbound events that
         // were buffered while the iframe was not yet a postMessage target.
         if (this.config.page === 'manager' && this.buffer.length) {
           this.flush();

--- a/code/core/src/cli/tools/architecture.md
+++ b/code/core/src/cli/tools/architecture.md
@@ -136,7 +136,7 @@ consumer amortizes config load across many calls on the live synced runtime.
    respawn → `EnvironmentMismatchError`.
 3. **Connect.** Node WebSocket to `record.url` + `/storybook-server-channel?token=…`, no
    Origin. `UniversalStore.__prepare(channel, follower)`.
-4. **Register.** Load config from `record.configDir`. Set delegated mode. `services:sync-start`
+4. **Register.** Load config from `record.configDir`. Set delegated mode. `services:sync-request`
    pulls snapshots and patches from the server.
 5. **Execute.** Toolset handler runs caller-side (`ctx.transport = 'cli'`). Queries read synced
    state. `.loaded()` warms via delegated commands. Every command goes over the channel.

--- a/code/core/src/manager-api/root.tsx
+++ b/code/core/src/manager-api/root.tsx
@@ -215,7 +215,7 @@ class ManagerProvider extends Component<ManagerProviderProps, State> {
     this.api = api;
 
     // Run addon register callbacks before the first render mounts the preview iframe, so manager-side
-    // listeners (e.g. open-service) exist before preview JS can emit sync-start.
+    // listeners (e.g. open-service) exist before preview JS can emit sync-request.
     props.provider.handleAPI(this.api);
   }
 

--- a/code/core/src/shared/open-service/README.md
+++ b/code/core/src/shared/open-service/README.md
@@ -78,9 +78,9 @@ Internal tests and implementation code may import from the individual modules di
 - [service-channel.ts](./service-channel.ts): `ServiceChannel` interface, event name constants, RFC 6902 entry schemas, and payload types
 - [service-error-serialization.ts](./service-error-serialization.ts): transport-safe (de)serialization of thrown errors and their `cause` chains, used by remote command replies
 - [channel-slot.ts](../../channels/channel-slot.ts): `getChannel` / `setChannel` — the shared channel install surface
-- [service-transport.ts](./service-transport.ts): shared channel transport — wraps commands to emit `services:entry`, wires the sync-start initialization + entry listeners (hub or leaf), and runs the remote-command-execution protocol
+- [service-transport.ts](./service-transport.ts): shared channel transport — wraps commands to emit `services:entry`, wires the sync-request / sync-reply + entry listeners (hub or leaf), and runs the remote-command-execution protocol
 - [json-patch.ts](./json-patch.ts): RFC 6902 apply-by-path; inverses are reverse apply order (`add`/`replace` upsert, `remove` of missing is a no-op). `parentAfterChild` orders recorder ops only.
-- [service-sync.ts](./service-sync.ts): last-write-wins snapshot ordering, Lamport Clock, Vector, ordered Log with undo/redo, `applyStatePatch` for bootstrap/static snapshots, and the per-service reconciler
+- [service-sync.ts](./service-sync.ts): vector domination for snapshot install, Lamport Clock, Vector, ordered Log with undo/redo, `applyStatePatch` for bootstrap/static snapshots, and the per-service reconciler
 - [sync-simulation.test.ts](./sync-simulation.test.ts): deterministic topology and fault simulation over real channels and service runtimes (`sync-simulation/`).
 - [use-service-query.ts](./use-service-query.ts): `useServiceQuery` React hook backed by `useSyncExternalStore`
 - [use-service-command.ts](./use-service-command.ts): `useServiceCommand` React hook returning a stable command reference
@@ -628,7 +628,7 @@ flowchart TD
 
 ## Client Architecture (Multi-Master)
 
-Browser processes (manager and preview) each run their own full `ServiceRuntime` — identical in shape to the server-side one. State is reconciled peer-to-peer through Storybook's existing manager↔preview channel using a sync-start initialization + `services:entry` protocol.
+Browser processes (manager and preview) each run their own full `ServiceRuntime` — identical in shape to the server-side one. State is reconciled peer-to-peer through Storybook's existing manager↔preview channel using `services:sync-request` / `services:sync-reply` for bootstrap and repair, and `services:entry` for ongoing writes.
 
 ```text
 ┌─────────────────────────┐     channel (services:*)     ┌─────────────────────────┐
@@ -656,10 +656,10 @@ registration fails without one).
 
 Creates a local `ServiceRuntime` from the service definition (identical across runtimes) and wires it into the sync protocol:
 
-1. **On registration** — emits `services:sync-start` so any existing peer can reply with its current snapshot.
-2. **On sync-start-reply** — applies the received snapshot into the local runtime so the new peer bootstraps from existing state.
+1. **On registration** — emits `services:sync-request` `{ serviceId, runtimeId, frontier }` so any direct peer whose vector dominates can reply with a snapshot. A fresh runtime sends an empty vector and clock 0.
+2. **On sync-reply** — installs the snapshot iff the reply's vector dominates the local vector (same rule for bootstrap and repair).
 3. **After each local command that writes** — emits `services:entry` `{ serviceId, stamp: { seq, runtimeId, counter }, command, patch }` where `patch` is an RFC 6902 document of the paths that command touched. A command that touches nothing emits nothing.
-4. **On incoming entries** — places the entry in the ordered Log (duplicate / later / earlier / gap / beyond-window) via `commandSelf.setState`, which triggers fine-grained signal updates and re-renders subscribed components.
+4. **On incoming entries** — places the entry in the ordered Log (duplicate / later / earlier / gap / beyond-window) via `commandSelf.setState`, which triggers fine-grained signal updates and re-renders subscribed components. A gap, a beyond-window drop, or a missing parent sends another `services:sync-request`.
 
 ### Replay contract
 
@@ -670,30 +670,30 @@ The two escape hatches: make the server the sole writer of that path, or derive 
 ### Glossary
 
 - **Entry** — one stamp plus the forward ops it recorded plus the inverse ops computed locally when applied here. Inverses never leave the runtime.
-- **Log** — applied entries in canonical order, bounded by the window. An adopted bootstrap snapshot retires the Log. Incoming `seq` at or below that snapshot's `version` is treated as already folded in.
+- **Log** — applied entries in canonical order, bounded by the window. A snapshot install drops log entries the reply's vector covers and re-applies the rest.
 - **Vector** — per `runtimeId`, the highest contiguous `counter` applied.
-- **Clock** — the Lamport high-water mark. It moves on incoming stamps (including duplicates and echoes), on local authoring, and on every observed bootstrap stamp (including snapshots that lose last-write-wins). After an accepted entry, snapshot `version` is at least the Clock.
-- **Frontier** — `{ vector, clock }`. Bootstrap replies will carry this in a later PR; today they still use `(version, runtimeId)`. After an accepted entry, `version` is at least the Clock; a joiner raises its Clock from that `version`.
+- **Clock** — the Lamport high-water mark. It moves on incoming stamps (including duplicates and echoes) and on snapshot install (`max` with `frontier.clock`). An installed clock is also an ordering floor: an uncovered entry whose `seq` is at or below it is beyond-window.
+- **Frontier** — `{ vector, clock }`. `services:sync-request` and `services:sync-reply` carry this so a joiner can place later entries and a replier can stay silent unless it is ahead.
 
 Canonical order is ascending `seq`, then ascending `runtimeId` with plain string comparison. The canonical stamp string is `${seq}:${runtimeId}:${counter}`.
 
 ### History window
 
-An entry is retained while it is younger than 15 seconds **or** among the newest 256, whichever keeps it longer. Eviction is lazy on append. There is no byte cap. Bounds are a runtime option with those defaults; peers never need to agree on the window. The Vector never evicts. An incoming entry that sorts before the oldest retained entry is dropped and warned.
+An entry is retained while it is younger than 15 seconds **or** among the newest 256, whichever keeps it longer. Eviction is lazy on append. There is no byte cap. Bounds are a runtime option with those defaults; peers never need to agree on the window. The Vector never evicts. An incoming entry that sorts before the oldest retained entry, or whose `seq` is at or below the last installed snapshot clock, is dropped and warned.
 
 ### Loop prevention
 
 Every channel event that names a writer carries a `runtimeId` generated per `registerService` call.
 Loop prevention is not a single self-id check:
 
-- `services:sync-start` is ignored when its `runtimeId` matches the listener's own, so a runtime does not reply to itself.
+- `services:sync-request` is ignored when its `runtimeId` matches the listener's own, so a runtime does not reply to itself.
 - `services:entry` drops a stamp that is already in the Log, or whose `counter` is at or below that writer's Vector. A hub that appended the entry to its Log forwards the original payload object in receipt order; duplicates and entries it could not place are not forwarded. The server websocket transport still echoes the author's own entry back once as one small frame, which the Log drops.
-- `services:sync-start-reply` drops echoes through last-write-wins stamp ordering (`isNewer`). A relay hub that adopts a bootstrap snapshot forwards the original reply payload.
+- `services:sync-reply` installs iff the reply's vector dominates; a concurrent reply is dropped with a warning. A relay hub that installs a reply forwards the original payload object; a rejected reply is not forwarded.
 - Command replies correlate on `callId`, not on `runtimeId`.
 
 ### State application without re-broadcast
 
-Incoming state (from sync-start-reply or entries) is applied via `serviceRuntime.commandSelf.setState(...)` directly — not through the wrapped commands — so no broadcast is triggered for received state.
+Incoming state (from sync-reply or entries) is applied via `serviceRuntime.commandSelf.setState(...)` directly — not through the wrapped commands — so no broadcast is triggered for received state.
 
 ### `applyJsonPatch` and `applyStatePatch`
 
@@ -703,17 +703,24 @@ Bootstrap snapshots and static JSON still use `applyStatePatch` (in [service-syn
 
 ### State sync sequence
 
+1. A runtime registers a service and emits `services:sync-request { frontier }` (empty when fresh).
+2. Each direct peer compares vectors. If its vector dominates the requester's, it emits `services:sync-reply { frontier, state }`; otherwise it stays silent. `getSnapshot()` / `structuredClone` runs only here.
+3. The requester installs each dominating reply: merge `state` onto the live proxy; `clock = max(clock, reply.clock)`; take the reply vector (then re-apply uncovered local entries, which fills in writers the snapshot lacked); drop log entries that vector covers; re-apply the rest in canonical order, recomputing inverses. The installed clock is an ordering floor for later uncovered arrivals. Concurrent replies are dropped with a warning naming the service and both frontiers.
+4. From then on, every outer command invocation with at least one recorded op emits one `services:entry` carrying its stamp and forward ops. Peers place it by the five-case rule.
+5. A peer that detects a gap applies the entry, warns, and requests a snapshot; a peer that meets a beyond-window entry drops it, warns, and requests a snapshot; a missing parent rolls back, warns, and requests. At most one outstanding request per service; a reply or 1 s of silence clears it. A repair needed during that wait is queued and sent when the outstanding request clears, using the frontier at send time. A reply — installed or rejected — sends the queued request. Dominate does not prove the snapshot covered the anomaly that queued it; equal peers stay silent.
+6. Log entries expire when older than 15 s and outside the newest 256.
+
 ```text
 Peer A (manager)            Channel              Peer B (preview)
 ─────────────────────────────────────────────────────────────────
 registerService()
-  └─ emit sync-start ──────────────────────────────────────►
+  └─ emit sync-request ────────────────────────────────────►
                                                 (no peer yet; silence)
 
                                                 registerService()
-◄─────────────────────────── emit sync-start ──────────────
-  └─ reply with snapshot ──────────────────────────────────────►
-                                                  └─ apply snapshot
+◄────────────────────────── emit sync-request ─────────────
+  └─ vector dominates → emit sync-reply ───────────────────────►
+                                                  └─ install snapshot
 
 service.commands.foo()
   └─ local runtime mutates
@@ -723,7 +730,9 @@ service.commands.foo()
 
 ### Server participation
 
-The dev server is a full peer, not a passive observer. `registerService` on the server registers as a relay hub (`relay: true`): it wraps commands to emit `services:entry`, responds to sync-starts, applies incoming entries by path, and forwards every accepted entry (original payload, receipt order) so peers on its other transports converge. A relay hub forwards, unchanged and in receipt order, every `services:entry` it appends to its own log; duplicates and entries it could not place are not forwarded. This is wired automatically at registration once the `services` preset has installed the channel — there is no separate connect step.
+The dev server is a full peer, not a passive observer. `registerService` on the server registers as a relay hub (`relay: true`): it wraps commands to emit `services:entry`, answers dominating `services:sync-request`s, applies incoming entries by path, and forwards so peers on its other transports converge. A relay hub forwards, unchanged and in receipt order, every `services:entry` it appends to its own log; duplicates and entries it could not place are not forwarded. It also forwards every `services:sync-reply` it installs, so repair reaches peers on its other transports. `services:sync-request` is never forwarded; a joiner asks its direct peers. There is no unasked hub push on startup — `sync-request` is the only way state moves without an authored entry behind it. This is wired automatically at registration once the `services` preset has installed the channel — there is no separate connect step.
+
+The server's websocket transport sends every emit to all clients including the authoring tab, so an author receives its own entry back once per command as one small frame the reconciler drops as a duplicate. Removing that residual echo means a sender-excluding server transport, which is channel internals and out of scope.
 
 ## Remote Command Execution
 
@@ -1055,7 +1064,7 @@ React hook tests must include `// @vitest-environment happy-dom` as the first li
 - If you need to change channel transport, relay behavior, remote command execution, or delegated dispatch, start in [service-transport.ts](./service-transport.ts) — the delegated-mode flag itself lives in [service-registry.ts](./service-registry.ts).
 - If you need to change how the tools CLI or SDK attaches, start in [cli/tools/README.md](../../cli/tools/README.md) and [cli/tools/architecture.md](../../cli/tools/architecture.md).
 - If you need to change how thrown errors cross the channel for remote commands, start in [service-error-serialization.ts](./service-error-serialization.ts).
-- If you need to change last-write-wins ordering or the structural merge, start in [service-sync.ts](./service-sync.ts).
+- If you need to change vector domination, snapshot install, the ordered log, or the structural merge, start in [service-sync.ts](./service-sync.ts).
 - If you need to change how `setState` records touched paths, start in [patch-recorder.ts](./patch-recorder.ts).
 - If you need to change the channel protocol (event names, payloads, channel reader), start in [service-channel.ts](./service-channel.ts).
 - If you need to change the React query hook, start in [use-service-query.ts](./use-service-query.ts).

--- a/code/core/src/shared/open-service/service-channel.test.ts
+++ b/code/core/src/shared/open-service/service-channel.test.ts
@@ -7,6 +7,8 @@ import {
   entrySchema,
   jsonPatchOperationSchema,
   jsonPointerSchema,
+  syncReplySchema,
+  syncRequestSchema,
 } from './service-channel.ts';
 
 const validEntry = {
@@ -92,5 +94,40 @@ describe('entrySchema', () => {
       v.safeParse(entrySchema, { serviceId: 'svc', command: 'setValue', patch: validEntry.patch })
         .success
     ).toBe(false);
+  });
+});
+
+describe('syncRequestSchema and syncReplySchema', () => {
+  const frontier = { vector: { writer: 2 }, clock: 3 };
+
+  it('accepts a frontier-shaped request and reply', () => {
+    expect(
+      v.safeParse(syncRequestSchema, {
+        serviceId: 'svc',
+        runtimeId: 'joiner',
+        frontier: { vector: {}, clock: 0 },
+      }).success
+    ).toBe(true);
+    expect(
+      v.safeParse(syncReplySchema, {
+        serviceId: 'svc',
+        frontier,
+        state: { n: 1 },
+      }).success
+    ).toBe(true);
+  });
+
+  it('rejects a negative clock, an array state, and a missing frontier', () => {
+    expect(
+      v.safeParse(syncRequestSchema, {
+        serviceId: 'svc',
+        runtimeId: 'joiner',
+        frontier: { vector: { a: 1 }, clock: -1 },
+      }).success
+    ).toBe(false);
+    expect(v.safeParse(syncReplySchema, { serviceId: 'svc', frontier, state: [1] }).success).toBe(
+      false
+    );
+    expect(v.safeParse(syncReplySchema, { serviceId: 'svc', state: { n: 1 } }).success).toBe(false);
   });
 });

--- a/code/core/src/shared/open-service/service-channel.ts
+++ b/code/core/src/shared/open-service/service-channel.ts
@@ -23,8 +23,8 @@ import type { SerializedError } from './service-error-serialization.ts';
  */
 export type ServiceChannel = Pick<ChannelLike, 'on' | 'off' | 'emit'>;
 
-export const SERVICE_SYNC_START = 'services:sync-start' as const;
-export const SERVICE_SYNC_START_REPLY = 'services:sync-start-reply' as const;
+export const SERVICE_SYNC_REQUEST = 'services:sync-request' as const;
+export const SERVICE_SYNC_REPLY = 'services:sync-reply' as const;
 export const SERVICE_ENTRY = 'services:entry' as const;
 export const SERVICE_COMMAND_INVOKE = 'services:command-invoke' as const;
 export const SERVICE_COMMAND_ACK = 'services:command-ack' as const;
@@ -39,8 +39,8 @@ export const SERVICE_COMMAND_UNHANDLED = 'services:command-unhandled' as const;
  *
  * - `state` must be a *plain* object: `v.record` accepts arrays, so a custom check rejects them
  *   (an array snapshot would corrupt the structural merge in `service-sync.ts`).
- * - `version` is a non-negative safe integer — the last-write-wins logical clock for bootstrap
- *   snapshots. Command broadcasts use `services:entry` and `{ seq, runtimeId, counter }` instead.
+ * - `frontier` is `{ vector, clock }` — the per-writer contiguous counters plus the Lamport
+ *   high-water mark. Command broadcasts use `services:entry` and `{ seq, runtimeId, counter }`.
  * - `input` / `result` are optional: a `void` command input or output serializes to `undefined`,
  *   which JSON / telejson transports drop entirely, so the key is legitimately absent on the wire.
  * - Unknown fields on `services:entry` are ignored so a later envelope field is not a protocol break.
@@ -117,26 +117,30 @@ export const entrySchema = v.object({
 });
 export type EntryPayload = v.InferOutput<typeof entrySchema>;
 
-/** Sent by a newly-registered peer to initialize its state from any existing peer. */
-export const syncStartSchema = v.object({
+export const frontierSchema = v.object({
+  vector: v.record(v.string(), nonNegativeSafeInteger),
+  clock: nonNegativeSafeInteger,
+});
+export type SyncFrontier = v.InferOutput<typeof frontierSchema>;
+
+/** Sent by a runtime that wants a snapshot from any direct peer ahead of its frontier. */
+export const syncRequestSchema = v.object({
   serviceId: v.string(),
   runtimeId: v.string(),
+  frontier: frontierSchema,
 });
-export type SyncStartPayload = v.InferOutput<typeof syncStartSchema>;
+export type SyncRequestPayload = v.InferOutput<typeof syncRequestSchema>;
 
 /**
- * A full state snapshot stamped for last-write-wins ordering. Used by `services:sync-start-reply`
- * to bootstrap a freshly registered peer. Recipients apply it only when it is strictly newer than
- * their own (see `isNewer` in `service-sync.ts`). Command broadcasts use `services:entry` instead.
+ * Snapshot reply to `services:sync-request`. A replier emits this only when its vector dominates
+ * the requester's. Recipients install it with the Bayou rule in `service-sync.ts`.
  */
-export const stampedSnapshotSchema = v.object({
+export const syncReplySchema = v.object({
   serviceId: v.string(),
+  frontier: frontierSchema,
   state: stateSnapshotSchema,
-  version: nonNegativeSafeInteger,
-  runtimeId: v.string(),
 });
-export type StampedSnapshotPayload = v.InferOutput<typeof stampedSnapshotSchema>;
-export type SyncStartReplyPayload = StampedSnapshotPayload;
+export type SyncReplyPayload = v.InferOutput<typeof syncReplySchema>;
 
 /**
  * Sent by a runtime that wants a command executed but has no local handler for it.
@@ -206,9 +210,8 @@ export type CommandErrorPayload = v.InferOutput<typeof commandErrorSchema>;
 /**
  * Unique id for one service registration.
  *
- * It is the last-write-wins tiebreak for equal versions and the loop guard that drops a runtime's
- * own `services:sync-start`. `nanoid` is used (over `Math.random`) so collisions cannot silently
- * break that determinism.
+ * It is the loop guard that drops a runtime's own `services:sync-request`. `nanoid` is used (over
+ * `Math.random`) so collisions cannot silently break that determinism.
  */
 export function generateRuntimeId(): string {
   return nanoid();

--- a/code/core/src/shared/open-service/service-registration-sync.test.ts
+++ b/code/core/src/shared/open-service/service-registration-sync.test.ts
@@ -1,12 +1,15 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as v from 'valibot';
+import { logger } from 'storybook/internal/client-logger';
 
 import { OpenServiceMissingChannelError } from '../../server-errors.ts';
 import { createTestChannel, installTestChannel } from '../../channels/test-channel.ts';
 import { mutableRecordLookupServiceDef, noInputSchema, voidOutputSchema } from './fixtures.ts';
 import { defineService } from './service-definition.ts';
-import { SERVICE_ENTRY, SERVICE_SYNC_START_REPLY, SERVICE_SYNC_START } from './service-channel.ts';
+import { SERVICE_ENTRY, SERVICE_SYNC_REPLY, SERVICE_SYNC_REQUEST } from './service-channel.ts';
 import { clearRegistry, registerService } from './server.ts';
+
+vi.mock('storybook/internal/client-logger', { spy: true });
 
 const { id: recordServiceId } = mutableRecordLookupServiceDef;
 
@@ -106,6 +109,14 @@ function entryEmits(channel: ReturnType<typeof createMockChannel>) {
 afterEach(() => {
   clearRegistry();
   installChannel(null);
+  vi.useRealTimers();
+});
+
+beforeEach(() => {
+  vi.mocked(logger.warn).mockReset();
+  vi.mocked(logger.debug).mockReset();
+  vi.mocked(logger.warn).mockImplementation(() => undefined);
+  vi.mocked(logger.debug).mockImplementation(() => undefined);
 });
 
 // These tests exercise the server transport that `registerService` wires when a channel is present
@@ -119,8 +130,8 @@ describe('registerService: channel wiring', () => {
 
     registerService(mutableRecordLookupServiceDef);
 
-    expect(channel.on).toHaveBeenCalledWith(SERVICE_SYNC_START, expect.any(Function));
-    expect(channel.on).toHaveBeenCalledWith(SERVICE_SYNC_START_REPLY, expect.any(Function));
+    expect(channel.on).toHaveBeenCalledWith(SERVICE_SYNC_REQUEST, expect.any(Function));
+    expect(channel.on).toHaveBeenCalledWith(SERVICE_SYNC_REPLY, expect.any(Function));
     expect(channel.on).toHaveBeenCalledWith(SERVICE_ENTRY, expect.any(Function));
   });
 
@@ -218,14 +229,13 @@ describe('server: command push', () => {
   });
 });
 
-describe('server: sync-start initialization', () => {
-  it('replies to a sync-start with its current snapshot and stamp', () => {
+describe('server: sync-request initialization', () => {
+  it('replies to a sync-request only when its vector dominates', () => {
     const channel = createMockChannel();
     installChannel(channel);
 
     const service = registerService(mutableRecordLookupServiceDef);
 
-    // Server adopts a peer entry: this both populates state and advances the server's snapshot stamp.
     channel.emitExternal(
       SERVICE_ENTRY,
       peerEntry(recordServiceId, [{ op: 'add', path: '/a', value: { k: 'v' } }], {
@@ -235,38 +245,53 @@ describe('server: sync-start initialization', () => {
     );
     expect(service.queries.recordFields.get({ entryId: 'a' })).toEqual({ k: 'v' });
 
-    // A different peer comes online and asks for current state; the server answers with the snapshot
-    // it now holds, stamped with the version/runtimeId it adopted (not its own initial runtimeId).
-    channel.emitExternal(SERVICE_SYNC_START, {
+    channel.emitExternal(SERVICE_SYNC_REQUEST, {
       serviceId: recordServiceId,
       runtimeId: 'peer-2',
+      frontier: { vector: {}, clock: 0 },
     });
 
     expect(channel.emit).toHaveBeenCalledWith(
-      SERVICE_SYNC_START_REPLY,
+      SERVICE_SYNC_REPLY,
       expect.objectContaining({
         serviceId: recordServiceId,
         state: expect.objectContaining({ a: { k: 'v' } }),
-        version: 1,
-        runtimeId: 'peer-1',
+        frontier: expect.objectContaining({ vector: { 'peer-1': 1 } }),
       })
     );
   });
 
-  it('does not reply to a sync-start for a different service id', () => {
+  it('stays silent when its vector does not dominate the requester', () => {
     const channel = createMockChannel();
     installChannel(channel);
 
     registerService(mutableRecordLookupServiceDef);
 
-    channel.emitExternal(SERVICE_SYNC_START, {
-      serviceId: 'some-other-service',
+    channel.emit.mockClear();
+    channel.emitExternal(SERVICE_SYNC_REQUEST, {
+      serviceId: recordServiceId,
       runtimeId: 'peer-2',
+      frontier: { vector: { ahead: 4 }, clock: 4 },
     });
 
-    const replyCalls = channel.emit.mock.calls.filter(
-      ([event]) => event === SERVICE_SYNC_START_REPLY
+    expect(channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REPLY)).toHaveLength(
+      0
     );
+  });
+
+  it('does not reply to a sync-request for a different service id', () => {
+    const channel = createMockChannel();
+    installChannel(channel);
+
+    registerService(mutableRecordLookupServiceDef);
+
+    channel.emitExternal(SERVICE_SYNC_REQUEST, {
+      serviceId: 'some-other-service',
+      runtimeId: 'peer-2',
+      frontier: { vector: {}, clock: 0 },
+    });
+
+    const replyCalls = channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REPLY);
     expect(replyCalls).toHaveLength(0);
   });
 });
@@ -373,8 +398,8 @@ describe('server: teardown via clearRegistry', () => {
 
     clearRegistry();
 
-    expect(channel.off).toHaveBeenCalledWith(SERVICE_SYNC_START, expect.any(Function));
-    expect(channel.off).toHaveBeenCalledWith(SERVICE_SYNC_START_REPLY, expect.any(Function));
+    expect(channel.off).toHaveBeenCalledWith(SERVICE_SYNC_REQUEST, expect.any(Function));
+    expect(channel.off).toHaveBeenCalledWith(SERVICE_SYNC_REPLY, expect.any(Function));
     expect(channel.off).toHaveBeenCalledWith(SERVICE_ENTRY, expect.any(Function));
 
     channel.emitExternal(
@@ -389,47 +414,44 @@ describe('server: teardown via clearRegistry', () => {
 });
 
 describe('server: bootstrap on registration', () => {
-  it('emits a sync-start so a freshly-registered server can catch up', () => {
+  it('emits a sync-request so a freshly-registered server can catch up', () => {
     const channel = createMockChannel();
     installChannel(channel);
 
     registerService(mutableRecordLookupServiceDef);
 
     expect(channel.emit).toHaveBeenCalledWith(
-      SERVICE_SYNC_START,
-      expect.objectContaining({ serviceId: recordServiceId })
+      SERVICE_SYNC_REQUEST,
+      expect.objectContaining({
+        serviceId: recordServiceId,
+        frontier: { vector: {}, clock: 0 },
+      })
     );
   });
 
-  it('adopts state from a sync-start-reply (a late/restarted server catches up)', () => {
+  it('adopts state from a dominating sync-reply (a late/restarted server catches up)', () => {
     const channel = createMockChannel();
     installChannel(channel);
 
     const service = registerService(mutableRecordLookupServiceDef);
 
-    // A peer answers the server's bootstrap request with state authored while the server was down.
-    channel.emitExternal(SERVICE_SYNC_START_REPLY, {
+    channel.emitExternal(SERVICE_SYNC_REPLY, {
       serviceId: recordServiceId,
       state: { a: { k: 'v' } },
-      version: 3,
-      runtimeId: 'peer-1',
+      frontier: { vector: { 'peer-1': 3 }, clock: 3 },
     });
 
     expect(service.queries.recordFields.get({ entryId: 'a' })).toEqual({ k: 'v' });
   });
 
-  it('does not treat its own sync-start echo as incoming state', () => {
+  it('does not treat its own sync-request echo as incoming state', () => {
     const channel = createMockChannel();
     installChannel(channel);
 
     const service = registerService(mutableRecordLookupServiceDef);
 
-    // The bootstrap sync-start echoes back through the shared bus; it must not reply to itself
-    // nor mutate state. With no peer to answer, state stays empty.
     expect(service.queries.recordFields.get({ entryId: 'a' })).toBeNull();
-    const replyCalls = channel.emit.mock.calls.filter(
-      ([event]) => event === SERVICE_SYNC_START_REPLY
-    );
+    const replyCalls = channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REPLY);
     expect(replyCalls).toHaveLength(0);
   });
 });
@@ -455,7 +477,7 @@ describe('server: relay role', () => {
     expect(relays[0][1]).toEqual(expect.objectContaining({ extra: 'keep-me' }));
   });
 
-  it('relays a bootstrap snapshot it adopts as the original sync-start-reply', () => {
+  it('relays a bootstrap snapshot it installs as the original sync-reply', () => {
     const channel = createMockChannel();
     installChannel(channel);
 
@@ -464,14 +486,67 @@ describe('server: relay role', () => {
     const payload = {
       serviceId: recordServiceId,
       state: { entry: { marker: 'boot' } },
-      version: 4,
-      runtimeId: 'peer-1',
+      frontier: { vector: { 'peer-1': 4 }, clock: 4 },
     };
-    channel.emitExternal(SERVICE_SYNC_START_REPLY, payload);
+    channel.emitExternal(SERVICE_SYNC_REPLY, payload);
 
-    const relays = channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_START_REPLY);
+    const relays = channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REPLY);
     expect(relays).toHaveLength(1);
     expect(relays[0][1]).toBe(payload);
+  });
+
+  it('does not forward a rejected sync-reply', () => {
+    const channel = createMockChannel();
+    installChannel(channel);
+
+    registerService(mutableRecordLookupServiceDef);
+    channel.emitExternal(
+      SERVICE_ENTRY,
+      peerEntry(recordServiceId, [{ op: 'add', path: '/entry', value: { marker: 'local' } }], {
+        runtimeId: 'aaa',
+        counter: 1,
+      })
+    );
+    channel.emit.mockClear();
+
+    channel.emitExternal(SERVICE_SYNC_REPLY, {
+      serviceId: recordServiceId,
+      state: { other: { marker: 'concurrent' } },
+      frontier: { vector: { zzz: 1 }, clock: 1 },
+    });
+
+    expect(channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REPLY)).toHaveLength(
+      0
+    );
+  });
+
+  it('does not forward a sync-request', () => {
+    const channel = createMockChannel();
+    installChannel(channel);
+
+    registerService(mutableRecordLookupServiceDef);
+    channel.emitExternal(
+      SERVICE_ENTRY,
+      peerEntry(recordServiceId, [{ op: 'add', path: '/entry', value: { marker: 'set' } }], {
+        runtimeId: 'peer-1',
+        counter: 1,
+      })
+    );
+    channel.emit.mockClear();
+
+    const payload = {
+      serviceId: recordServiceId,
+      runtimeId: 'peer-2',
+      frontier: { vector: {}, clock: 0 },
+    };
+    channel.emitExternal(SERVICE_SYNC_REQUEST, payload);
+
+    expect(
+      channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REQUEST)
+    ).toHaveLength(0);
+    expect(channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REPLY)).toHaveLength(
+      1
+    );
   });
 
   it('does not forward a duplicate entry', () => {
@@ -495,5 +570,119 @@ describe('server: relay role', () => {
     );
 
     expect(entryEmits(channel)).toHaveLength(1);
+  });
+});
+
+describe('server: repair requests', () => {
+  function clearBootstrapRequest(channel: ReturnType<typeof createMockChannel>) {
+    channel.emitExternal(SERVICE_SYNC_REPLY, {
+      serviceId: recordServiceId,
+      frontier: { vector: {}, clock: 0 },
+      state: {},
+    });
+    channel.emit.mockClear();
+  }
+
+  it('sends one sync-request on a gap and does not send a second while outstanding', () => {
+    const channel = createMockChannel();
+    installChannel(channel);
+
+    registerService(mutableRecordLookupServiceDef);
+    clearBootstrapRequest(channel);
+
+    channel.emitExternal(
+      SERVICE_ENTRY,
+      peerEntry(recordServiceId, [{ op: 'add', path: '/a', value: { k: '1' } }], {
+        runtimeId: 'peer',
+        counter: 2,
+        seq: 2,
+      })
+    );
+    channel.emitExternal(
+      SERVICE_ENTRY,
+      peerEntry(recordServiceId, [{ op: 'add', path: '/b', value: { k: '2' } }], {
+        runtimeId: 'peer',
+        counter: 3,
+        seq: 3,
+      })
+    );
+
+    expect(
+      channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REQUEST)
+    ).toHaveLength(1);
+  });
+
+  it('sends a sync-request on a missing parent', () => {
+    const channel = createMockChannel();
+    installChannel(channel);
+
+    registerService(mutableRecordLookupServiceDef);
+    clearBootstrapRequest(channel);
+
+    channel.emitExternal(
+      SERVICE_ENTRY,
+      peerEntry(recordServiceId, [{ op: 'add', path: '/missing/y', value: 3 }], {
+        runtimeId: 'peer',
+        counter: 1,
+      })
+    );
+
+    expect(
+      channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REQUEST)
+    ).toHaveLength(1);
+  });
+
+  it('clears the outstanding request after 1 s of silence so a later gap can ask again', () => {
+    vi.useFakeTimers();
+    const channel = createMockChannel();
+    installChannel(channel);
+
+    registerService(mutableRecordLookupServiceDef);
+    vi.advanceTimersByTime(1000);
+    channel.emit.mockClear();
+
+    channel.emitExternal(
+      SERVICE_ENTRY,
+      peerEntry(recordServiceId, [{ op: 'add', path: '/a', value: { k: '1' } }], {
+        runtimeId: 'peer',
+        counter: 2,
+        seq: 2,
+      })
+    );
+    expect(
+      channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REQUEST)
+    ).toHaveLength(1);
+
+    channel.emitExternal(
+      SERVICE_ENTRY,
+      peerEntry(recordServiceId, [{ op: 'add', path: '/b', value: { k: '2' } }], {
+        runtimeId: 'peer',
+        counter: 3,
+        seq: 3,
+      })
+    );
+    expect(
+      channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REQUEST)
+    ).toHaveLength(1);
+
+    vi.advanceTimersByTime(1000);
+    expect(
+      channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REQUEST)
+    ).toHaveLength(2);
+
+    vi.advanceTimersByTime(1000);
+    channel.emit.mockClear();
+
+    channel.emitExternal(
+      SERVICE_ENTRY,
+      peerEntry(recordServiceId, [{ op: 'add', path: '/c', value: { k: '3' } }], {
+        runtimeId: 'peer',
+        counter: 5,
+        seq: 5,
+      })
+    );
+    expect(
+      channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REQUEST)
+    ).toHaveLength(1);
   });
 });

--- a/code/core/src/shared/open-service/service-registry.ts
+++ b/code/core/src/shared/open-service/service-registry.ts
@@ -6,8 +6,8 @@
  * into the cross-peer sync protocol through the shared transport. The only thing that differs per
  * runtime is the `relay` role: the dev server and the manager are hubs (`relay: true`) that bridge
  * their other channel transports, while a preview is a leaf (`relay: false`) — a single transport has
- * nothing to forward. The handshake + entry protocol lives in `service-transport.ts` and the
- * last-write-wins snapshot reconciliation in `service-sync.ts`; both transports drive them identically.
+ * nothing to forward. The request/reply + entry protocol lives in `service-transport.ts` and the
+ * snapshot install and ordered-log reconciliation in `service-sync.ts`; both transports drive them identically.
  *
  * The registry is anchored on a symbol-keyed `globalThis` slot so every module in one realm shares a
  * single registration map even if this file is reached through different import paths. Server (Node),
@@ -323,7 +323,6 @@ export function registerService<
   const reconciler = createSnapshotReconciler({
     setState: (mutate) =>
       runtime.commandSelf.setState((state) => mutate(state as Record<string, unknown>)),
-    initialStamp: { version: 0, runtimeId: ownRuntimeId },
   });
 
   const getSnapshot = (): Record<string, unknown> =>
@@ -350,7 +349,7 @@ export function registerService<
   );
 
   // Wire the runtime to the channel end to end against the one channel captured above: broadcast-wrap
-  // commands, run the remote-command protocol, and attach the sync-start + entry listeners.
+  // commands, run the remote-command protocol, and attach the sync-request + entry listeners.
   const { commands, disconnect } = connectServiceToChannel({
     serviceId: definition.id,
     ownRuntimeId,

--- a/code/core/src/shared/open-service/service-sync.test.ts
+++ b/code/core/src/shared/open-service/service-sync.test.ts
@@ -9,6 +9,9 @@ import {
   compareStamps,
   createSnapshotReconciler,
   DEFAULT_LOG_MAX_ENTRIES,
+  formatFrontier,
+  vectorDominates,
+  vectorsConcurrent,
   type AuthoredEntry,
 } from './service-sync.ts';
 
@@ -88,6 +91,22 @@ describe('applyStatePatch', () => {
   });
 });
 
+describe('vectorDominates', () => {
+  it('treats a non-empty vector as dominating an empty one, and not the reverse', () => {
+    expect(vectorDominates({ a: 1 }, {})).toBe(true);
+    expect(vectorDominates({}, { a: 1 })).toBe(false);
+    expect(vectorDominates({}, {})).toBe(false);
+    expect(vectorDominates({ a: 0 }, { b: 0 })).toBe(false);
+  });
+
+  it('requires every counter at least equal and at least one greater', () => {
+    expect(vectorDominates({ a: 2, b: 1 }, { a: 1, b: 1 })).toBe(true);
+    expect(vectorDominates({ a: 1, b: 1 }, { a: 1, b: 1 })).toBe(false);
+    expect(vectorDominates({ a: 2, b: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(vectorsConcurrent({ a: 2, b: 1 }, { a: 1, b: 2 })).toBe(true);
+  });
+});
+
 describe('compareStamps', () => {
   it('orders by seq first, then by plain string runtimeId', () => {
     expect(compareStamps(stamp('zzz', 1, 1), stamp('aaa', 1, 2))).toBeLessThan(0);
@@ -121,7 +140,6 @@ describe('createSnapshotReconciler entries', () => {
       setState: (mutate) => {
         mutate(state);
       },
-      initialStamp: { version: 0, runtimeId: 'self' },
       window,
     });
     return { state, reconciler };
@@ -152,7 +170,7 @@ describe('createSnapshotReconciler entries', () => {
     expect(reconciler.clock).toBe(2);
   });
 
-  it('does not replay retained log entries across an adopted snapshot', () => {
+  it('drops covered log entries on install and treats their counters as duplicates', () => {
     const { state, reconciler } = createReconciler({ n: 0, extra: 0 });
     expect(
       reconciler.tryAdoptEntry({
@@ -161,28 +179,59 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setN',
         patch: [{ op: 'replace', path: '/n', value: 2 }],
       })
-    ).toBe(true);
+    ).toBe('accepted');
     expect(state.n).toBe(2);
 
-    expect(reconciler.tryAdopt({ version: 10, runtimeId: 'peer' }, { n: 99, extra: 0 })).toBe(true);
+    expect(
+      reconciler.tryAdopt({ vector: { writer: 2 }, clock: 10 }, { n: 99, extra: 0 }, 'svc')
+    ).toBe(true);
     expect(state).toEqual({ n: 99, extra: 0 });
     expect(reconciler.log).toEqual([]);
+    expect(reconciler.vector).toEqual({ writer: 2 });
 
     expect(
       reconciler.tryAdoptEntry({
         serviceId: 'svc',
-        stamp: stamp('other', 1, 1),
+        stamp: stamp('writer', 1, 1),
         command: 'setExtra',
         patch: [{ op: 'replace', path: '/extra', value: 1 }],
       })
-    ).toBe(false);
+    ).toBe('duplicate');
     expect(state).toEqual({ n: 99, extra: 0 });
     expect(reconciler.log).toEqual([]);
   });
 
-  it('still places an entry later than an adopted snapshot', () => {
+  it('re-applies uncovered log entries in canonical order after install', () => {
+    const { state, reconciler } = createReconciler({ n: 0, mine: 0 });
+    expect(
+      reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: stamp('peer', 1, 1),
+        command: 'setN',
+        patch: [{ op: 'replace', path: '/n', value: 1 }],
+      })
+    ).toBe('accepted');
+    expect(
+      reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: stamp('self', 5, 2),
+        command: 'setMine',
+        patch: [{ op: 'replace', path: '/mine', value: 5 }],
+      })
+    ).toBe('gap');
+
+    expect(reconciler.tryAdopt({ vector: { peer: 4 }, clock: 8 }, { n: 4, mine: 0 }, 'svc')).toBe(
+      true
+    );
+    expect(state).toEqual({ n: 4, mine: 5 });
+    expect(reconciler.log.map((entry) => entry.stamp)).toEqual([stamp('self', 5, 2)]);
+    expect(reconciler.vector).toEqual({ peer: 4 });
+    expect(reconciler.clock).toBe(8);
+  });
+
+  it('places an entry later than an installed snapshot', () => {
     const { state, reconciler } = createReconciler({ n: 0 });
-    expect(reconciler.tryAdopt({ version: 10, runtimeId: 'peer' }, { n: 99 })).toBe(true);
+    expect(reconciler.tryAdopt({ vector: { peer: 3 }, clock: 10 }, { n: 99 }, 'svc')).toBe(true);
 
     expect(
       reconciler.tryAdoptEntry({
@@ -191,12 +240,45 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setN',
         patch: [{ op: 'replace', path: '/n', value: 11 }],
       })
-    ).toBe(true);
+    ).toBe('accepted');
     expect(state.n).toBe(11);
     expect(reconciler.log).toHaveLength(1);
   });
 
-  it('keeps the log when a bootstrap snapshot loses last-write-wins', () => {
+  it('drops a delayed concurrent entry after snapshot install as beyond-window and heals from a dominating snapshot', () => {
+    const { state, reconciler } = createReconciler({ n: 'z' });
+    expect(reconciler.tryAdopt({ vector: { z: 1 }, clock: 1 }, { n: 'z' }, 'svc')).toBe(true);
+
+    expect(
+      reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: stamp('z', 1, 1),
+        command: 'setN',
+        patch: [{ op: 'replace', path: '/n', value: 'z' }],
+      })
+    ).toBe('duplicate');
+    expect(state.n).toBe('z');
+
+    expect(
+      reconciler.tryAdoptEntry({
+        serviceId: 'svc',
+        stamp: stamp('a', 1, 1),
+        command: 'setN',
+        patch: [{ op: 'replace', path: '/n', value: 'a' }],
+      })
+    ).toBe('beyond-window');
+    expect(state.n).toBe('z');
+    expect(reconciler.vector).toEqual({ z: 1 });
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.stringContaining('service=svc stamps=1:a:1 paths=/n command=setN')
+    );
+
+    expect(reconciler.tryAdopt({ vector: { a: 1, z: 1 }, clock: 1 }, { n: 'z' }, 'svc')).toBe(true);
+    expect(state.n).toBe('z');
+    expect(reconciler.vector).toEqual({ a: 1, z: 1 });
+  });
+
+  it('does not install a snapshot that does not dominate', () => {
     const { state, reconciler } = createReconciler({ n: 0 });
     expect(
       reconciler.tryAdoptEntry({
@@ -205,17 +287,17 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setN',
         patch: [{ op: 'replace', path: '/n', value: 1 }],
       })
-    ).toBe(true);
+    ).toBe('accepted');
     expect(reconciler.log).toHaveLength(1);
 
-    expect(reconciler.tryAdopt({ version: 0, runtimeId: 'stale' }, { n: 99 })).toBe(false);
+    expect(reconciler.tryAdopt({ vector: {}, clock: 0 }, { n: 99 }, 'svc')).toBe(false);
     expect(state.n).toBe(1);
     expect(reconciler.log).toHaveLength(1);
   });
 
-  it('raises the clock to an adopted snapshot version so the next local seq is later', () => {
+  it('raises the clock to an installed frontier so the next local seq is later', () => {
     const { reconciler } = createReconciler({ value: '' });
-    expect(reconciler.tryAdopt({ version: 3, runtimeId: 'peer' }, { value: '' })).toBe(true);
+    expect(reconciler.tryAdopt({ vector: { peer: 2 }, clock: 3 }, { value: '' }, 'svc')).toBe(true);
     expect(reconciler.clock).toBe(3);
 
     const local = reconciler.advanceLocal(
@@ -239,7 +321,7 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setValue',
         patch: [{ op: 'replace', path: '/value', value: 'from panel' }],
       })
-    ).toBe(true);
+    ).toBe('accepted');
     expect(
       server.reconciler.tryAdoptEntry({
         serviceId: 'svc',
@@ -247,7 +329,7 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setValue',
         patch: [{ op: 'replace', path: '/value', value: 'from story' }],
       })
-    ).toBe(true);
+    ).toBe('accepted');
     expect(
       server.reconciler.tryAdoptEntry({
         serviceId: 'svc',
@@ -255,12 +337,12 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setValue',
         patch: [{ op: 'replace', path: '/value', value: '' }],
       })
-    ).toBe(true);
+    ).toBe('accepted');
     expect(server.state.value).toBe('');
 
     const joining = createReconciler({ value: '' });
     expect(
-      joining.reconciler.tryAdopt(server.reconciler.stamp, { value: server.state.value })
+      joining.reconciler.tryAdopt(server.reconciler.frontier, { value: server.state.value }, 'svc')
     ).toBe(true);
 
     const local = joining.reconciler.advanceLocal(
@@ -280,11 +362,11 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setValue',
         patch: [{ op: 'replace', path: '/value', value: 'before reload' }],
       })
-    ).toBe(true);
+    ).toBe('accepted');
     expect(server.state.value).toBe('before reload');
   });
 
-  it('keeps snapshot version at least the clock after a gapped seq so a joiner writes later', () => {
+  it('seeds a joiner clock from the installed frontier so its next seq is later', () => {
     const server = createReconciler({ n: 0 });
     expect(
       server.reconciler.tryAdoptEntry({
@@ -293,12 +375,13 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setN',
         patch: [{ op: 'replace', path: '/n', value: 1 }],
       })
-    ).toBe(true);
+    ).toBe('accepted');
     expect(server.reconciler.clock).toBe(100);
-    expect(server.reconciler.stamp.version).toBeGreaterThanOrEqual(100);
 
     const joining = createReconciler({ n: 0 });
-    expect(joining.reconciler.tryAdopt(server.reconciler.stamp, { n: server.state.n })).toBe(true);
+    expect(
+      joining.reconciler.tryAdopt(server.reconciler.frontier, { n: server.state.n }, 'svc')
+    ).toBe(true);
     expect(joining.reconciler.clock).toBeGreaterThanOrEqual(100);
 
     const local = joining.reconciler.advanceLocal(
@@ -318,38 +401,28 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setN',
         patch: [{ op: 'replace', path: '/n', value: 2 }],
       })
-    ).toBe(true);
+    ).toBe('accepted');
     expect(server.state.n).toBe(2);
   });
 
-  it('advances the clock from a rejected older bootstrap stamp', () => {
-    const { reconciler } = createReconciler({ n: 0 });
-    for (const runtimeId of ['aaa', 'mmm', 'zzz']) {
-      expect(
-        reconciler.tryAdoptEntry({
-          serviceId: 'svc',
-          stamp: stamp(runtimeId, 1, 1),
-          command: 'setN',
-          patch: [{ op: 'replace', path: '/n', value: runtimeId }],
-        })
-      ).toBe(true);
-    }
-    expect(reconciler.clock).toBe(1);
-    expect(reconciler.stamp.version).toBe(3);
+  it('drops a concurrent snapshot and warns with both frontiers', () => {
+    const { state, reconciler } = createReconciler({ n: 0, m: 0 });
+    expect(
+      reconciler.tryAdoptEntry({
+        serviceId: 'demo',
+        stamp: stamp('aaa', 1, 1),
+        command: 'setN',
+        patch: [{ op: 'replace', path: '/n', value: 1 }],
+      })
+    ).toBe('accepted');
 
-    expect(reconciler.tryAdopt({ version: 2, runtimeId: 'peer' }, { n: 'stale' })).toBe(false);
-    expect(reconciler.clock).toBe(2);
-    expect(reconciler.stamp.version).toBe(3);
-
-    const local = reconciler.advanceLocal(
-      'self',
-      authored(
-        'setN',
-        [{ op: 'replace', path: '/n', value: 'local' }],
-        [{ op: 'replace', path: '/n', value: 'zzz' }]
-      )
+    const local = reconciler.frontier;
+    const reply = { vector: { zzz: 1 }, clock: 2 };
+    expect(reconciler.tryAdopt(reply, { n: 0, m: 9 }, 'demo')).toBe(false);
+    expect(state).toEqual({ n: 1, m: 0 });
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      `Open-service sync: concurrent snapshot reply dropped. service=demo local=${formatFrontier(local)} reply=${formatFrontier(reply)}`
     );
-    expect(local.seq).toBe(3);
   });
 
   it('drops a duplicate stamp including the local echo, and still advances the clock', () => {
@@ -371,7 +444,7 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setN',
         patch: [{ op: 'replace', path: '/n', value: 99 }],
       })
-    ).toBe(false);
+    ).toBe('duplicate');
     expect(state.n).toBe(1);
     expect(reconciler.clock).toBe(1);
 
@@ -382,7 +455,7 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setN',
         patch: [{ op: 'replace', path: '/n', value: 99 }],
       })
-    ).toBe(false);
+    ).toBe('duplicate');
     expect(state.n).toBe(1);
     expect(reconciler.clock).toBe(9);
   });
@@ -396,7 +469,7 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setA',
         patch: [{ op: 'add', path: '/a', value: 1 }],
       })
-    ).toBe(true);
+    ).toBe('accepted');
     expect(
       reconciler.tryAdoptEntry({
         serviceId: 'svc',
@@ -404,7 +477,7 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setA',
         patch: [{ op: 'add', path: '/a', value: 9 }],
       })
-    ).toBe(false);
+    ).toBe('duplicate');
     expect(state).toEqual({ a: 1 });
   });
 
@@ -417,7 +490,7 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setA',
         patch: [{ op: 'add', path: '/a', value: 1 }],
       })
-    ).toBe(true);
+    ).toBe('accepted');
     expect(state).toEqual({ a: 1 });
     expect(reconciler.log.map((entry) => entry.stamp)).toEqual([stamp('w', 1, 1)]);
     expect(reconciler.clock).toBe(1);
@@ -435,7 +508,6 @@ describe('createSnapshotReconciler entries', () => {
           mutate(state);
         });
       },
-      initialStamp: { version: 0, runtimeId: 'self' },
     });
 
     let transitions = 0;
@@ -453,7 +525,7 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setB',
         patch: [{ op: 'replace', path: '/b', value: 'B' }],
       })
-    ).toBe(true);
+    ).toBe('accepted');
     expect(transitions - afterSubscribe).toBe(1);
 
     expect(
@@ -463,7 +535,7 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setA',
         patch: [{ op: 'replace', path: '/a', value: 'A' }],
       })
-    ).toBe(true);
+    ).toBe('accepted');
 
     expect(transitions - afterSubscribe).toBe(2);
     expect({ a: state.a, b: state.b }).toEqual({ a: 'A', b: 'B' });
@@ -481,7 +553,7 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setN',
         patch: [{ op: 'replace', path: '/n', value: 'later' }],
       })
-    ).toBe(true);
+    ).toBe('accepted');
     expect(
       reconciler.tryAdoptEntry({
         serviceId: 'svc',
@@ -489,37 +561,38 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setN',
         patch: [{ op: 'replace', path: '/n', value: 'earlier' }],
       })
-    ).toBe(true);
+    ).toBe('accepted');
 
     expect(state.n).toBe('later');
   });
 
-  it('applies a gap without advancing the vector so the skipped counter still applies', () => {
+  it('applies a gap without advancing the vector so the skipped counter still applies, and warns', () => {
     const { state, reconciler } = createReconciler();
 
     expect(
       reconciler.tryAdoptEntry({
-        serviceId: 'svc',
+        serviceId: 'demo',
         stamp: stamp('w', 2, 2),
         command: 'setB',
         patch: [{ op: 'add', path: '/b', value: 2 }],
       })
-    ).toBe(true);
+    ).toBe('gap');
     expect(state).toEqual({ b: 2 });
     expect(reconciler.vector).toEqual({});
-    expect(vi.mocked(logger.warn)).not.toHaveBeenCalled();
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.stringContaining('service=demo stamps=2:w:2 paths=/b command=setB')
+    );
 
     expect(
       reconciler.tryAdoptEntry({
-        serviceId: 'svc',
+        serviceId: 'demo',
         stamp: stamp('w', 1, 1),
         command: 'setA',
         patch: [{ op: 'add', path: '/a', value: 1 }],
       })
-    ).toBe(true);
+    ).toBe('accepted');
     expect(state).toEqual({ b: 2, a: 1 });
     expect(reconciler.vector).toEqual({ w: 2 });
-    expect(vi.mocked(logger.warn)).not.toHaveBeenCalled();
   });
 
   it('warns with service, stamp, path, and command on missing parent and does not accept', () => {
@@ -532,7 +605,7 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setNested',
         patch: [{ op: 'add', path: '/missing/y', value: 3 }],
       })
-    ).toBe(false);
+    ).toBe('missing-parent');
     expect(state).toEqual({ a: 1 });
     expect(reconciler.has(stamp('writer', 1))).toBe(false);
     expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
@@ -550,7 +623,7 @@ describe('createSnapshotReconciler entries', () => {
         command: 'clearM',
         patch: [{ op: 'remove', path: '/m' }],
       })
-    ).toBe(true);
+    ).toBe('accepted');
     expect(state).toEqual({ n: 1 });
     expect(vi.mocked(logger.debug)).toHaveBeenCalledWith(
       expect.stringContaining('service=demo stamp=1:writer:1 path=/m command=clearM')
@@ -567,7 +640,7 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setA',
         patch: [{ op: 'add', path: '/a', value: 1 }],
       })
-    ).toBe(true);
+    ).toBe('accepted');
     expect(
       reconciler.tryAdoptEntry({
         serviceId: 'demo',
@@ -575,7 +648,7 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setB',
         patch: [{ op: 'add', path: '/b', value: 2 }],
       })
-    ).toBe(true);
+    ).toBe('accepted');
     expect(
       reconciler.tryAdoptEntry({
         serviceId: 'demo',
@@ -583,7 +656,7 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setC',
         patch: [{ op: 'add', path: '/c', value: 3 }],
       })
-    ).toBe(true);
+    ).toBe('accepted');
 
     expect(reconciler.log.map((entry) => entry.stamp.seq)).toEqual([2, 3]);
 
@@ -594,7 +667,7 @@ describe('createSnapshotReconciler entries', () => {
         command: 'setZ',
         patch: [{ op: 'add', path: '/z', value: 9 }],
       })
-    ).toBe(false);
+    ).toBe('beyond-window');
     expect(state).toEqual({ a: 1, b: 2, c: 3 });
     expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
       expect.stringContaining('service=demo stamps=1:other:1,2:w:2 paths=/z command=setZ')
@@ -617,7 +690,6 @@ describe('log window eviction', () => {
     const state: Record<string, unknown> = { n: 0 };
     const reconciler = createSnapshotReconciler({
       setState: (mutate) => mutate(state),
-      initialStamp: { version: 0, runtimeId: 'self' },
       window: { maxAgeMs: 15_000, maxEntries: 2 },
     });
 
@@ -637,7 +709,6 @@ describe('log window eviction', () => {
     const state: Record<string, unknown> = { n: 0 };
     const reconciler = createSnapshotReconciler({
       setState: (mutate) => mutate(state),
-      initialStamp: { version: 0, runtimeId: 'self' },
       window: { maxAgeMs: 15_000, maxEntries: 2 },
     });
 

--- a/code/core/src/shared/open-service/service-sync.ts
+++ b/code/core/src/shared/open-service/service-sync.ts
@@ -4,31 +4,32 @@
  * Every runtime — server (Node), manager (top window), preview (iframe) — runs a full
  * `ServiceRuntime` and reconciles incoming state here. Command broadcasts carry a Lamport stamp
  * `{ seq, runtimeId, counter }` and an RFC 6902 patch. Each replica keeps an ordered Log, a
- * per-writer Vector, and a Clock. Bootstrap still uses last-write-wins snapshot replies. The
- * transport that moves entries and snapshots lives in `service-transport.ts`.
+ * per-writer Vector, and a Clock. Snapshots are bootstrap and repair only. The transport that
+ * moves entries and snapshots lives in `service-transport.ts`.
  *
- * ## 1. `isNewer` — last-write-wins ordering for bootstrap snapshots
- *
- * Each bootstrap snapshot carries a `(version, runtimeId)` stamp. `version` stays at least the
- * Lamport Clock after each accepted entry, so a joiner that raises its Clock from `version` cannot
- * author a `seq` into retained history. Equal versions mean concurrent snapshot replies; the
- * lexicographically greater `runtimeId` wins. An *equal* stamp is **not** newer, which drops
- * snapshot echoes. The Clock still moves on every observed snapshot stamp, including those that
- * lose last-write-wins.
- *
- * ## 2. Entries — Clock, Vector, ordered Log
+ * ## 1. Entries — Clock, Vector, ordered Log
  *
  * Each `services:entry` carries `{ seq, runtimeId, counter }`. `seq` is the Lamport order key.
  * One comparator orders the Log ascending on `seq`, then on `runtimeId` by plain string
- * comparison. Incoming cases, in order: duplicate (in the Log, counter at or below the Vector, or
- * `seq` at or below an adopted snapshot `version`) drops but still advances the Clock; later
- * appends; earlier undoes newest-first, applies, and redoes from stored forward ops inside one
- * `setState` batch; a gap still places but does not advance the Vector; beyond-window (sorts before
- * the oldest retained entry) drops and warns. Adopting a bootstrap snapshot raises the Clock to at
- * least that snapshot's `version`, so a late joiner's next `seq` is later than the peer's accepted
- * history, and retires the Log so old inverses cannot replay across the new state. The Vector stays,
- * so later echoes still drop. The Vector never evicts. Log eviction is lazy on append: an entry is
- * retained while younger than 15 s or among the newest 256.
+ * comparison. Incoming cases, in order: duplicate (in the Log, or counter at or below the Vector)
+ * drops but still advances the Clock; later appends; earlier undoes newest-first, applies, and
+ * redoes from stored forward ops inside one `setState` batch; a gap still places but does not
+ * advance the Vector, and warns; beyond-window (sorts before the oldest retained entry, or `seq`
+ * at or below the last installed frontier clock) drops and warns. Gap, beyond-window, and
+ * missing-parent all ask the transport to send `sync-request`. The Vector never evicts. Log
+ * eviction is lazy on append: an entry is retained while younger than 15 s or among the newest 256.
+ *
+ * ## 2. Snapshots — Frontier install
+ *
+ * A `services:sync-reply` carries `{ frontier: { vector, clock }, state }`. Install iff the
+ * reply's vector dominates the replica's: every counter at least equal, at least one greater, or
+ * the replica's vector is empty and the reply's is not. Inside one `setState` batch: merge
+ * `state` onto the live proxy; `clock = max(clock, reply.clock)`; take the reply's vector;
+ * drop log entries that vector covers; re-apply the rest in canonical order, recomputing
+ * inverses (which also fills in writers the snapshot lacked). Keep the installed clock as
+ * an ordering floor so a delayed concurrent entry at or below that clock cannot apply over
+ * snapshot state. A concurrent reply — each side has writes the other lacks — is dropped with a
+ * warning naming both frontiers.
  *
  * ## 3. `applyStatePatch` — structural merge for snapshots
  *
@@ -43,44 +44,102 @@ import { logger } from 'storybook/internal/client-logger';
 
 import { applyJsonPatch } from './json-patch.ts';
 import { FORBIDDEN_KEYS, hasOwn, isPlainObject } from './plain-object.ts';
-import { entryStampKey, type EntryStamp, type JsonPatchOperation } from './service-channel.ts';
+import {
+  entryStampKey,
+  type EntryStamp,
+  type JsonPatchOperation,
+  type SyncFrontier,
+} from './service-channel.ts';
 
 export const DEFAULT_LOG_MAX_AGE_MS = 15_000;
 export const DEFAULT_LOG_MAX_ENTRIES = 256;
+
+export type { SyncFrontier };
 
 export type LogWindow = {
   maxAgeMs: number;
   maxEntries: number;
 };
 
-/** Per-service last-write-wins stamp carried on bootstrap snapshot replies. */
-export type SyncStamp = {
-  /** Logical clock for the state lineage. At least the Lamport Clock after each accepted entry. */
-  version: number;
-  /** Id of the runtime that produced this version; the deterministic tiebreak for equal versions. */
-  runtimeId: string;
-};
+export type AdoptEntryOutcome =
+  | 'accepted'
+  | 'gap'
+  | 'duplicate'
+  | 'beyond-window'
+  | 'missing-parent';
+
+function vectorCounter(vector: Record<string, number>, runtimeId: string): number {
+  return vector[runtimeId] ?? 0;
+}
+
+export function isEmptyVector(vector: Record<string, number>): boolean {
+  for (const value of Object.values(vector)) {
+    if (value > 0) {
+      return false;
+    }
+  }
+  return true;
+}
 
 /**
- * Returns whether `incoming` should replace `local` under last-write-wins ordering.
+ * Returns whether `left` dominates `right`.
  *
- * Higher `version` always wins. At an equal version (concurrent writes) the lexicographically
- * greater `runtimeId` wins so every runtime picks the same winner. An equal stamp is **not** newer —
- * that is precisely what makes echoes and relayed re-broadcasts terminate rather than loop.
+ * Every counter in `left` is at least the matching counter in `right`, and at least one is
+ * greater. An empty `right` is dominated by any non-empty `left`, so a fresh joiner hears from
+ * every peer that has writes. Two empty vectors do not dominate each other.
  */
-export function isNewer(incoming: SyncStamp, local: SyncStamp): boolean {
-  if (incoming.version !== local.version) {
-    return incoming.version > local.version;
+export function vectorDominates(
+  left: Record<string, number>,
+  right: Record<string, number>
+): boolean {
+  if (isEmptyVector(right)) {
+    return !isEmptyVector(left);
   }
 
-  return incoming.runtimeId > local.runtimeId;
+  const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+  let greater = false;
+  for (const key of keys) {
+    const leftCount = vectorCounter(left, key);
+    const rightCount = vectorCounter(right, key);
+    if (leftCount < rightCount) {
+      return false;
+    }
+    if (leftCount > rightCount) {
+      greater = true;
+    }
+  }
+  return greater;
+}
+
+export function vectorsEqual(left: Record<string, number>, right: Record<string, number>): boolean {
+  const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+  for (const key of keys) {
+    if (vectorCounter(left, key) !== vectorCounter(right, key)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function vectorsConcurrent(
+  left: Record<string, number>,
+  right: Record<string, number>
+): boolean {
+  return (
+    !vectorDominates(left, right) && !vectorDominates(right, left) && !vectorsEqual(left, right)
+  );
+}
+
+export function formatFrontier(frontier: SyncFrontier): string {
+  const keys = Object.keys(frontier.vector).sort();
+  const body = keys.map((key) => `${key}:${frontier.vector[key]}`).join(',');
+  return `{clock:${frontier.clock} vector:{${body}}}`;
 }
 
 /**
  * Canonical entry order: ascending `seq`, then ascending `runtimeId` with plain string comparison.
  *
- * "Later in the log", "greater stamp", and "wins the path" coincide. Greater `runtimeId` is later,
- * matching last-write-wins snapshot ties.
+ * "Later in the log", "greater stamp", and "wins the path" coincide.
  */
 export function compareStamps(left: EntryStamp, right: EntryStamp): number {
   if (left.seq !== right.seq) {
@@ -118,7 +177,6 @@ export function applyStatePatch(
   options: { preserveMissingKeys: boolean }
 ): void {
   if (!options.preserveMissingKeys) {
-    // Remove keys the source no longer carries (deletion propagation).
     for (const key of Object.keys(target)) {
       if (FORBIDDEN_KEYS.has(key)) {
         continue;
@@ -130,7 +188,6 @@ export function applyStatePatch(
     }
   }
 
-  // Merge or assign keys the source provides.
   for (const key of Object.keys(source)) {
     if (FORBIDDEN_KEYS.has(key)) {
       continue;
@@ -177,21 +234,18 @@ type StoredLogEntry = ReconcilerLogEntry & {
 /**
  * The per-service reconciler shared by every runtime's channel integration.
  *
- * It owns the bootstrap snapshot stamp, the Clock, the per-writer Vector, and the ordered Log.
- * Local commands call {@link SnapshotReconciler.advanceLocal} before emitting. Incoming entries go
- * through {@link SnapshotReconciler.tryAdoptEntry}. Incoming bootstrap snapshots go through
+ * It owns the Clock, the per-writer Vector, and the ordered Log. Local commands call
+ * {@link SnapshotReconciler.advanceLocal} before emitting. Incoming entries go through
+ * {@link SnapshotReconciler.tryAdoptEntry}. Incoming snapshot replies go through
  * {@link SnapshotReconciler.tryAdopt}.
  */
 export type SnapshotReconciler = {
-  /** The current local snapshot stamp (read for sync-start-reply envelopes). */
-  readonly stamp: SyncStamp;
-  /**
-   * Lamport high-water mark. Moves on incoming stamps (including duplicates), local authoring,
-   * observed bootstrap stamps (including LWW rejects), and adopted snapshot `version`.
-   */
+  /** Lamport high-water mark. Moves on incoming stamps (including duplicates) and on install. */
   readonly clock: number;
   /** Per-writer highest contiguous counter applied. */
   readonly vector: Readonly<Record<string, number>>;
+  /** `{ vector, clock }` copied for request and reply envelopes. */
+  readonly frontier: SyncFrontier;
   /** Applied entries in canonical order, after window eviction. */
   readonly log: readonly ReconcilerLogEntry[];
   /** Whether this stamp is in the retained Log. */
@@ -203,18 +257,18 @@ export type SnapshotReconciler = {
    */
   advanceLocal(runtimeId: string, authored: AuthoredEntry): EntryStamp;
   /**
-   * Adopts an incoming snapshot iff it is strictly newer (LWW). Always raises the Clock to at least
-   * `incoming.version`, including when the snapshot loses last-write-wins. An accepted snapshot
-   * retires the Log and ignores later arrivals with `seq` at or below that `version`. Returns
-   * whether state was adopted, so relay hubs can re-broadcast only on a real advance.
+   * Installs a snapshot iff `frontier.vector` dominates the local vector. Concurrent replies
+   * warn and return false. Raises an installed-frontier ordering floor to the installed clock
+   * so later uncovered arrivals at or below that clock are beyond-window. Returns whether
+   * state was installed, so a hub forwards only then.
    */
-  tryAdopt(incoming: SyncStamp, state: Record<string, unknown>): boolean;
+  tryAdopt(frontier: SyncFrontier, state: Record<string, unknown>, serviceId: string): boolean;
   /**
-   * Places an incoming entry into the Log. Returns whether it was accepted, so a hub forwards the
-   * original payload only then. Duplicates, entries at or below the last adopted snapshot `version`,
-   * and beyond-window entries return false; a gap is accepted without advancing the Vector.
+   * Places an incoming entry into the Log. `accepted` and `gap` mean it was logged, so a hub
+   * forwards the original payload. `gap`, `beyond-window`, and `missing-parent` mean the
+   * transport should send `sync-request`.
    */
-  tryAdoptEntry(incoming: AdoptEntryInput): boolean;
+  tryAdoptEntry(incoming: AdoptEntryInput): AdoptEntryOutcome;
 };
 
 /**
@@ -223,25 +277,24 @@ export type SnapshotReconciler = {
  * @param setState - The runtime's batched in-place mutator (`commandSelf.setState`), adapted to a
  *   plain record. Adopting goes through this rather than the wrapped commands so it never triggers
  *   a re-broadcast.
- * @param initialStamp - Starting snapshot stamp, typically `{ version: 0, runtimeId: <own id> }`.
  */
 export function createSnapshotReconciler(options: {
   setState: (mutate: StateMutator) => void;
-  initialStamp: SyncStamp;
   window?: Partial<LogWindow>;
 }): SnapshotReconciler {
-  const { setState, initialStamp } = options;
+  const { setState } = options;
   const window: LogWindow = {
     maxAgeMs: options.window?.maxAgeMs ?? DEFAULT_LOG_MAX_AGE_MS,
     maxEntries: options.window?.maxEntries ?? DEFAULT_LOG_MAX_ENTRIES,
   };
-  let localStamp = initialStamp;
   let clock = 0;
   let snapshotSeq = 0;
   const vector = new Map<string, number>();
   const log: StoredLogEntry[] = [];
   const logKeys = new Set<string>();
   let truncated = false;
+
+  const vectorRecord = (): Record<string, number> => Object.fromEntries(vector);
 
   const vectorOf = (runtimeId: string): number => vector.get(runtimeId) ?? 0;
 
@@ -286,7 +339,6 @@ export function createSnapshotReconciler(options: {
     entry.inverse = result.inverse;
   };
 
-  // Inclusive of `index`: those entries sit after the incoming stamp and are replayed after it.
   const undoToIndex = (
     current: Record<string, unknown>,
     index: number,
@@ -365,10 +417,6 @@ export function createSnapshotReconciler(options: {
     if (advanceVector) {
       tryAdvanceVector(entry.stamp);
     }
-    localStamp = {
-      version: Math.max(localStamp.version + 1, clock),
-      runtimeId: entry.stamp.runtimeId,
-    };
     evict(entry.appliedAt);
   };
 
@@ -388,16 +436,16 @@ export function createSnapshotReconciler(options: {
   };
 
   return {
-    get stamp(): SyncStamp {
-      return localStamp;
-    },
-
     get clock(): number {
       return clock;
     },
 
     get vector(): Readonly<Record<string, number>> {
-      return Object.fromEntries(vector);
+      return vectorRecord();
+    },
+
+    get frontier(): SyncFrontier {
+      return { vector: vectorRecord(), clock };
     },
 
     get log(): readonly ReconcilerLogEntry[] {
@@ -427,48 +475,86 @@ export function createSnapshotReconciler(options: {
       return stamp;
     },
 
-    tryAdopt(incoming: SyncStamp, state: Record<string, unknown>): boolean {
-      advanceClock(incoming.version);
-      if (!isNewer(incoming, localStamp)) {
+    tryAdopt(frontier: SyncFrontier, state: Record<string, unknown>, serviceId: string): boolean {
+      const localVector = vectorRecord();
+      if (!vectorDominates(frontier.vector, localVector)) {
+        if (vectorsConcurrent(frontier.vector, localVector)) {
+          logger.warn(
+            `Open-service sync: concurrent snapshot reply dropped. service=${serviceId} local=${formatFrontier({ vector: localVector, clock })} reply=${formatFrontier(frontier)}`
+          );
+        }
         return false;
       }
 
-      localStamp = { version: incoming.version, runtimeId: incoming.runtimeId };
-      snapshotSeq = incoming.version;
-      logKeys.clear();
-      log.length = 0;
-      truncated = false;
-      setState((current) => applyStatePatch(current, state, { preserveMissingKeys: false }));
+      advanceClock(frontier.clock);
+      snapshotSeq = Math.max(snapshotSeq, clock);
+
+      const remaining = log.filter(
+        (entry) => entry.stamp.counter > vectorCounter(frontier.vector, entry.stamp.runtimeId)
+      );
+
+      setState((current) => {
+        applyStatePatch(current, state, { preserveMissingKeys: false });
+
+        logKeys.clear();
+        log.length = 0;
+        truncated = false;
+        vector.clear();
+        for (const [runtimeId, counter] of Object.entries(frontier.vector)) {
+          if (counter > 0) {
+            vector.set(runtimeId, counter);
+          }
+        }
+
+        for (const entry of remaining) {
+          const result = applyOps(current, entry.patch, silentMissingRemove);
+          if (!result.ok) {
+            logger.warn(
+              `Open-service sync: replay failed. service=${serviceId} stamp=${entryStampKey(entry.stamp)} path=${result.path} command=${entry.command}`
+            );
+            continue;
+          }
+          const stored: StoredLogEntry = {
+            stamp: entry.stamp,
+            command: entry.command,
+            patch: entry.patch,
+            inverse: result.inverse,
+            appliedAt: entry.appliedAt,
+          };
+          log.push(stored);
+          logKeys.add(entryStampKey(entry.stamp));
+          tryAdvanceVector(entry.stamp);
+        }
+      });
 
       return true;
     },
 
-    tryAdoptEntry(incoming: AdoptEntryInput): boolean {
+    tryAdoptEntry(incoming: AdoptEntryInput): AdoptEntryOutcome {
       const { serviceId, stamp, command, patch } = incoming;
       const key = entryStampKey(stamp);
 
       advanceClock(stamp.seq);
 
-      if (
-        hasStamp(stamp) ||
-        stamp.counter <= vectorOf(stamp.runtimeId) ||
-        stamp.seq <= snapshotSeq
-      ) {
-        return false;
+      if (hasStamp(stamp) || stamp.counter <= vectorOf(stamp.runtimeId)) {
+        return 'duplicate';
       }
 
-      // log[0] is a window floor only after eviction; until then an earlier stamp inserts at 0.
-      if (truncated && log.length > 0 && compareStamps(stamp, log[0].stamp) < 0) {
+      if (
+        stamp.seq <= snapshotSeq ||
+        (truncated && log.length > 0 && compareStamps(stamp, log[0].stamp) < 0)
+      ) {
+        const floor = log.length > 0 ? `,${entryStampKey(log[0].stamp)}` : '';
         logger.warn(
-          `Open-service sync: entry beyond the log window. service=${serviceId} stamps=${key},${entryStampKey(log[0].stamp)} paths=${patchPaths(patch)} command=${command}`
+          `Open-service sync: entry beyond the log window. service=${serviceId} stamps=${key}${floor} paths=${patchPaths(patch)} command=${command}`
         );
-        return false;
+        return 'beyond-window';
       }
 
       const gap = stamp.counter > vectorOf(stamp.runtimeId) + 1;
       const index = insertIndexFor(stamp);
       if (index < log.length && compareStamps(log[index].stamp, stamp) === 0) {
-        return false;
+        return 'duplicate';
       }
 
       const now = Date.now();
@@ -502,15 +588,21 @@ export function createSnapshotReconciler(options: {
         logger.warn(
           `Open-service sync: missing parent while applying entry. service=${serviceId} stamp=${key} path=${failedPath} command=${command}`
         );
-        return false;
+        return 'missing-parent';
       }
 
       if (!stored) {
-        return false;
+        return 'duplicate';
+      }
+
+      if (gap) {
+        logger.warn(
+          `Open-service sync: gap in writer counters. service=${serviceId} stamps=${key} paths=${patchPaths(patch)} command=${command}`
+        );
       }
 
       appendOrInsert(stored, index, !gap);
-      return true;
+      return gap ? 'gap' : 'accepted';
     },
   };
 }

--- a/code/core/src/shared/open-service/service-transport-leaf.test.ts
+++ b/code/core/src/shared/open-service/service-transport-leaf.test.ts
@@ -5,12 +5,15 @@
  * Runtime queries, subscriptions, and registry metadata live in
  * {@link ./service-runtime.test.ts} and {@link ./service-registration.test.ts}.
  */
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { logger } from 'storybook/internal/client-logger';
 
 import { mutableRecordLookupServiceDef } from './fixtures.ts';
-import { SERVICE_ENTRY, SERVICE_SYNC_START_REPLY, SERVICE_SYNC_START } from './service-channel.ts';
+import { SERVICE_ENTRY, SERVICE_SYNC_REPLY, SERVICE_SYNC_REQUEST } from './service-channel.ts';
 import { clearRegistry, registerService, unregisterService } from './service-registry.ts';
 import { createTestChannel, installTestChannel } from '../../channels/test-channel.ts';
+
+vi.mock('storybook/internal/client-logger', { spy: true });
 
 const createMockChannel = createTestChannel;
 const installChannel = installTestChannel;
@@ -34,6 +37,11 @@ function entryEmits(channel: ReturnType<typeof createMockChannel>) {
   return channel.emit.mock.calls.filter(([event]) => event === SERVICE_ENTRY);
 }
 
+beforeEach(() => {
+  vi.mocked(logger.warn).mockReset();
+  vi.mocked(logger.warn).mockImplementation(() => undefined);
+});
+
 afterEach(() => {
   clearRegistry();
   installChannel(null);
@@ -49,8 +57,8 @@ describe('registerService (leaf)', () => {
   });
 });
 
-describe('channel: sync-start initialization (leaf)', () => {
-  it('adopts a sync-start-reply from a hub that was not listening at registration time', async () => {
+describe('channel: sync-request initialization (leaf)', () => {
+  it('adopts a sync-reply from a hub that was not listening at registration time', async () => {
     const channel = createMockChannel();
     installChannel(channel);
 
@@ -59,27 +67,29 @@ describe('channel: sync-start initialization (leaf)', () => {
     });
 
     expect(channel.emit).toHaveBeenCalledWith(
-      SERVICE_SYNC_START,
-      expect.objectContaining({ serviceId: mutableRecordLookupServiceDef.id })
+      SERVICE_SYNC_REQUEST,
+      expect.objectContaining({
+        serviceId: mutableRecordLookupServiceDef.id,
+        frontier: { vector: {}, clock: 0 },
+      })
     );
 
-    channel.emitExternal(SERVICE_SYNC_START_REPLY, {
+    channel.emitExternal(SERVICE_SYNC_REPLY, {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { 'entry-late': { marker: 'synced' } },
-      version: 1,
-      runtimeId: 'manager-hub',
+      frontier: { vector: { 'manager-hub': 1 }, clock: 1 },
     });
 
     expect(preview.queries.recordFields.get({ entryId: 'entry-late' })).toEqual({
       marker: 'synced',
     });
 
-    expect(channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_START).length).toBe(
+    expect(channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REQUEST).length).toBe(
       1
     );
   });
 
-  it('converges via entries when a sync-start-reply carried stale v0 state', async () => {
+  it('converges via entries when a sync-reply carried empty state', async () => {
     const channel = createMockChannel();
     installChannel(channel);
 
@@ -87,11 +97,10 @@ describe('channel: sync-start initialization (leaf)', () => {
       relay: false,
     });
 
-    channel.emitExternal(SERVICE_SYNC_START_REPLY, {
+    channel.emitExternal(SERVICE_SYNC_REPLY, {
       serviceId: mutableRecordLookupServiceDef.id,
-      state: { 'entry-stale': { marker: 'v0' } },
-      version: 0,
-      runtimeId: 'early-hub',
+      state: {},
+      frontier: { vector: {}, clock: 0 },
     });
 
     channel.emitExternal(
@@ -218,30 +227,27 @@ describe('channel: entry apply', () => {
   });
 });
 
-describe('channel: multi-peer sync-start bootstrap', () => {
-  it('converges on the newest sync-start-reply when several peers answer out of order', async () => {
+describe('channel: multi-peer sync-reply bootstrap', () => {
+  it('installs dominating replies in arrival order', async () => {
     const channel = createMockChannel();
     installChannel(channel);
 
     const service = registerService(mutableRecordLookupServiceDef);
 
-    channel.emitExternal(SERVICE_SYNC_START_REPLY, {
+    channel.emitExternal(SERVICE_SYNC_REPLY, {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { item: { v: '1' } },
-      version: 1,
-      runtimeId: 'p1',
+      frontier: { vector: { p1: 1 }, clock: 1 },
     });
-    channel.emitExternal(SERVICE_SYNC_START_REPLY, {
+    channel.emitExternal(SERVICE_SYNC_REPLY, {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { item: { v: '3' } },
-      version: 3,
-      runtimeId: 'p3',
+      frontier: { vector: { p1: 1, p3: 2 }, clock: 3 },
     });
-    channel.emitExternal(SERVICE_SYNC_START_REPLY, {
+    channel.emitExternal(SERVICE_SYNC_REPLY, {
       serviceId: mutableRecordLookupServiceDef.id,
       state: { item: { v: '2' } },
-      version: 2,
-      runtimeId: 'p2',
+      frontier: { vector: { p1: 1, p2: 1 }, clock: 2 },
     });
 
     await vi.waitFor(() =>
@@ -310,7 +316,7 @@ describe('channel: untrusted payloads', () => {
     expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
   });
 
-  it('drops malformed sync-start-reply and entry payloads without mutating state', async () => {
+  it('drops malformed sync-reply and entry payloads without mutating state', async () => {
     const channel = createMockChannel();
     installChannel(channel);
 
@@ -330,7 +336,7 @@ describe('channel: untrusted payloads', () => {
 
     for (const payload of malformed) {
       expect(() => channel.emitExternal(SERVICE_ENTRY, payload)).not.toThrow();
-      expect(() => channel.emitExternal(SERVICE_SYNC_START_REPLY, payload)).not.toThrow();
+      expect(() => channel.emitExternal(SERVICE_SYNC_REPLY, payload)).not.toThrow();
     }
 
     await new Promise<void>((resolve) => setTimeout(resolve, 10));
@@ -382,8 +388,8 @@ describe('channel: disconnect on unregister', () => {
 
     unregisterService(mutableRecordLookupServiceDef.id);
 
-    expect(channel.off).toHaveBeenCalledWith(SERVICE_SYNC_START, expect.any(Function));
-    expect(channel.off).toHaveBeenCalledWith(SERVICE_SYNC_START_REPLY, expect.any(Function));
+    expect(channel.off).toHaveBeenCalledWith(SERVICE_SYNC_REQUEST, expect.any(Function));
+    expect(channel.off).toHaveBeenCalledWith(SERVICE_SYNC_REPLY, expect.any(Function));
     expect(channel.off).toHaveBeenCalledWith(SERVICE_ENTRY, expect.any(Function));
 
     channel.emitExternal(

--- a/code/core/src/shared/open-service/service-transport-sync.test.ts
+++ b/code/core/src/shared/open-service/service-transport-sync.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { logger } from 'storybook/internal/client-logger';
+
+import { createTestChannel } from '../../channels/test-channel.ts';
+import { SERVICE_ENTRY, SERVICE_SYNC_REPLY, SERVICE_SYNC_REQUEST } from './service-channel.ts';
+import { createSnapshotReconciler } from './service-sync.ts';
+import { connectRuntimeToChannel } from './service-transport.ts';
+
+vi.mock('storybook/internal/client-logger', { spy: true });
+
+const SERVICE_ID = 'internal-fixture/transport-sync';
+
+describe('connectRuntimeToChannel request policy', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(logger.warn).mockReset();
+    vi.mocked(logger.warn).mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('sends a sync-request for a beyond-window entry', () => {
+    const channel = createTestChannel();
+    const state: Record<string, unknown> = {};
+    const getSnapshot = vi.fn(() => ({ ...state }));
+    const reconciler = createSnapshotReconciler({
+      setState: (mutate) => mutate(state),
+      window: { maxAgeMs: 0, maxEntries: 2 },
+    });
+
+    const disconnect = connectRuntimeToChannel({
+      serviceId: SERVICE_ID,
+      ownRuntimeId: 'self',
+      reconciler,
+      getSnapshot,
+      channel,
+      relay: false,
+    });
+    vi.advanceTimersByTime(1000);
+    channel.emit.mockClear();
+
+    channel.emitExternal(SERVICE_ENTRY, {
+      serviceId: SERVICE_ID,
+      stamp: { seq: 1, runtimeId: 'w', counter: 1 },
+      command: 'setA',
+      patch: [{ op: 'add', path: '/a', value: 1 }],
+    });
+    channel.emitExternal(SERVICE_ENTRY, {
+      serviceId: SERVICE_ID,
+      stamp: { seq: 2, runtimeId: 'w', counter: 2 },
+      command: 'setB',
+      patch: [{ op: 'add', path: '/b', value: 2 }],
+    });
+    channel.emitExternal(SERVICE_ENTRY, {
+      serviceId: SERVICE_ID,
+      stamp: { seq: 3, runtimeId: 'w', counter: 3 },
+      command: 'setC',
+      patch: [{ op: 'add', path: '/c', value: 3 }],
+    });
+    channel.emit.mockClear();
+
+    channel.emitExternal(SERVICE_ENTRY, {
+      serviceId: SERVICE_ID,
+      stamp: { seq: 1, runtimeId: 'other', counter: 1 },
+      command: 'setZ',
+      patch: [{ op: 'add', path: '/z', value: 9 }],
+    });
+
+    expect(
+      channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REQUEST)
+    ).toHaveLength(1);
+
+    disconnect();
+  });
+
+  it('sends a queued repair request after bootstrap silence when a gap arrives during the cooldown', () => {
+    const channel = createTestChannel();
+    const state: Record<string, unknown> = {};
+    const getSnapshot = vi.fn(() => ({ ...state }));
+    const reconciler = createSnapshotReconciler({
+      setState: (mutate) => mutate(state),
+    });
+
+    const disconnect = connectRuntimeToChannel({
+      serviceId: SERVICE_ID,
+      ownRuntimeId: 'self',
+      reconciler,
+      getSnapshot,
+      channel,
+      relay: false,
+    });
+
+    expect(
+      channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REQUEST)
+    ).toHaveLength(1);
+    channel.emit.mockClear();
+
+    channel.emitExternal(SERVICE_ENTRY, {
+      serviceId: SERVICE_ID,
+      stamp: { seq: 2, runtimeId: 'w', counter: 2 },
+      command: 'setA',
+      patch: [{ op: 'add', path: '/a', value: 1 }],
+    });
+    expect(
+      channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REQUEST)
+    ).toHaveLength(0);
+
+    vi.advanceTimersByTime(1000);
+
+    const requests = channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REQUEST);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.[1]).toEqual({
+      serviceId: SERVICE_ID,
+      runtimeId: 'self',
+      frontier: reconciler.frontier,
+    });
+    expect(reconciler.frontier).toEqual({ vector: {}, clock: 2 });
+
+    disconnect();
+  });
+
+  it('sends a queued repair after an installed reply', () => {
+    const channel = createTestChannel();
+    const state: Record<string, unknown> = {};
+    const getSnapshot = vi.fn(() => ({ ...state }));
+    const reconciler = createSnapshotReconciler({
+      setState: (mutate) => mutate(state),
+    });
+
+    const disconnect = connectRuntimeToChannel({
+      serviceId: SERVICE_ID,
+      ownRuntimeId: 'self',
+      reconciler,
+      getSnapshot,
+      channel,
+      relay: false,
+    });
+    channel.emit.mockClear();
+
+    channel.emitExternal(SERVICE_ENTRY, {
+      serviceId: SERVICE_ID,
+      stamp: { seq: 2, runtimeId: 'w', counter: 2 },
+      command: 'setA',
+      patch: [{ op: 'add', path: '/a', value: 1 }],
+    });
+    expect(
+      channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REQUEST)
+    ).toHaveLength(0);
+
+    channel.emitExternal(SERVICE_SYNC_REPLY, {
+      serviceId: SERVICE_ID,
+      frontier: { vector: { w: 2 }, clock: 2 },
+      state: { a: 1 },
+    });
+
+    const requests = channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REQUEST);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.[1]).toEqual({
+      serviceId: SERVICE_ID,
+      runtimeId: 'self',
+      frontier: reconciler.frontier,
+    });
+    expect(state).toEqual({ a: 1 });
+
+    disconnect();
+  });
+
+  it('sends a queued repair after an installed reply that does not cover the gap', () => {
+    const channel = createTestChannel();
+    const state: Record<string, unknown> = {};
+    const getSnapshot = vi.fn(() => ({ ...state }));
+    const reconciler = createSnapshotReconciler({
+      setState: (mutate) => mutate(state),
+    });
+
+    const disconnect = connectRuntimeToChannel({
+      serviceId: SERVICE_ID,
+      ownRuntimeId: 'self',
+      reconciler,
+      getSnapshot,
+      channel,
+      relay: false,
+    });
+    channel.emit.mockClear();
+
+    channel.emitExternal(SERVICE_ENTRY, {
+      serviceId: SERVICE_ID,
+      stamp: { seq: 2, runtimeId: 'w', counter: 2 },
+      command: 'setA',
+      patch: [{ op: 'add', path: '/a', value: 1 }],
+    });
+    expect(
+      channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REQUEST)
+    ).toHaveLength(0);
+    expect(reconciler.vector).toEqual({});
+
+    channel.emitExternal(SERVICE_SYNC_REPLY, {
+      serviceId: SERVICE_ID,
+      frontier: { vector: { z: 1 }, clock: 1 },
+      state: { z: 1 },
+    });
+
+    const requests = channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REQUEST);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.[1]).toEqual({
+      serviceId: SERVICE_ID,
+      runtimeId: 'self',
+      frontier: reconciler.frontier,
+    });
+    expect(reconciler.vector).toEqual({ z: 1 });
+    expect(reconciler.frontier.clock).toBe(2);
+    expect(state).toEqual({ z: 1, a: 1 });
+
+    disconnect();
+  });
+
+  it('re-emits a queued repair when a concurrent reply is dropped', () => {
+    const channel = createTestChannel();
+    const state: Record<string, unknown> = { n: 1 };
+    const getSnapshot = vi.fn(() => ({ ...state }));
+    const reconciler = createSnapshotReconciler({
+      setState: (mutate) => mutate(state),
+    });
+    reconciler.tryAdoptEntry({
+      serviceId: SERVICE_ID,
+      stamp: { seq: 1, runtimeId: 'self', counter: 1 },
+      command: 'setN',
+      patch: [{ op: 'replace', path: '/n', value: 1 }],
+    });
+
+    const disconnect = connectRuntimeToChannel({
+      serviceId: SERVICE_ID,
+      ownRuntimeId: 'self',
+      reconciler,
+      getSnapshot,
+      channel,
+      relay: false,
+    });
+    channel.emit.mockClear();
+
+    channel.emitExternal(SERVICE_ENTRY, {
+      serviceId: SERVICE_ID,
+      stamp: { seq: 2, runtimeId: 'w', counter: 2 },
+      command: 'setA',
+      patch: [{ op: 'add', path: '/a', value: 1 }],
+    });
+    expect(
+      channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REQUEST)
+    ).toHaveLength(0);
+
+    channel.emitExternal(SERVICE_SYNC_REPLY, {
+      serviceId: SERVICE_ID,
+      frontier: { vector: { other: 1 }, clock: 1 },
+      state: { n: 99 },
+    });
+
+    const requests = channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REQUEST);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.[1]).toEqual({
+      serviceId: SERVICE_ID,
+      runtimeId: 'self',
+      frontier: reconciler.frontier,
+    });
+
+    disconnect();
+  });
+
+  it('calls getSnapshot only when answering a dominating request', () => {
+    const channel = createTestChannel();
+    const state: Record<string, unknown> = { n: 1 };
+    const getSnapshot = vi.fn(() => ({ ...state }));
+    const reconciler = createSnapshotReconciler({
+      setState: (mutate) => mutate(state),
+    });
+    reconciler.tryAdoptEntry({
+      serviceId: SERVICE_ID,
+      stamp: { seq: 1, runtimeId: 'self', counter: 1 },
+      command: 'setN',
+      patch: [{ op: 'replace', path: '/n', value: 1 }],
+    });
+
+    const disconnect = connectRuntimeToChannel({
+      serviceId: SERVICE_ID,
+      ownRuntimeId: 'self',
+      reconciler,
+      getSnapshot,
+      channel,
+      relay: false,
+    });
+    getSnapshot.mockClear();
+
+    channel.emitExternal(SERVICE_SYNC_REQUEST, {
+      serviceId: SERVICE_ID,
+      runtimeId: 'ahead',
+      frontier: { vector: { ahead: 9 }, clock: 9 },
+    });
+    expect(getSnapshot).not.toHaveBeenCalled();
+    expect(channel.emit.mock.calls.filter(([event]) => event === SERVICE_SYNC_REPLY)).toHaveLength(
+      0
+    );
+
+    channel.emitExternal(SERVICE_SYNC_REQUEST, {
+      serviceId: SERVICE_ID,
+      runtimeId: 'joiner',
+      frontier: { vector: {}, clock: 0 },
+    });
+    expect(getSnapshot).toHaveBeenCalledTimes(1);
+    expect(channel.emit).toHaveBeenCalledWith(
+      SERVICE_SYNC_REPLY,
+      expect.objectContaining({ serviceId: SERVICE_ID, state: { n: 1 } })
+    );
+
+    disconnect();
+  });
+});

--- a/code/core/src/shared/open-service/service-transport.ts
+++ b/code/core/src/shared/open-service/service-transport.ts
@@ -15,16 +15,18 @@
  * - {@link wrapCommandsForBroadcast} wraps a runtime's commands so each local call that touched
  *   state, after it resolves, stamps an RFC 6902 `services:entry` and emits it. A command that
  *   writes nothing emits nothing and does not bump the stamp.
- * - {@link connectRuntimeToChannel} attaches the sync-start initialization and entry listeners, emits
- *   the bootstrap sync-start, and returns a teardown. A `relay` hub re-emits every `services:entry`
- *   it accepted and every bootstrap snapshot it adopted, forwarding the original payload object.
+ * - {@link connectRuntimeToChannel} attaches the sync-request / sync-reply and entry listeners,
+ *   emits a bootstrap `services:sync-request`, and returns a teardown. A `relay` hub re-emits every
+ *   `services:entry` it accepted and every `services:sync-reply` it installed, forwarding the
+ *   original payload object. It never forwards a request.
  * - {@link connectCommandTransport} bridges the gap where a command is only implemented in *some*
  *   runtimes (e.g. a handler supplied at server registration). A runtime without a local handler
  *   requests remote execution; a runtime that has one listens for those requests, runs the command,
  *   and replies. See its docs for the request/ack/result/error protocol.
  *
  * The merge and ordering rules themselves live in `service-sync.ts`; this module only moves entries
- * and bootstrap snapshots on and off the channel.
+ * and snapshot replies on and off the channel. `getSnapshot()` runs only to answer a dominating
+ * request.
  */
 
 import * as v from 'valibot';
@@ -42,8 +44,8 @@ import {
   SERVICE_COMMAND_RESULT,
   SERVICE_COMMAND_UNHANDLED,
   SERVICE_ENTRY,
-  SERVICE_SYNC_START,
-  SERVICE_SYNC_START_REPLY,
+  SERVICE_SYNC_REPLY,
+  SERVICE_SYNC_REQUEST,
   type CommandAckPayload,
   type CommandErrorPayload,
   type CommandInvokePayload,
@@ -51,8 +53,8 @@ import {
   type CommandUnhandledPayload,
   type EntryPayload,
   type ServiceChannel,
-  type SyncStartPayload,
-  type SyncStartReplyPayload,
+  type SyncReplyPayload,
+  type SyncRequestPayload,
   commandAckSchema,
   commandErrorSchema,
   commandInvokeSchema,
@@ -60,11 +62,11 @@ import {
   commandUnhandledSchema,
   entrySchema,
   generateCallId,
-  stampedSnapshotSchema,
-  syncStartSchema,
+  syncReplySchema,
+  syncRequestSchema,
 } from './service-channel.ts';
 import { deserializeError, serializeError } from './service-error-serialization.ts';
-import type { SnapshotReconciler } from './service-sync.ts';
+import { vectorDominates, type SnapshotReconciler } from './service-sync.ts';
 import type { ServiceId } from './types.ts';
 
 /** A runtime command as seen by the transport layer: `(input, collector?) => Promise<result>`. */
@@ -91,6 +93,9 @@ type RuntimeCommand = (input: unknown, collector?: PatchCollector) => Promise<un
  */
 export const REMOTE_COMMAND_ACK_TIMEOUT_MS = 300;
 
+/** A reply, or this much silence, clears the one outstanding `sync-request` per service. */
+export const SYNC_REQUEST_SILENCE_MS = 1000;
+
 type PendingRemoteCommand = {
   commandName: string;
   resolve: (value: unknown) => void;
@@ -104,7 +109,7 @@ interface RuntimeTransportContext {
   serviceId: ServiceId;
   /** This runtime's stable id, used to drop its own bootstrap request and its own echoes. */
   ownRuntimeId: string;
-  /** The reconciler owning this runtime's LWW stamp and its adopt/advance transitions. */
+  /** The reconciler owning this runtime's Log, Vector, Clock, and adopt/advance transitions. */
   reconciler: SnapshotReconciler;
   /** Reads the runtime's current live state at emit time. */
   getSnapshot: () => Record<string, unknown>;
@@ -159,40 +164,60 @@ export function wrapCommandsForBroadcast(
 /**
  * Attaches the channel listeners that keep one runtime in sync with its peers, and returns a teardown.
  *
- * Wires three handlers and emits a bootstrap `services:sync-start` so a freshly-registered runtime
+ * Wires three handlers and emits a bootstrap `services:sync-request` so a freshly-registered runtime
  * catches up to state authored before it joined:
- * - sync-start → reply with our current snapshot+stamp (ignoring our own request);
- * - sync-start-reply → adopt iff strictly newer (and, on a relay hub, forward the original payload);
- * - entry → apply by path unless duplicate (and, on a relay hub, forward the original payload).
+ * - sync-request → reply `{ frontier, state }` only when our vector dominates the requester's;
+ * - sync-reply → install iff dominating (and, on a relay hub, forward the original payload);
+ * - entry → place by the five-case rule (and, on a relay hub, forward when logged).
  *
- * A `relay` hub re-emits every entry it accepted and every bootstrap snapshot it adopted, using the
- * original payload object so unknown fields survive the hop. Leaves keep `relay: false`.
+ * A `relay` hub re-emits every entry it logged and every snapshot reply it installed, using the
+ * original payload object so unknown fields survive the hop. It never forwards a request. Leaves
+ * keep `relay: false`. At most one outstanding request per service; a reply or
+ * {@link SYNC_REQUEST_SILENCE_MS} of silence clears the flag. A gap, beyond-window, or
+ * missing-parent during that wait queues one more request, sent when the outstanding request
+ * clears, using the frontier at send time. A reply — installed or rejected — sends that queued
+ * request.
  */
 export function connectRuntimeToChannel(
   context: RuntimeTransportContext & { channel: ServiceChannel; relay: boolean }
 ): () => void {
   const { serviceId, ownRuntimeId, reconciler, getSnapshot, channel, relay } = context;
 
-  const emitSyncStart = (): void => {
-    channel.emit(SERVICE_SYNC_START, {
+  let requestOutstanding = false;
+  let repairQueued = false;
+  let silenceTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const clearOutstandingRequest = (): void => {
+    requestOutstanding = false;
+    if (silenceTimer !== undefined) {
+      clearTimeout(silenceTimer);
+      silenceTimer = undefined;
+    }
+  };
+
+  const emitSyncRequest = (): void => {
+    if (requestOutstanding) {
+      repairQueued = true;
+      return;
+    }
+    requestOutstanding = true;
+    repairQueued = false;
+    channel.emit(SERVICE_SYNC_REQUEST, {
       serviceId,
       runtimeId: ownRuntimeId,
-    } satisfies SyncStartPayload);
+      frontier: reconciler.frontier,
+    } satisfies SyncRequestPayload);
+    silenceTimer = setTimeout(() => {
+      requestOutstanding = false;
+      silenceTimer = undefined;
+      if (repairQueued) {
+        emitSyncRequest();
+      }
+    }, SYNC_REQUEST_SILENCE_MS);
   };
 
-  const emitSyncStartReply = (): void => {
-    channel.emit(SERVICE_SYNC_START_REPLY, {
-      serviceId,
-      state: getSnapshot(),
-      version: reconciler.stamp.version,
-      runtimeId: reconciler.stamp.runtimeId,
-    } satisfies SyncStartReplyPayload);
-  };
-
-  // Reply to a peer's sync-start with our current snapshot+stamp (which may be one we adopted from yet
-  // another peer, not necessarily our own runtimeId). Skip our own bootstrap request.
-  const onSyncStart = (payload: unknown): void => {
-    const request = v.safeParse(syncStartSchema, payload);
+  const onSyncRequest = (payload: unknown): void => {
+    const request = v.safeParse(syncRequestSchema, payload);
     if (
       !request.success ||
       request.output.serviceId !== serviceId ||
@@ -201,24 +226,37 @@ export function connectRuntimeToChannel(
       return;
     }
 
-    emitSyncStartReply();
+    if (!vectorDominates(reconciler.vector, request.output.frontier.vector)) {
+      return;
+    }
+
+    channel.emit(SERVICE_SYNC_REPLY, {
+      serviceId,
+      frontier: reconciler.frontier,
+      state: getSnapshot(),
+    } satisfies SyncReplyPayload);
   };
 
-  // Bootstrap from a peer's sync-start-reply. Version-gating (not a first-reply-only guard) is what
-  // makes this converge when several peers reply: each reply is adopted only if strictly newer.
-  const onSyncStartReply = (payload: unknown): void => {
-    const snapshot = v.safeParse(stampedSnapshotSchema, payload);
+  const onSyncReply = (payload: unknown): void => {
+    const snapshot = v.safeParse(syncReplySchema, payload);
     if (!snapshot.success || snapshot.output.serviceId !== serviceId) {
       return;
     }
 
-    const adopted = reconciler.tryAdopt(
-      { version: snapshot.output.version, runtimeId: snapshot.output.runtimeId },
-      snapshot.output.state
+    const installed = reconciler.tryAdopt(
+      snapshot.output.frontier,
+      snapshot.output.state,
+      serviceId
     );
+    const queued = repairQueued;
+    clearOutstandingRequest();
 
-    if (adopted && relay) {
-      channel.emit(SERVICE_SYNC_START_REPLY, payload);
+    if (queued) {
+      emitSyncRequest();
+    }
+
+    if (installed && relay) {
+      channel.emit(SERVICE_SYNC_REPLY, payload);
     }
   };
 
@@ -228,35 +266,51 @@ export function connectRuntimeToChannel(
       return;
     }
 
-    const accepted = reconciler.tryAdoptEntry({
+    const outcome = reconciler.tryAdoptEntry({
       serviceId: parsed.output.serviceId,
       stamp: parsed.output.stamp,
       command: parsed.output.command,
       patch: parsed.output.patch,
     });
 
-    if (accepted && relay) {
-      channel.emit(SERVICE_ENTRY, payload);
+    switch (outcome) {
+      case 'accepted':
+        if (relay) {
+          channel.emit(SERVICE_ENTRY, payload);
+        }
+        break;
+      case 'gap':
+        if (relay) {
+          channel.emit(SERVICE_ENTRY, payload);
+        }
+        emitSyncRequest();
+        break;
+      case 'beyond-window':
+      case 'missing-parent':
+        emitSyncRequest();
+        break;
+      case 'duplicate':
+        break;
+      default: {
+        const exhaustive: never = outcome;
+        void exhaustive;
+        break;
+      }
     }
   };
 
-  channel.on(SERVICE_SYNC_START, onSyncStart);
-  channel.on(SERVICE_SYNC_START_REPLY, onSyncStartReply);
+  channel.on(SERVICE_SYNC_REQUEST, onSyncRequest);
+  channel.on(SERVICE_SYNC_REPLY, onSyncReply);
   channel.on(SERVICE_ENTRY, onEntry);
 
-  // Ask any existing peer for the current state so we catch up to changes authored before we joined.
-  emitSyncStart();
-
-  // A hub that already holds peer-adopted state (e.g. after a hot reload) pushes once so late
-  // joiners on other transports can converge without waiting for another mutation.
-  if (relay && reconciler.stamp.version > 0) {
-    emitSyncStartReply();
-  }
+  emitSyncRequest();
 
   return (): void => {
-    channel.off(SERVICE_SYNC_START, onSyncStart);
-    channel.off(SERVICE_SYNC_START_REPLY, onSyncStartReply);
+    channel.off(SERVICE_SYNC_REQUEST, onSyncRequest);
+    channel.off(SERVICE_SYNC_REPLY, onSyncReply);
     channel.off(SERVICE_ENTRY, onEntry);
+    repairQueued = false;
+    clearOutstandingRequest();
   };
 }
 
@@ -577,7 +631,7 @@ type ChannelConnectedRuntime = {
  * a single teardown.
  *
  * This is the one entry point `registerService` uses, so the three transport halves — command
- * broadcasting, the remote-command protocol, and the sync-start + entry listeners — are always
+ * broadcasting, the remote-command protocol, and the sync-request + entry listeners — are always
  * assembled together against the same `channel` and can never drift into using different channels.
  * The channel-routed command map is also installed on the runtime so load bodies invoke
  * peer-implemented commands remotely instead of throwing locally.

--- a/code/core/src/shared/open-service/sync-simulation.test.ts
+++ b/code/core/src/shared/open-service/sync-simulation.test.ts
@@ -1,9 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { logger } from 'storybook/internal/client-logger';
 
-import { entryStampKey, SERVICE_ENTRY } from './service-channel.ts';
+import {
+  entryStampKey,
+  SERVICE_ENTRY,
+  SERVICE_SYNC_REPLY,
+  SERVICE_SYNC_REQUEST,
+} from './service-channel.ts';
 import { compareStamps } from './service-sync.ts';
 import { createWorld, topologies, type TopologyKind, type World } from './sync-simulation/world.ts';
+import { VirtualNetwork } from './sync-simulation/network.ts';
 
 vi.mock('storybook/internal/client-logger', { spy: true });
 
@@ -12,6 +18,30 @@ const formatWorld = (world: World) =>
 
 const drain = vi.defineHelper((world: World): void => {
   world.network.drain();
+});
+
+const assertStateConverged = vi.defineHelper((world: World): void => {
+  const expected = world.replicas[0];
+  for (const replica of world.replicas) {
+    expect(replica.getState(), `State differs on ${replica.id}. ${formatWorld(world)}`).toEqual(
+      expected.getState()
+    );
+  }
+});
+
+const assertCoverage = vi.defineHelper((world: World): void => {
+  const authored = world.replicas.flatMap((replica) => replica.authored);
+  for (const replica of world.replicas) {
+    for (const stamp of authored) {
+      const covered =
+        replica.reconciler.has(stamp) ||
+        (replica.reconciler.vector[stamp.runtimeId] ?? 0) >= stamp.counter;
+      expect(
+        covered,
+        `Stamp ${entryStampKey(stamp)} missing on ${replica.id}. ${formatWorld(world)}`
+      ).toBe(true);
+    }
+  }
 });
 
 const assertReplicasAgree = vi.defineHelper((world: World): void => {
@@ -62,6 +92,12 @@ const settle = vi.defineHelper((world: World): void => {
   assertReplicasAgree(world);
 });
 
+const settleRepaired = vi.defineHelper((world: World): void => {
+  drain(world);
+  assertStateConverged(world);
+  assertCoverage(world);
+});
+
 describe('open-service sync simulation', () => {
   let world: World | undefined;
 
@@ -107,15 +143,15 @@ describe('open-service sync simulation', () => {
     assertRelayTermination(current);
   });
 
-  it('places a gap then the skipped earlier counter without warning', async () => {
+  it('places a gap then the skipped earlier counter, warns, and repairs', async () => {
     const current = boot('dev-triangle');
     current.network.setDelay('server', 'manager', 20);
     current.network.dropNext('preview', 'manager');
     await current.replica('preview').commands.setSlot({ slot: 'a', value: '1' });
     await current.replica('preview').commands.setSlot({ slot: 'b', value: '2' });
-    settle(current);
+    settleRepaired(current);
     expect(current.replica('manager').getState().slots).toEqual({ a: '1', b: '2' });
-    expect(vi.mocked(logger.warn)).not.toHaveBeenCalled();
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(expect.stringContaining('gap in writer'));
   });
 
   it('undoes through a burst past 256 when a concurrent write is placed earlier', async () => {
@@ -177,28 +213,191 @@ describe('open-service sync simulation', () => {
     expect(current.replica('pb').getState().slots).toEqual({ a: '1' });
   });
 
-  it('keeps entry frames within a small constant of the first and does not structuredClone on the entry path', async () => {
-    const current = boot('dev-triangle');
+  it('keeps entry frames within a small constant of the first; structuredClone runs only inside a reply', async () => {
+    world = createWorld(topologies['dev-triangle'], { skip: ['preview'] });
+    drain(world);
     vi.spyOn(globalThis, 'structuredClone');
     const cloneSpy = vi.mocked(globalThis.structuredClone);
     cloneSpy.mockClear();
-    current.network.frames.length = 0;
+    world.network.frames.length = 0;
 
     for (let index = 0; index < 20; index += 1) {
-      await current.replica('preview').commands.setSlot({
+      await world.replica('manager').commands.setSlot({
         slot: `s${index}`,
         value: 'v'.repeat(40),
       });
     }
-    drain(current);
+    drain(world);
 
-    const entryFrames = current.network.frames.filter((frame) => frame.type === SERVICE_ENTRY);
+    const entryFrames = world.network.frames.filter((frame) => frame.type === SERVICE_ENTRY);
     expect(entryFrames.length).toBeGreaterThan(0);
     const first = entryFrames[0].bytes;
     for (const frame of entryFrames) {
       expect(frame.bytes).toBeLessThan(first + 80);
     }
     expect(cloneSpy).not.toHaveBeenCalled();
+
+    cloneSpy.mockClear();
+    world.join('preview');
+    drain(world);
+    expect(cloneSpy).toHaveBeenCalled();
+    expect(world.replica('preview').getState().slots.s0).toBe('v'.repeat(40));
+  });
+
+  it.each(['dev-triangle', 'production-fan', 'two-tabs'] as const)(
+    'bootstraps a late joiner with an empty frontier on %s',
+    async (kind) => {
+      const lateId = kind === 'dev-triangle' ? 'preview' : kind === 'production-fan' ? 'p2' : 'pb';
+      const writerId =
+        kind === 'dev-triangle' ? 'manager' : kind === 'production-fan' ? 'p1' : 'pa';
+      world = createWorld(topologies[kind], { skip: [lateId] });
+      drain(world);
+      await world.replica(writerId).commands.setSlot({ slot: 'late', value: 'yes' });
+      drain(world);
+
+      world.join(lateId);
+      settleRepaired(world);
+      expect(world.replica(lateId).getState().slots.late).toBe('yes');
+    }
+  );
+
+  it('keeps a behind replica own writes while catching up through a snapshot', async () => {
+    const current = boot('dev-triangle');
+    await vi.advanceTimersByTimeAsync(1000);
+    current.network.dropNext('manager', 'preview', 2);
+    current.network.dropNext('server', 'preview', 2);
+    await current.replica('manager').commands.setSlot({ slot: 'a', value: '1' });
+    await current.replica('manager').commands.setSlot({ slot: 'b', value: '2' });
+    await current.replica('preview').commands.setSlot({ slot: 'mine', value: 'p' });
+    await current.replica('manager').commands.setSlot({ slot: 'c', value: '3' });
+    settleRepaired(current);
+    expect(current.replica('preview').getState().slots).toEqual({
+      a: '1',
+      b: '2',
+      mine: 'p',
+      c: '3',
+    });
+  });
+
+  it('installs two dominating replies in arrival order', async () => {
+    world = createWorld(topologies['dev-triangle'], { skip: ['preview'] });
+    drain(world);
+    await world.replica('server').commands.setSlot({ slot: 'a', value: '1' });
+    drain(world);
+    world.network.hold('server', 'manager');
+    world.network.hold('manager', 'server');
+    await world.replica('server').commands.setSlot({ slot: 'b', value: '2' });
+    drain(world);
+
+    world.network.hold('server', 'preview');
+    world.join('preview');
+    drain(world);
+    expect(world.replica('preview').getState().slots).toEqual({ a: '1' });
+
+    world.network.release('server', 'preview');
+    drain(world);
+    expect(world.replica('preview').getState().slots).toEqual({ a: '1', b: '2' });
+
+    world.network.release('server', 'manager');
+    world.network.release('manager', 'server');
+    settleRepaired(world);
+  });
+
+  it('drops a concurrent reply with a warning and does not assert convergence', async () => {
+    world = createWorld(topologies['dev-triangle'], { skip: ['preview'] });
+    drain(world);
+    world.network.hold('server', 'manager');
+    world.network.hold('manager', 'server');
+    await world.replica('manager').commands.setSlot({ slot: 'a', value: 'from-manager' });
+    await world.replica('server').commands.setSlot({ slot: 'b', value: 'from-server' });
+    drain(world);
+
+    world.join('preview');
+    drain(world);
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.stringContaining('concurrent snapshot reply dropped')
+    );
+  });
+
+  it('clears a silent request after 1 s so a later gap can ask again', async () => {
+    const current = boot('dev-triangle');
+    const requestsAtBoot = current.network.frames.filter(
+      (frame) => frame.type === SERVICE_SYNC_REQUEST
+    ).length;
+    expect(requestsAtBoot).toBeGreaterThan(0);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    current.network.frames.length = 0;
+    current.network.dropNext('preview', 'manager');
+    current.network.dropNext('preview', 'server');
+    await current.replica('preview').commands.setSlot({ slot: 'a', value: '1' });
+    await current.replica('preview').commands.setSlot({ slot: 'b', value: '2' });
+    drain(current);
+
+    expect(current.network.frames.some((frame) => frame.type === SERVICE_SYNC_REQUEST)).toBe(true);
+    settleRepaired(current);
+  });
+
+  it('requests a snapshot after the window shrinks past an incoming entry', async () => {
+    world = createWorld(topologies['dev-triangle'], {
+      windows: { preview: { maxAgeMs: 0, maxEntries: 2 } },
+    });
+    drain(world);
+    await vi.advanceTimersByTimeAsync(1000);
+    world.network.dropNext('manager', 'preview', 1);
+    world.network.setDelay('server', 'preview', 50);
+    await world.replica('server').commands.setSlot({ slot: 'old', value: 'from-server' });
+    world.network.drainDue();
+    world.network.setDelay('server', 'preview', 0);
+    await world.replica('manager').commands.setSlot({ slot: 'a', value: '1' });
+    await world.replica('manager').commands.setSlot({ slot: 'b', value: '2' });
+    await world.replica('manager').commands.setSlot({ slot: 'c', value: '3' });
+    world.network.drainDue();
+    settleRepaired(world);
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.stringContaining('beyond the log window')
+    );
+    expect(world.replica('preview').getState().slots).toEqual({
+      old: 'from-server',
+      a: '1',
+      b: '2',
+      c: '3',
+    });
+  });
+
+  it('converges a preview through a forwarded snapshot after the server drops a beyond-window entry', async () => {
+    world = createWorld(topologies['dev-triangle'], {
+      windows: { server: { maxAgeMs: 0, maxEntries: 2 } },
+    });
+    drain(world);
+    await vi.advanceTimersByTimeAsync(1000);
+    world.network.dropNext('manager', 'server', 1);
+    world.network.dropNext('manager', 'preview', 10);
+    world.network.dropNext('server', 'preview', 3);
+    world.network.setDelay('preview', 'server', 50);
+
+    await world.replica('preview').commands.setSlot({ slot: 'early', value: 'yes' });
+    world.network.drainDue();
+    await world.replica('manager').commands.setSlot({ slot: 'a', value: '1' });
+    await world.replica('manager').commands.setSlot({ slot: 'b', value: '2' });
+    await world.replica('manager').commands.setSlot({ slot: 'c', value: '3' });
+    world.network.drainDue();
+    settleRepaired(world);
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.stringContaining('beyond the log window')
+    );
+    expect(world.replica('preview').getState().slots).toEqual({
+      early: 'yes',
+      a: '1',
+      b: '2',
+      c: '3',
+    });
+    expect(
+      world.network.frames.some(
+        (frame) =>
+          frame.type === SERVICE_SYNC_REPLY && frame.from === 'server' && frame.to === 'preview'
+      )
+    ).toBe(true);
   });
 
   it.each([
@@ -216,5 +415,62 @@ describe('open-service sync simulation', () => {
 
     expect(current.replica(earlier).getState().slots.shared).toBe(later);
     assertRelayTermination(current);
+  });
+
+  it('repairs a delayed concurrent entry that arrives after snapshot bootstrap', async () => {
+    world = createWorld(topologies['dev-triangle'], { skip: ['preview'] });
+    drain(world);
+
+    world.network.hold('manager', 'server');
+    world.network.hold('manager', 'preview');
+
+    await world.replica('server').commands.setSlot({ slot: 'shared', value: 'server' });
+    await world.replica('manager').commands.setSlot({ slot: 'shared', value: 'manager' });
+    drain(world);
+
+    expect(world.replica('server').getState().slots.shared).toBe('server');
+    expect(world.replica('manager').getState().slots.shared).toBe('server');
+
+    world.join('preview');
+    drain(world);
+    expect(world.replica('preview').getState().slots.shared).toBe('server');
+    expect(world.replica('preview').reconciler.vector).toEqual({ server: 1 });
+
+    world.network.release('manager', 'server');
+    settleRepaired(world);
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.stringContaining('beyond the log window')
+    );
+    expect(world.replica('preview').getState().slots.shared).toBe('server');
+    expect(world.replica('preview').reconciler.vector).toEqual({ manager: 1, server: 1 });
+  });
+});
+
+describe('VirtualNetwork time', () => {
+  it('does not move now backward when delivering a released earlier frame', () => {
+    const network = new VirtualNetwork(
+      ['a', 'b', 'c'],
+      [
+        ['a', 'b'],
+        ['b', 'c'],
+      ]
+    );
+    network.hold('a', 'b');
+    network.channel('a').emit(SERVICE_ENTRY, { n: 1 });
+    network.setDelay('b', 'c', 50);
+    network.channel('b').emit(SERVICE_ENTRY, { n: 2 });
+    network.drain();
+
+    network.release('a', 'b');
+    network.setDelay('b', 'c', 0);
+    network.channel('b').emit(SERVICE_ENTRY, { n: 3 });
+    network.drainDue();
+
+    expect(
+      network.frames.some(
+        (frame) =>
+          frame.from === 'b' && frame.to === 'c' && (frame.payload as { n: number }).n === 3
+      )
+    ).toBe(true);
   });
 });

--- a/code/core/src/shared/open-service/sync-simulation/network.ts
+++ b/code/core/src/shared/open-service/sync-simulation/network.ts
@@ -18,6 +18,7 @@ type DirectedLink = {
   availableAt: number;
   dropNext: number;
   duplicateNext: number;
+  held: boolean;
 };
 
 type Delivery = {
@@ -88,14 +89,31 @@ export class VirtualNetwork {
     this.link(from, to).duplicateNext += count;
   }
 
+  hold(from: NodeId, to: NodeId): void {
+    this.link(from, to).held = true;
+  }
+
+  release(from: NodeId, to: NodeId): void {
+    this.link(from, to).held = false;
+  }
+
   drain(): void {
     let steps = 0;
-    while (this.deliveries.length > 0) {
+    while (this.deliverNext()) {
       steps += 1;
       if (steps > 10_000) {
         throw new Error('VirtualNetwork drain exceeded 10000 steps');
       }
-      this.deliverNext();
+    }
+  }
+
+  drainDue(): void {
+    let steps = 0;
+    while (this.deliverDue()) {
+      steps += 1;
+      if (steps > 10_000) {
+        throw new Error('VirtualNetwork drainDue exceeded 10000 steps');
+      }
     }
   }
 
@@ -107,6 +125,7 @@ export class VirtualNetwork {
       availableAt: 0,
       dropNext: 0,
       duplicateNext: 0,
+      held: false,
     };
   }
 
@@ -143,13 +162,29 @@ export class VirtualNetwork {
     }
   }
 
-  private deliverNext(): void {
+  private deliverNext(): boolean {
     this.deliveries.sort((left, right) => left.at - right.at || left.order - right.order);
-    const delivery = this.deliveries.shift();
-    if (!delivery) {
-      return;
+    const index = this.deliveries.findIndex((delivery) => !delivery.link.held);
+    if (index < 0) {
+      return false;
     }
-    this.now = delivery.at;
+    return this.deliverAt(index);
+  }
+
+  private deliverDue(): boolean {
+    this.deliveries.sort((left, right) => left.at - right.at || left.order - right.order);
+    const index = this.deliveries.findIndex(
+      (delivery) => !delivery.link.held && delivery.at <= this.now
+    );
+    if (index < 0) {
+      return false;
+    }
+    return this.deliverAt(index);
+  }
+
+  private deliverAt(index: number): true {
+    const delivery = this.deliveries.splice(index, 1)[0];
+    this.now = Math.max(this.now, delivery.at);
     this.frames.push({
       from: delivery.link.from,
       to: delivery.link.to,
@@ -158,5 +193,6 @@ export class VirtualNetwork {
       payload: delivery.event.args[0],
     });
     this.channels.get(delivery.link.to)?.receive(delivery.event);
+    return true;
   }
 }

--- a/code/core/src/shared/open-service/sync-simulation/replicas.ts
+++ b/code/core/src/shared/open-service/sync-simulation/replicas.ts
@@ -121,7 +121,6 @@ export function attachReplica(options: {
   const reconciler = createSnapshotReconciler({
     setState: (mutate) =>
       runtime.commandSelf.setState((state) => mutate(state as Record<string, unknown>)),
-    initialStamp: { version: 0, runtimeId },
     window,
   });
 

--- a/code/core/src/shared/open-service/sync-simulation/world.ts
+++ b/code/core/src/shared/open-service/sync-simulation/world.ts
@@ -1,5 +1,6 @@
 import { attachReplica, type Replica } from './replicas.ts';
 import { VirtualNetwork, type NodeId } from './network.ts';
+import type { LogWindow } from '../service-sync.ts';
 
 export type TopologyKind = 'dev-triangle' | 'production-fan' | 'two-tabs';
 
@@ -60,18 +61,47 @@ export type World = {
   network: VirtualNetwork;
   replicas: Replica[];
   replica: (id: NodeId) => Replica;
+  join: (id: NodeId, options?: { window?: Partial<LogWindow> }) => Replica;
   disconnect: () => void;
 };
 
-export function createWorld(topology: Topology): World {
+export function createWorld(
+  topology: Topology,
+  options?: { skip?: readonly NodeId[]; windows?: Partial<Record<NodeId, Partial<LogWindow>>> }
+): World {
+  const skipped = new Set(options?.skip ?? []);
+  const windows = options?.windows ?? {};
   const network = new VirtualNetwork(
     topology.nodes.map((node) => node.id),
     topology.edges
   );
-  const replicas = topology.nodes.map((node) =>
-    attachReplica({ network, id: node.id, relay: node.relay })
-  );
-  const byId = new Map(replicas.map((replica) => [replica.id, replica]));
+  const replicas: Replica[] = [];
+  const byId = new Map<NodeId, Replica>();
+
+  const join = (id: NodeId, extra?: { window?: Partial<LogWindow> }): Replica => {
+    if (byId.has(id)) {
+      throw new Error(`Replica ${id} is already joined`);
+    }
+    const node = topology.nodes.find((candidate) => candidate.id === id);
+    if (!node) {
+      throw new Error(`Unknown replica ${id}`);
+    }
+    const replica = attachReplica({
+      network,
+      id: node.id,
+      relay: node.relay,
+      window: extra?.window ?? windows[id],
+    });
+    replicas.push(replica);
+    byId.set(id, replica);
+    return replica;
+  };
+
+  for (const node of topology.nodes) {
+    if (!skipped.has(node.id)) {
+      join(node.id);
+    }
+  }
 
   return {
     topology,
@@ -84,6 +114,7 @@ export function createWorld(topology: Topology): World {
       }
       return replica;
     },
+    join,
     disconnect: () => {
       for (const replica of replicas) {
         replica.disconnect();

--- a/code/core/src/shared/open-service/sync-wire.test.ts
+++ b/code/core/src/shared/open-service/sync-wire.test.ts
@@ -77,7 +77,6 @@ function connectLeafRuntime(channel: Channel) {
   const reconciler = createSnapshotReconciler({
     setState: (mutate) =>
       runtime.commandSelf.setState((state) => mutate(state as Record<string, unknown>)),
-    initialStamp: { version: 0, runtimeId: ownRuntimeId },
   });
 
   const commandNames = Object.keys(definition.commands);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

Linear: [SB-2052](https://linear.app/chromaui/issue/SB-2052/pr-5-bootstrap-and-repair-through-snapshots-sync-request-sync-reply) (PR 5 of [SB-2054](https://linear.app/chromaui/issue/SB-2054)). Stacked on [PR 4](https://github.com/storybookjs/storybook/pull/36265).

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Bootstrap and repair no longer use last-write-wins `services:sync-start`. A runtime **asks** with a frontier. A peer **answers** only when it is strictly ahead. Install keeps local writes the snapshot has not covered, and treats the installed clock as a history floor so a delayed concurrent entry cannot apply over snapshot state.

```text
services:sync-request  { serviceId, runtimeId, frontier: { vector, clock } }
services:sync-reply    { serviceId, frontier, state }
```

There is no unasked hub push. Hubs forward installed replies (original payload), never requests.

**Not in this PR:** how entries are ordered, undone, or redone (that is [PR 4](https://github.com/storybookjs/storybook/pull/36265)). README polish is still a later pass — skip that commit.

The How to review section is the useful bit. Commits 1 and 2 are the protocol. Commits 3 and 4 are tests and docs.

<details>
<summary><h2>ELI5: ask, dominate, install, floor</h2></summary>

PR 4 gave every runtime a **Log**, a **Vector** (“I have Alice through 3 with no holes”), and a **Clock** (highest `seq` I have heard). This PR puts Vector + Clock on the wire as a **Frontier**, and uses it for join and repair.

### Ask, don’t push

On register, a runtime emits `sync-request` with its frontier. Fresh joiners send an empty vector and clock 0. A peer looks at that vector. If the peer is **ahead**, it snapshots and replies. If not, it stays silent. Empty vs empty stays silent too — nobody has writes yet.

```mermaid
sequenceDiagram
  participant J as Joiner
  participant P as Peer
  J->>P: sync-request { vector: {}, clock: 0 }
  P->>P: my vector dominates empty
  P->>J: sync-reply { frontier, state }
  J->>J: install in one setState batch
```

**Dominate** means: every counter is at least equal, and at least one is greater. Or: the other side is empty and you are not. Concurrent vectors (`{a:1}` vs `{b:1}`) do not dominate. That reply is dropped with a warning naming both frontiers.

```mermaid
flowchart LR
  empty["joiner {}"] --> yes["{z:1} dominates → reply"]
  concurrent["{a:1} vs {b:1}"] --> no["neither dominates → drop"]
```

### Install is not last-write-wins

Inside one `setState` batch: merge `state`, `clock = max(clock, reply.clock)`, take the reply vector, **drop log entries that vector covers**, re-apply the rest in canonical order (and recompute inverses). Those leftover entries are writes the snapshot did not know about — a behind replica keeps its own slots while catching up.

### Why the installed clock is a floor

A snapshot folds history. If a delayed concurrent write then arrives with a `seq` at or below that clock, appending it over the snapshot can split state while both vectors become `{a:1,z:1}` — and later snapshots cannot heal that, because neither dominates.

```mermaid
sequenceDiagram
  participant Peer
  participant Joiner
  Note over Peer: has 1:z:1, state z
  Joiner->>Joiner: install {z:1} clock 1, empty log
  Peer->>Peer: delayed 1:a:1, reorder, still z, vector {a:1,z:1}
  alt without floor
    Peer->>Joiner: 1:a:1
    Joiner->>Joiner: append over snapshot, state a, same vector
    Note over Peer,Joiner: split. later snapshots cannot dominate
  else with floor
    Peer->>Joiner: 1:a:1
    Joiner->>Joiner: seq 1 is beyond-window, request repair
    Peer->>Joiner: snapshot {a:1,z:1} state z
  end
```

Covered snapshot writers (`1:z:1` after `{z:1}`) still count as **duplicate**, not beyond-window.

### One outstanding request, plus a queue

Gap / beyond-window / missing-parent ask for a snapshot. At most one request is in flight. A second anomaly during that wait is queued. A reply — even one that installs — sends that queued request with the **current** frontier. Dominate does not prove the snapshot covered the hole that queued it (a `{z:1}` reply can install over an empty vector while `w:2` was a gap). Equal peers stay silent, so the extra request is cheap.

</details>

### How to review

History is four commits, oldest first. Walk the **Commits** tab in that order. Do not start on the Files tab — that mixes the protocol with harness plumbing and README.

1. **[Open-service: Install dominating snapshot frontiers](https://github.com/storybookjs/storybook/pull/36271/commits/c34d7a83fda21147294be4ecbd261bb4452ea527)** — **read this one.** Core install rule.

   What to look for: `vectorDominates` (empty vs empty is silent; empty vs nonempty is not); `tryAdopt` drops covered log entries and re-applies the rest; `snapshotSeq` is `max(existing, clock)` after install; uncovered `seq` at or below that floor is `beyond-window`; covered snapshot writers still hit `duplicate` first.

   Start in `service-sync.ts` and `service-sync.test.ts`. `service-channel.ts` is the envelope (`sync-request` / `sync-reply`, `frontier`). Skip the one-line `initialStamp` deletions in `service-registry.ts`, `replicas.ts`, and `sync-wire.test.ts`.

2. **[Open-service: Request and reply with frontiers on the wire](https://github.com/storybookjs/storybook/pull/36271/commits/3f73d5885daf1e7270515c37b6b71f7ab6918d2f)** — **read this one.** Who speaks, and when.

   What to look for: every runtime emits one request on register; a peer replies only when its vector dominates, and `getSnapshot()` runs only then; hubs forward an **installed** reply (original payload) and never a request; gap / beyond-window / missing-parent set at most one outstanding request; a second anomaly queues; any reply sends the queued request with the frontier after adopt.

   Start in `service-transport.ts` and `service-transport-sync.test.ts`. `service-registration-sync.test.ts` and `service-transport-leaf.test.ts` are the same policy through `registerService`.

3. **[Open-service: Cover snapshot bootstrap and repair in the harness](https://github.com/storybookjs/storybook/pull/36271/commits/a1e5d92d1ac9c74d6064e535ceaa063831ec4b5e)** — **skippable.** World plumbing so a late joiner can install a snapshot, then a held concurrent entry is released. Same idea as PR 4’s simulation commit. Feel free to skip it entirely.

4. **[Open-service: Document snapshot request and reply](https://github.com/storybookjs/storybook/pull/36271/commits/9c8903cf3a10c0c36e3c966fb63a0bac961b186a)** — **skip.** README protocol sequence plus leftover `sync-start` comment renames. There is a later task to keep README and tests aligned at the end of this stack.

### Protocol details worth checking

- Reply iff `vectorDominates(local, requester)`. Concurrent replies warn and are not forwarded.
- Install: merge state; `clock = max(clock, reply.clock)`; take the reply vector; drop covered log entries; re-apply the rest in canonical order.
- Installed clock is an ordering floor. Uncovered arrivals at or below it are beyond-window (warn + request). Folded writers stay duplicates.
- At most one outstanding request per service. A reply or 1 s of silence clears it. A repair needed during that wait is queued and sent when the outstanding request clears, using the frontier at send time. A reply always sends the queued request.
- Hubs never forward `sync-request`. No unasked hub push on startup.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [x] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

Primary proof is automated. Optional UI check of join/reload, after PR 4 is available:

1. From the repo root: `yarn nx compile core`
2. `cd code && yarn storybook:ui`
3. Open an Open Service demo story. Confirm manager and preview state match.
4. Reload the preview iframe. State should catch up through a snapshot, then keep matching on later writes.

Focused checks:

```bash
yarn test service-sync.test.ts service-channel.test.ts service-registration-sync.test.ts service-transport-sync.test.ts service-transport-leaf.test.ts sync-simulation.test.ts sync-wire.test.ts
```

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa18e831-f475-46c8-9da3-4ec50d9b9d7c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa18e831-f475-46c8-9da3-4ec50d9b9d7c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

