### PR TITLE
UI: Ensure FocusScope reuse across manager

### DIFF
--- a/code/.storybook/main.ts
+++ b/code/.storybook/main.ts
@@ -182,6 +182,9 @@ const config = defineMain({
                 'sb-original/image-context': imageContextPath,
               }
             : {
+                // The components dist bundle inlines react-aria; resolving to source keeps the
+                // preview on a single react-aria copy so FocusScopes can nest across modules.
+                'storybook/internal/components': componentsPath,
                 'storybook/manager-api': managerApiPath,
                 'storybook/preview-api': previewApiPath,
               },

--- a/code/core/src/components/index.ts
+++ b/code/core/src/components/index.ts
@@ -45,9 +45,6 @@ export { ActionList } from './components/ActionList/ActionList.tsx';
 export { Collapsible } from './components/Collapsible/Collapsible.tsx';
 export { Card } from './components/Card/Card.tsx';
 export { Modal, ModalDecorator } from './components/Modal/Modal.tsx';
-// Manager code must use this copy of @react-aria/focus: a FocusScope from another module instance
-// cannot nest inside the Modal's scope, so both scopes would handle each Tab press.
-export { FocusScope } from '@react-aria/focus';
 export { Spaced } from './components/spaced/Spaced.tsx';
 export { Placeholder } from './components/placeholder/placeholder.tsx';
 export { ScrollArea } from './components/ScrollArea/ScrollArea.tsx';

--- a/code/core/src/manager/components/mobile/about/MobileAbout.tsx
+++ b/code/core/src/manager/components/mobile/about/MobileAbout.tsx
@@ -1,10 +1,11 @@
 import type { FC } from 'react';
 import React, { useEffect, useRef } from 'react';
 
-import { ActionList, Button, FocusScope, Link, ScrollArea } from 'storybook/internal/components';
+import { ActionList, Button, Link, ScrollArea } from 'storybook/internal/components';
 
 import { ArrowLeftIcon, GithubIcon, ShareAltIcon, StorybookIcon } from '@storybook/icons';
 
+import { FocusScope } from 'react-aria/FocusScope';
 import { useTransitionState } from 'react-transition-state';
 import { keyframes, styled } from 'storybook/theming';
 

--- a/code/core/src/manager/globals/exports.ts
+++ b/code/core/src/manager/globals/exports.ts
@@ -56,6 +56,7 @@ export default {
     'version',
   ],
   'react-dom/client': ['createRoot', 'hydrateRoot'],
+  'react-aria/FocusScope': ['FocusScope', 'useFocusManager'],
   '@storybook/icons': [
     'AccessibilityAltIcon',
     'AccessibilityIcon',
@@ -520,7 +521,6 @@ export default {
     'EmptyTabContent',
     'ErrorFormatter',
     'FlexBar',
-    'FocusScope',
     'Form',
     'H1',
     'H2',

--- a/code/core/src/manager/globals/globals.ts
+++ b/code/core/src/manager/globals/globals.ts
@@ -3,6 +3,9 @@ export const globalsNameReferenceMap = {
   react: '__REACT__',
   'react-dom': '__REACT_DOM__',
   'react-dom/client': '__REACT_DOM_CLIENT__',
+  // FocusScope keeps a module-level scope tree, so all manager code must share the copy bundled
+  // with the components' Modal — scopes from a second copy cannot nest inside the Modal's scope.
+  'react-aria/FocusScope': '__REACT_ARIA_FOCUS_SCOPE__',
   '@storybook/icons': '__STORYBOOK_ICONS__',
 
   'storybook/manager-api': '__STORYBOOK_API__',

--- a/code/core/src/manager/globals/runtime.ts
+++ b/code/core/src/manager/globals/runtime.ts
@@ -1,4 +1,5 @@
 import * as REACT from 'react';
+import * as REACT_ARIA_FOCUS_SCOPE from 'react-aria/FocusScope';
 import * as REACT_DOM from 'react-dom';
 import * as REACT_DOM_CLIENT from 'react-dom/client';
 
@@ -24,6 +25,7 @@ export const globalsNameValueMap: Required<Record<keyof typeof globalsNameRefere
   react: REACT,
   'react-dom': REACT_DOM,
   'react-dom/client': REACT_DOM_CLIENT,
+  'react-aria/FocusScope': REACT_ARIA_FOCUS_SCOPE,
   '@storybook/icons': ICONS,
 
   'storybook/manager-api': MANAGER_API,

--- a/code/core/src/manager/typings.d.ts
+++ b/code/core/src/manager/typings.d.ts
@@ -17,6 +17,7 @@ declare var VERSIONCHECK: any;
 declare var LOGLEVEL: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent' | undefined;
 
 declare var __REACT__: any;
+declare var __REACT_ARIA_FOCUS_SCOPE__: any;
 declare var __REACT_DOM__: any;
 declare var __REACT_DOM_CLIENT__: any;
 declare var __STORYBOOK_COMPONENTS__: any;


### PR DESCRIPTION
## What I did

Fixes a regression occurring today at the intersection of #36224 and a RAC update PR. Ensures that we have a single ReactAria FocusManager, using the new react-aria import path and not re-exporting it publicly.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

ø

#### Manual testing

* Run SB
* Notice no errors in dev server
* Make the viewport small enough to get the mobile UI
* Open navigation menu
* Tab to the cog icon opening the about menu
* Press Enter
* Tab around and notice coherent focus order

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
