### PR TITLE
Core: Add regression test for handled interaction errors

### DIFF
--- a/code/core/src/instrumenter/instrumenter.test.ts
+++ b/code/core/src/instrumenter/instrumenter.test.ts
@@ -502,6 +502,36 @@ describe('Instrumenter', () => {
     );
   });
 
+  it('keeps logging interactions after a handled async error', async () => {
+    const fn = async () => {};
+    const failingFn = async () => {
+      throw new Error('handled');
+    };
+    const { fn1, fn2, fn3 } = instrument({ fn1: fn, fn2: failingFn, fn3: fn }, { intercept: true });
+
+    setRenderPhase('playing');
+    await fn1();
+    let handledError: unknown;
+    try {
+      await fn2();
+    } catch (err) {
+      handledError = err;
+    }
+    expect(handledError).toEqual(new Error('handled'));
+    await fn3();
+    await tick();
+
+    expect(mocks.syncSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        logItems: [
+          { callId: 'kind--story [0] fn1', status: 'done', ancestors: [] },
+          { callId: 'kind--story [1] fn2', status: 'error', ancestors: [] },
+          { callId: 'kind--story [2] fn3', status: 'done', ancestors: [] },
+        ],
+      })
+    );
+  });
+
   it('emits a "sync" event with debounce after a patched function is invoked', () => {
     const { fn } = instrument({ fn: (...args: any) => {} }, { intercept: true });
     vi.useFakeTimers();


### PR DESCRIPTION
Closes #21746

## What I did

Added a regression test covering the scenario from #21746: when an instrumented call in a play function throws an error that the play function catches and handles, subsequent instrumented calls must still appear in the interactions log.

The test instruments three functions, makes the middle one reject, catches the error in the play function (exactly like a user would with `try/catch` around `screen.findByTestId`), then asserts the final `sync` payload still contains all three calls — with the failed call marked `error` and the later calls marked `done`.

## Why

The underlying behavior already works on `next`, but nothing prevents a regression. The original bug report (#21746, Storybook 6.5) showed the panel stopping at the first error even when the error was handled; a prior attempt to add this coverage (#34900) was closed, so this re-adds it in the current test style.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

### Documentation

Not needed — test-only change.