### PR TITLE
Docs: Backfill SB11 migration references and guide links

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,14 +1,19 @@
 <h1>Migration</h1>
 
 - [From version 10.x to 11.0.0](#from-version-10x-to-1100)
+  - [Node.js 22.12 or higher](#nodejs-2212-or-higher)
+  - [Yarn PnP support removed](#yarn-pnp-support-removed)
   - [Top-level `setConfig` layout and UI options removed](#top-level-setconfig-layout-and-ui-options-removed)
   - [Vitest Addon: requires Vitest 4.0 or higher](#vitest-addon-requires-vitest-40-or-higher)
+  - [Vite: `publicDir` is handled by Storybook's `staticDirs`](#vite-publicdir-is-handled-by-storybooks-staticdirs)
   - [Vite: requires Vite 6.3 or higher](#vite-requires-vite-63-or-higher)
   - [Next.js: Require v15 and up](#nextjs-require-v15-and-up)
   - [Angular: requires Angular 21 or higher](#angular-requires-angular-21-or-higher)
   - [`@storybook/nextjs` is deprecated](#nextjs-storybooknextjs-is-deprecated)
   - [Create React App support removed](#create-react-app-support-removed)
   - [`@storybook/angular-vite`: legacy animation modules are no longer auto-converted](#storybookangular-vite-legacy-animation-modules-are-no-longer-auto-converted)
+  - [Internal WebSocket heartbeat controls removed](#internal-websocket-heartbeat-controls-removed)
+  - [Internal toolset telemetry now returns with the outcome](#internal-toolset-telemetry-now-returns-with-the-outcome)
 
 - [From version 10.5.x to 10.6.0](#from-version-105x-to-1060)
   - [Vue 3: `vue-docgen-api` is deprecated](#vue-3-vue-docgen-api-is-deprecated)
@@ -542,6 +547,24 @@
 
 ## From version 10.x to 11.0.0
 
+### Node.js 22.12 or higher
+
+Storybook 11 targets Node.js 22.12 or higher. Before upgrading, update Node.js in your local development environment, CI jobs, and deployment environments that build Storybook. Update any Node.js version pins, such as `.nvmrc`, `.node-version`, or your CI configuration.
+
+During the Storybook 11 prerelease cycle, some releases still accept Node.js 20.19. This does not mean Node.js 20 will remain supported in the final release. Use Node.js 22.12 or higher when testing your migration.
+
+### Yarn PnP support removed
+
+Storybook 11 removes support for Yarn Plug'n'Play, which was deprecated in Storybook 10. If you use Yarn PnP, configure Yarn to install dependencies in `node_modules` before upgrading Storybook.
+
+Set the following in your project's `.yarnrc.yml`, then run `yarn install`:
+
+```yaml
+nodeLinker: node-modules
+```
+
+Remove `--use-pnp` from any `storybook init` or `create storybook` commands. The `detectPnp` utility is also no longer exported from `storybook/internal/cli`; remove imports of that utility from custom tooling.
+
 ### Top-level `setConfig` layout and UI options removed
 
 The deprecated top-level layout and UI options passed to `addons.setConfig` are no longer applied.
@@ -576,6 +599,8 @@ option exists in both places, keep the nested value because it was authoritative
 ### Vitest Addon: requires Vitest 4.0 or higher
 
 The `@storybook/addon-vitest` addon requires **Vitest 4.0 or higher**. Setup now always installs `@vitest/browser-playwright`, generates configuration with the `test.projects` array, and no longer creates or updates `vitest.workspace.*` files. If your Vitest config still uses the deprecated `test.workspace` / `defineWorkspace` style, rename it to `test.projects` and re-run `npx storybook@latest add @storybook/addon-vitest` to merge your existing config.
+
+If your custom tooling imports `canUpdateVitestWorkspaceFile` from `storybook/internal/babel`, remove that import. The workspace-file helper has been removed; migrate the configuration to `test.projects`.
 
 ### Vite: `publicDir` is handled by Storybook's `staticDirs`
 
@@ -651,6 +676,18 @@ Migrating off Create React App is not a hard requirement. To keep using Storyboo
 ### `@storybook/angular-vite`: legacy animation modules are no longer auto-converted
 
 `@storybook/angular-vite` no longer depends on `@angular/animations` and no longer auto-converts `BrowserAnimationsModule`/`NoopAnimationsModule` found in a story's `moduleMetadata.imports` into `provideAnimations()`/`provideNoopAnimations()`. If a story still references one of these modules, Storybook now logs a deprecation warning instead. Migrate to native CSS transitions or the `animate.enter`/`animate.leave` bindings (Angular 20.2+), or continue using the legacy animations API yourself by adding `provideAnimations()`/`provideNoopAnimations()` to the `providers` array of the `applicationConfig` decorator; that path is unaffected by this change.
+
+### Internal WebSocket heartbeat controls removed
+
+If your addon or custom tooling imports `WebsocketTransport` from `storybook/internal/channels`, remove the `enableHeartbeat` constructor option and calls to `pauseHeartbeat()` and `resumeHeartbeat()`. The `HEARTBEAT_MAX_LATENCY` export has also been removed.
+
+Storybook no longer closes the client connection because its event loop failed to process a heartbeat in time. The transport still responds to server pings, so these client timeout controls have no replacement. Standard addon channel usage requires no changes.
+
+### Internal toolset telemetry now returns with the outcome
+
+If you implement toolsets using Storybook's internal open-service APIs, return usage data as `telemetry: { payload: { ... } }` alongside `ok`, `data`, and `markdown`. The `ToolsetCtx.telemetry` callback, `ToolsetTelemetry` type, and `reportToolsetTelemetry` helper have been removed. The adapter derives the event name from the registered toolset and method.
+
+Custom SDK callers must remove the `telemetry` callback from `ToolsCallOptions`. The `toolsCommandDimensions` and `wrapMethodTelemetry` helpers are no longer exported from `storybook/internal/tools`. The CLI and MCP adapters handle reporting for their own calls.
 
 ## From version 10.5.x to 10.6.0
 

--- a/docs/addons/addon-migration-guide.mdx
+++ b/docs/addons/addon-migration-guide.mdx
@@ -17,7 +17,7 @@ We sincerely appreciate the dedication and effort addon creators put into keepin
   action={{
     label: 'Copy prompt',
     event: 'copy_addon_migration_prompt',
-    copy: 'In this repository, you will find a Storybook addon package. Migrate the addon to Storybook 11 using https://storybook.js.org/docs/11/addons/addon-migration-guide.md. Addon repositories usually contain a local Storybook instance. Migrate it using https://storybook.js.org/docs/11/releases/migration-guide.md. In case the local repository does not align well with the content of the migration guide, use the https://github.com/storybookjs/addon-kit repository as a reference implementation. Create a PR for the user to review.',
+    copy: 'In this repository, you will find a Storybook addon package. Migrate the addon to Storybook 11 using [addon migration guide](https://storybook.js.org/docs/11/addons/addon-migration-guide.md). Addon repositories usually contain a local Storybook instance. Migrate it using [Storybook migration guide](https://storybook.js.org/docs/11/releases/migration-guide.md). In case the local repository does not align well with the content of the migration guide, use the [Addon Kit](https://github.com/storybookjs/addon-kit) repository as a reference implementation. Create a PR for the user to review.',
   }}
 >
   Use this prompt with your AI assistant to migrate your addon.
@@ -70,7 +70,7 @@ Here are the changes in version 11.0 that impact addon development.
 
 #### Node.js
 
-Storybook 11's minimum supported version is now 22.12. Update the types package in your `package.json` to `^22.12.0`.
+Storybook 11 targets Node.js 22.12 or higher. See the [Node.js migration reference](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#nodejs-2212-or-higher) for environment updates and prerelease support. Update the types package in your `package.json` to `^22.12.0`.
 
 ```diff title="package.json"
 -    "@types/node": "^20",
@@ -149,6 +149,18 @@ export default definePreview({
 ````
 
 ### Addon API changes
+
+#### Manager layout configuration
+
+Move deprecated top-level `addons.setConfig` layout options into `layout`, and move `enableShortcuts` into `ui`. The old top-level values are no longer applied. See the [setConfig migration reference](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#top-level-setconfig-layout-and-ui-options-removed) for an example and automigration instructions.
+
+#### Internal API changes
+
+If your addon imports internal Storybook APIs, review these additional changes:
+
+- [Removed WebSocket heartbeat controls](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#internal-websocket-heartbeat-controls-removed)
+- [Removed Vitest workspace configuration helper](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#vitest-addon-requires-vitest-40-or-higher)
+- [Toolset telemetry returned with the outcome](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#internal-toolset-telemetry-now-returns-with-the-outcome)
 
 #### Tab UI type removed
 

--- a/docs/releases/migration-guide.mdx
+++ b/docs/releases/migration-guide.mdx
@@ -24,7 +24,18 @@ You'll first need to [upgrade to Storybook 10](./migration-guide-from-older-vers
 The rest of this guide will help you upgrade successfully, either automatically or manually. But first, there are some [breaking changes][full-migration-notes] in Storybook 11. Here are the most impactful changes you should know about before you go further:
 
 - Ecosystem updates
-  - [Yarn PNP support removed](#yarn-pnp-support-removed)
+  - [Node.js 22.12 or higher](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#nodejs-2212-or-higher)
+  - [Vite 6.3 or higher](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#vite-requires-vite-63-or-higher)
+  - [Vitest 4 or higher for the Vitest addon](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#vitest-addon-requires-vitest-40-or-higher)
+  - [Next.js 15 or higher](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#nextjs-require-v15-and-up)
+  - [Angular 21 or higher](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#angular-requires-angular-21-or-higher)
+  - [Create React App preset removed](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#create-react-app-support-removed)
+  - [Yarn PnP support removed](#yarn-pnp-support-removed)
+- Configuration changes
+  - [Move top-level `setConfig` layout and UI options](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#top-level-setconfig-layout-and-ui-options-removed)
+  - [Vite static asset copying and conflict precedence](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#vite-publicdir-is-handled-by-storybooks-staticdirs)
+  - [Configure legacy Angular animations explicitly with Angular Vite](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#storybookangular-vite-legacy-animation-modules-are-no-longer-auto-converted)
+- [Changes for addon authors](../addons/addon-migration-guide.mdx)
 
 If any of these changes apply to your project, please read through the linked migration notes before continuing.
 
@@ -84,9 +95,15 @@ Storybook 11 removes support for Yarn [Plug'n'Play](https://yarnpkg.com/features
 - Storybook no longer bootstraps or scaffolds projects with Yarn PnP enabled. New projects always use the standard `node_modules` layout; if your project relies on Yarn PnP, switch your [`nodeLinker`](https://yarnpkg.com/features/linkers) setting to `node-modules`.
 - The `detectPnp` utility is no longer exported from `storybook/internal/cli`.
 
+For the configuration steps and removed CLI options, see the [Yarn PnP migration reference](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#yarn-pnp-support-removed).
+
 ## Optional migrations
 
 In addition to the automigrations and manual migrations above, there are also optional migrations that you should consider. These are features that we’ve deprecated in Storybook 11 (but remain backwards compatible), or best practices that should help you be more productive in the future.
+
+### Next.js Webpack to Next.js Vite
+
+The Webpack-based `@storybook/nextjs` framework is deprecated but remains supported in Storybook 11. Its removal is planned for Storybook 12. Follow the [Next.js framework migration reference](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#nextjs-storybooknextjs-is-deprecated) to migrate to `@storybook/nextjs-vite`.
 
 ### `test-runner` to `addon-vitest`
 


### PR DESCRIPTION
Related to SB-1963 and SB-2028.

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

The SB11 migration guide only listed Yarn PnP after #36258, leaving merged breaking changes undiscoverable. This backfills the guide links and missing MIGRATION.md references for Node preparation, Yarn PnP, and internal API removals. The addon guide now links the setConfig and internal API migrations too.

Vite remains supported from 6.3. Next.js Webpack deprecation stays an optional migration because removal is planned for SB12. Node 22.12 is documented as the release target, with an explicit note that some prereleases still accept Node 20.

<details>
<summary>Merged PR audit (41 PRs)</summary>

Audited all 41 PRs merged on `next` after the `11.0.0-alpha.0` version bump, through `bf6972a1145`. Checked merge diffs and the resulting migration references, accounting for reversions and re-lands.

| PR | Audit result |
| --- | --- |
| [#36261](https://github.com/storybookjs/storybook/pull/36261) | Addon guide: add setConfig/internal API references and qualify the Node target; fix prompt URL formatting. |
| [#36258](https://github.com/storybookjs/storybook/pull/36258) | Main guide: backfill links to all merged SB11 migration topics. |
| [#36270](https://github.com/storybookjs/storybook/pull/36270) | Vitest 5 compatibility fix and expanded peer ranges; existing Vitest 4+ minimum remains correct. |
| [#35664](https://github.com/storybookjs/storybook/pull/35664) | Type inference/export fix; no consumer migration. |
| [#36209](https://github.com/storybookjs/storybook/pull/36209) | Same-story HMR preserves DOM, React root and scroll position; bug fix, no configuration migration. |
| [#36247](https://github.com/storybookjs/storybook/pull/36247) | Existing publicDir reference; add guide link and missing table-of-contents entry. |
| [#36262](https://github.com/storybookjs/storybook/pull/36262) | Internal jscodeshift dependency update; no new user configuration contract. |
| [#36255](https://github.com/storybookjs/storybook/pull/36255) | Restore Vite 6.3 support; link the corrected reference, not the superseded Vite 7 floor. |
| [#36210](https://github.com/storybookjs/storybook/pull/36210) | Document removed internal telemetry callbacks/helpers and the returned outcome report. |
| [#36249](https://github.com/storybookjs/storybook/pull/36249) | Contributor skill/documentation only. |
| [#36187](https://github.com/storybookjs/storybook/pull/36187) | Upgrade blocker implements the documented addon-vitest Vitest 4 minimum; link that reference. |
| [#36242](https://github.com/storybookjs/storybook/pull/36242) | Internal PnP sandbox/CI cleanup; covered by the consolidated PnP reference. |
| [#36212](https://github.com/storybookjs/storybook/pull/36212) | Docgen baseline tests and source-render helper extraction; no consumer migration. |
| [#36229](https://github.com/storybookjs/storybook/pull/36229) | WebSocket/status flood fix; optional ChannelLike.receive addition requires no migration. |
| [#36244](https://github.com/storybookjs/storybook/pull/36244) | Document removed internal WebSocket heartbeat controls and export. |
| [#36236](https://github.com/storybookjs/storybook/pull/36236) | PnP guide text exists; add the missing MIGRATION.md reference and cross-link. |
| [#36237](https://github.com/storybookjs/storybook/pull/36237) | PnP removal: document nodeLinker, removed CLI flag and detectPnp export. |
| [#36168](https://github.com/storybookjs/storybook/pull/36168) | CRA removal reference exists; add guide link. |
| [#36213](https://github.com/storybookjs/storybook/pull/36213) | Next.js deprecation documentation; add optional migration link. |
| [#36128](https://github.com/storybookjs/storybook/pull/36128) | setConfig reference exists; link it from both guides. |
| [#36223](https://github.com/storybookjs/storybook/pull/36223) | Internal merge-authorization diagnostics only. |
| [#35437](https://github.com/storybookjs/storybook/pull/35437) | Angular Vite animation reference exists; add guide link. |
| [#36200](https://github.com/storybookjs/storybook/pull/36200) | Vitest compatibility cleanup; document removed internal workspace helper under Vitest reference. |
| [#36183](https://github.com/storybookjs/storybook/pull/36183) | Review-screen accessibility bug fix; no consumer migration. |
| [#33917](https://github.com/storybookjs/storybook/pull/33917) | Adds Preact 11 compatibility while retaining existing versions; no required migration. |
| [#36196](https://github.com/storybookjs/storybook/pull/36196) | Canary workflow fix only. |
| [#36193](https://github.com/storybookjs/storybook/pull/36193) | Next.js Webpack deprecation reference exists; add optional migration link. |
| [#36166](https://github.com/storybookjs/storybook/pull/36166) | Angular 21 reference exists; add guide link. |
| [#36201](https://github.com/storybookjs/storybook/pull/36201) | Final Next.js 15 implementation; link existing reference. |
| [#36198](https://github.com/storybookjs/storybook/pull/36198) | Reverts #36188; audit final re-land #36200 instead. |
| [#36199](https://github.com/storybookjs/storybook/pull/36199) | Reverts #36167; audit final re-land #36201 instead. |
| [#36188](https://github.com/storybookjs/storybook/pull/36188) | Reverted by #36198; final behavior covered by #36200. |
| [#36167](https://github.com/storybookjs/storybook/pull/36167) | Reverted by #36199; final behavior covered by #36201. |
| [#36164](https://github.com/storybookjs/storybook/pull/36164) | Vitest 4 reference exists; add guide link. |
| [#36158](https://github.com/storybookjs/storybook/pull/36158) | Package-manager telemetry detection fix; no consumer migration. |
| [#36181](https://github.com/storybookjs/storybook/pull/36181) | Composition ref fetch error handling fix; no consumer migration. |
| [#36162](https://github.com/storybookjs/storybook/pull/36162) | Vite 7 floor superseded by #36255; document the final Vite 6.3 floor. |
| [#34799](https://github.com/storybookjs/storybook/pull/34799) | Canary publishing/installation support; contributor release documentation updated, no required 10-to-11 migration. |
| [#35337](https://github.com/storybookjs/storybook/pull/35337) | Node 26 TypeScript loader compatibility fix; does not implement the Node 22 minimum. |
| [#36094](https://github.com/storybookjs/storybook/pull/36094) | Removes unsupported-version sandbox coverage; does not itself remove React 16 consumer support. |
| [#35885](https://github.com/storybookjs/storybook/pull/35885) | Next.js image virtual-ID fix; no consumer migration. |

Pending implementation is not treated as merged behavior: the Node check still accepts 20.19, so the new reference explicitly distinguishes the 22.12 release target from prerelease enforcement. SB-1964 tracks that implementation. TypeScript 5, TAB removal, unattached-doc index changes, component removals and useThemeParameters removal are already described prospectively by the addon guide, but their implementations are outside this merged-change audit. Their implementing PRs still need matching MIGRATION.md references. The React floor PR and CSS loader PR are also outside this audit until merged.

</details>

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No runtime QA is needed for these documentation-only changes. Review the rendered main and addon migration guides and follow the new links to the corresponding MIGRATION.md headings on this branch. GitHub links to `next` will resolve to the new headings after merge.


> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

Documentation validation: `cd code && yarn fmt:write`, `yarn docs:check`, and a local anchor check covering all 13 SB11 reference sections and 19 guide links.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [x] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
