### PR TITLE
Docs: Use Callout prompt variant for AI-prompt callouts

### DIFF
--- a/docs/get-started/install.mdx
+++ b/docs/get-started/install.mdx
@@ -10,8 +10,7 @@ Use the Storybook CLI to install it in a single command. Run this inside your pr
 <CodeSnippets path="create-command.md" variant="new-users" copyEvent="CreateCommandCopy" />
 
 <Callout
-  variant="info"
-  icon="🤖"
+  variant="prompt"
   action={{
     label: 'Copy prompt',
     copy: 'Set up Storybook for me with npm create storybook@latest and follow its instructions precisely',

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -12,8 +12,7 @@ Run this command to install Storybook into an existing project or create a new o
 <CodeSnippets path="create-command.md" variant="new-users" copyEvent="CreateCommandCopy" />
 
 <Callout
-  variant="info"
-  icon="🤖"
+  variant="prompt"
   action={{
     label: 'Copy prompt',
     copy: 'Set up Storybook for me with npm create storybook@latest and follow its instructions precisely',


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Converted the two remaining AI-prompt callouts to the `Callout` component's `prompt` variant:

- `docs/index.mdx`
- `docs/get-started/install.mdx`

Both previously reproduced the prompt-callout look by hand with `variant="info" icon="🤖"`. The `prompt` variant provides that treatment, including its own `WandIcon`, so the explicit icon is removed. `docs/addons/addon-migration-guide.mdx` already uses the variant.

No copy, link, or analytics event changed — the prompt text and the `PromptInstallCopy` event are untouched.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Open the docs landing page (`/docs`) and the install page (`/docs/get-started/install`).
2. Confirm each page still shows the AI-prompt callout with its **Copy prompt** button, now rendered with the `prompt` variant's wand icon.
3. Click **Copy prompt** and confirm the clipboard contains: `Set up Storybook for me with npm create storybook@latest and follow its instructions precisely`

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw4P3WHXbXzKeawmdjJqBE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw4P3WHXbXzKeawmdjJqBE)_