### PR TITLE
Vite: Fix emptyOutDir override by plugins like Adonis

### DIFF
--- a/code/builders/builder-vite/src/build.test.ts
+++ b/code/builders/builder-vite/src/build.test.ts
@@ -1,7 +1,8 @@
 import { Channel } from 'storybook/internal/channels';
 import type { Presets } from 'storybook/internal/types';
 
-import { build as viteBuild } from 'vite';
+import type { InlineConfig, Plugin } from 'vite';
+import { resolveConfig, build as viteBuild } from 'vite';
 import { expect, it, vi } from 'vitest';
 
 import { build } from './build.ts';
@@ -30,4 +31,54 @@ it('keeps Vite from copying the public dir, which Storybook copies through stati
       }),
     })
   );
+});
+
+it("re-asserts Storybook's build options when a user plugin's config hook overrides them", async () => {
+  // Mimics @adonisjs/vite, whose `config` hook returns hardcoded build options that would
+  // otherwise win Vite's config merge and empty Storybook's output directory mid-build.
+  const clobberingPlugin: Plugin = {
+    name: 'test:clobber-build-options',
+    enforce: 'post',
+    config: () => ({
+      build: { outDir: 'clobbered', emptyOutDir: true },
+    }),
+  };
+
+  await build({
+    configType: 'PRODUCTION',
+    configDir: '',
+    outputDir: 'storybook-static-test',
+    channel: new Channel({}),
+    presets: {
+      apply: async (key: string, config?: InlineConfig) =>
+        ({
+          core: { builder: {} },
+          viteFinal: { ...config, plugins: [...(config?.plugins ?? []), clobberingPlugin] },
+        })[key],
+    } as Presets,
+  });
+
+  const finalConfig = vi.mocked(viteBuild).mock.lastCall?.[0] as InlineConfig;
+  const guardPlugins = (finalConfig.plugins ?? []).filter(
+    (p): p is Plugin =>
+      !!p && !Array.isArray(p) && 'name' in p && p.name === 'storybook:enforce-build-options'
+  );
+
+  const resolved = await resolveConfig(
+    {
+      configFile: false,
+      logLevel: 'silent',
+      root: process.cwd(),
+      build: finalConfig.build,
+      plugins: [clobberingPlugin, ...guardPlugins],
+    },
+    'build'
+  );
+
+  const enforced = {
+    outDir: 'storybook-static-test',
+    emptyOutDir: false,
+  };
+  expect(resolved.build).toMatchObject(enforced);
+  expect(resolved.environments.client.build).toMatchObject(enforced);
 });

--- a/code/builders/builder-vite/src/build.test.ts
+++ b/code/builders/builder-vite/src/build.test.ts
@@ -42,6 +42,9 @@ it("re-asserts Storybook's build options when a user plugin's config hook overri
     config: () => ({
       build: { outDir: 'clobbered', emptyOutDir: true },
     }),
+    configEnvironment: () => ({
+      build: { outDir: 'clobbered', emptyOutDir: true },
+    }),
   };
 
   await build({

--- a/code/builders/builder-vite/src/build.ts
+++ b/code/builders/builder-vite/src/build.ts
@@ -45,26 +45,27 @@ export async function build(options: Options) {
 
   const finalConfig = (await presets.apply('viteFinal', config, options)) as InlineConfig;
 
-  // Add a plugin to enforce Storybook's outDir after all other plugins.
-  // This prevents frameworks like Nitro from redirecting
-  // build output to their own directories (e.g., .output/public/).
-  // The 'enforce: post' ensures this runs after all other config hooks.
+  // Add a plugin to enforce key build properties that may be overwritten
+  // by framework plugins like Nitro or Adonis. We run in `enforce: 'post'`
+  // both for `config` and `configEnvironment` to ensure we run last.
   finalConfig.plugins?.push({
-    name: 'storybook:enforce-output-dir',
+    name: 'storybook:enforce-build-options',
     enforce: 'post',
     config: () => ({
       build: {
+        emptyOutDir: false,
         outDir: options.outputDir,
       },
     }),
-    // configEnvironment is a new method in Vite 6
-    // It is used to configure configs based on the environment
-    // E.g. Nitro uses this method to set the output directory to .output/public/
-    configEnvironment: () => ({
-      build: {
-        outDir: options.outputDir,
-      },
-    }),
+    configEnvironment: (name) =>
+      name === 'client'
+        ? {
+            build: {
+              emptyOutDir: false,
+              outDir: options.outputDir,
+            },
+          }
+        : null,
   });
 
   if (options.features?.developmentModeForBuild) {

--- a/code/builders/builder-vite/src/build.ts
+++ b/code/builders/builder-vite/src/build.ts
@@ -57,6 +57,8 @@ export async function build(options: Options) {
         outDir: options.outputDir,
       },
     }),
+    // Our builds only touch the client environment. No need to change build
+    // config for other environments at the expense of third-party plugins.
     configEnvironment: (name) =>
       name === 'client'
         ? {


### PR DESCRIPTION
Closes #32245 


## What I did

Prevented Vite plugins from messing with `emptyOutDir` which causes Storybook builds to lose files. We previously had this logic in place for user-written config but it didn't catch `post` enforce changes made by users' plugins.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

* Make canary
* Check out reproduction repo
* Install canary
* Run `pnpm i && pnpm build-storybook && pnpx serve storybook-static`

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚢 Released [`f16332f`](https://pkg.pr.new/~/storybookjs/storybook)
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as canary packages. Try it out in a new project or update an existing project with the commands below.

```sh
# For a new project
npx --yes --allow-remote=all https://pkg.pr.new/create-storybook@f16332f

# or for an existing project
npx --yes --allow-remote=all https://pkg.pr.new/storybook@f16332f upgrade
```
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
