### PR TITLE
Addon-docs: Keep test builds from crashing when docs config is missing

### DIFF
--- a/code/addons/docs/src/preset.test.ts
+++ b/code/addons/docs/src/preset.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { docs } from './preset.ts';
+
+describe('docs preset', () => {
+  it('returns an object when autodocs is disabled for a test build', () => {
+    const result = docs({ defaultName: 'Docs' }, {
+      build: { test: { disableAutoDocs: true } },
+    } as Parameters<typeof docs>[1]);
+
+    expect(result).toEqual({});
+  });
+});

--- a/code/addons/docs/src/preset.ts
+++ b/code/addons/docs/src/preset.ts
@@ -138,7 +138,7 @@ async function webpack(webpackConfig: any = {}, options: DocsOptions) {
 
 const docs: PresetProperty<'docs'> = (input = {}, options) => {
   if (options?.build?.test?.disableAutoDocs) {
-    return undefined;
+    return {};
   }
 
   const result: StorybookConfigRaw['docs'] = {

--- a/code/frameworks/angular-vite/src/preset.ts
+++ b/code/frameworks/angular-vite/src/preset.ts
@@ -52,7 +52,7 @@ export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
   }
 
   const docsConfig = await options.presets.apply('docs', {}, options);
-  const docsEnabled = Object.keys(docsConfig).length > 0;
+  const docsEnabled = Object.keys(docsConfig ?? {}).length > 0;
   if (docsEnabled) {
     const docsConfigPath = fileURLToPath(
       import.meta.resolve('@storybook/angular-vite/client/docs/config')

--- a/code/frameworks/angular/src/preset.ts
+++ b/code/frameworks/angular/src/preset.ts
@@ -23,7 +23,7 @@ export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
   }
 
   const docsConfig = await options.presets.apply('docs', {}, options);
-  const docsEnabled = Object.keys(docsConfig).length > 0;
+  const docsEnabled = Object.keys(docsConfig ?? {}).length > 0;
   if (docsEnabled) {
     const docsConfigPath = fileURLToPath(
       import.meta.resolve('@storybook/angular/client/docs/config')

--- a/code/renderers/html/src/preset.ts
+++ b/code/renderers/html/src/preset.ts
@@ -6,7 +6,8 @@ export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
   input = [],
   options
 ) => {
-  const docsEnabled = Object.keys(await options.presets.apply('docs', {}, options)).length > 0;
+  const docsEnabled =
+    Object.keys((await options.presets.apply('docs', {}, options)) ?? {}).length > 0;
   const result: string[] = [];
 
   return result

--- a/code/renderers/preact/src/preset.ts
+++ b/code/renderers/preact/src/preset.ts
@@ -6,7 +6,8 @@ export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
   input = [],
   options
 ) => {
-  const docsEnabled = Object.keys(await options.presets.apply('docs', {}, options)).length > 0;
+  const docsEnabled =
+    Object.keys((await options.presets.apply('docs', {}, options)) ?? {}).length > 0;
   const result: string[] = [];
 
   return result

--- a/code/renderers/react/src/preset.test.ts
+++ b/code/renderers/react/src/preset.test.ts
@@ -14,6 +14,10 @@ describe('optimizeViteDeps', () => {
 
 describe('previewAnnotations', () => {
   it('does not throw when the docs preset returns undefined', async () => {
+    if (typeof previewAnnotations !== 'function') {
+      throw new Error('expected previewAnnotations to be a function');
+    }
+
     const options = {
       presets: {
         apply: async (key: string) => {

--- a/code/renderers/react/src/preset.test.ts
+++ b/code/renderers/react/src/preset.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { optimizeViteDeps } from './preset.ts';
+import { optimizeViteDeps, previewAnnotations } from './preset.ts';
 
 describe('optimizeViteDeps', () => {
   it('includes react-dom/test-utils', () => {
@@ -9,5 +9,25 @@ describe('optimizeViteDeps', () => {
     // so it must be listed explicitly in optimizeViteDeps.
     // If this test fails, add 'react-dom/test-utils' back to the optimizeViteDeps array in preset.ts.
     expect(optimizeViteDeps).toContain('react-dom/test-utils');
+  });
+});
+
+describe('previewAnnotations', () => {
+  it('does not throw when the docs preset returns undefined', async () => {
+    const options = {
+      presets: {
+        apply: async (key: string) => {
+          if (key === 'docs') {
+            return undefined;
+          }
+          if (key === 'features') {
+            return {};
+          }
+          return {};
+        },
+      },
+    };
+
+    await expect(previewAnnotations([], options as never)).resolves.toEqual(expect.any(Array));
   });
 });

--- a/code/renderers/react/src/preset.ts
+++ b/code/renderers/react/src/preset.ts
@@ -42,7 +42,7 @@ export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
     options.presets.apply('docs', {}, options),
     options.presets.apply('features', {}, options),
   ]);
-  const docsEnabled = Object.keys(docsConfig).length > 0;
+  const docsEnabled = Object.keys(docsConfig ?? {}).length > 0;
   const experimentalRSC = features?.experimentalRSC;
   const result: string[] = [];
 

--- a/code/renderers/svelte/src/preset.ts
+++ b/code/renderers/svelte/src/preset.ts
@@ -7,7 +7,8 @@ export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
   input = [],
   options
 ) => {
-  const docsEnabled = Object.keys(await options.presets.apply('docs', {}, options)).length > 0;
+  const docsEnabled =
+    Object.keys((await options.presets.apply('docs', {}, options)) ?? {}).length > 0;
   const result: string[] = [];
 
   return result

--- a/code/renderers/vue3/src/preset.ts
+++ b/code/renderers/vue3/src/preset.ts
@@ -11,7 +11,8 @@ export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
   input = [],
   options
 ) => {
-  const docsEnabled = Object.keys(await options.presets.apply('docs', {}, options)).length > 0;
+  const docsEnabled =
+    Object.keys((await options.presets.apply('docs', {}, options)) ?? {}).length > 0;
   const result: string[] = [];
 
   return result

--- a/code/renderers/web-components/src/preset.ts
+++ b/code/renderers/web-components/src/preset.ts
@@ -6,7 +6,8 @@ export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
   input = [],
   options
 ) => {
-  const docsEnabled = Object.keys(await options.presets.apply('docs', {}, options)).length > 0;
+  const docsEnabled =
+    Object.keys((await options.presets.apply('docs', {}, options)) ?? {}).length > 0;
   const result: string[] = [];
 
   return result


### PR DESCRIPTION
Closes #31699

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Chromatic local visual tests run a Storybook test build (`SB_TESTBUILD` / `--test`). In that mode addon-docs returned `undefined` for the `docs` preset, and renderer `previewAnnotations` hooks called `Object.keys` on it, which threw `Cannot convert undefined or null to object`.

This returns `{}` from the docs preset instead, and treats a missing docs config as disabled in React, Vue, Svelte, Preact, HTML, Web Components, Angular, and Angular Vite.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

1. In a React Vite project with `@storybook/addon-docs` enabled (Yarn PnP plus `getAbsolutePath` is the original repro, but a normal project is enough to check the test-build path).
2. Run `SB_TESTBUILD=true yarn build-storybook`.
3. Confirm the preview build completes. It should not fail with `Cannot convert undefined or null to object` in `@storybook/react` `previewAnnotations`.
4. Optional: start Storybook, run Visual Tests from the browser, and confirm the Chromatic Storybook build succeeds with addon-docs still listed in `main`.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->