### PR TITLE
docs: document storybookNextJsPlugin for Vitest + Next.js

### DIFF
--- a/docs/_snippets/vite-includeStorybookNextjsPlugin.md
+++ b/docs/_snippets/vite-includeStorybookNextjsPlugin.md
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite';
 import { storybookNextJsPlugin } from '@storybook/nextjs-vite/vite-plugin';
 
 export default defineConfig({
-  // only necessary when not using @storybook/addon-vitest, otherwise the plugin is loaded automatically
+  // Required when configuring Vitest manually or using portable stories; loaded automatically by the Vitest addon
   plugins: [storybookNextJsPlugin()],
 });
 ```

--- a/docs/get-started/frameworks/nextjs-vite.mdx
+++ b/docs/get-started/frameworks/nextjs-vite.mdx
@@ -562,6 +562,16 @@ If your server components access data via the network, we recommend using the [M
 
 In the future we will provide better mocking support in Storybook and support for [Server Actions](https://nextjs.org/docs/app/api-reference/functions/server-actions).
 
+## Testing with Vitest
+
+When running Vitest tests against Next.js components — whether with the [Vitest addon](../../writing-tests/integrations/vitest-addon/index.mdx) or [portable stories](../../api/portable-stories/portable-stories-vitest.mdx) — Next.js features such as `next/image` and `next/font` must work outside Storybook's dev server. The `@storybook/nextjs-vite` package re-exports `storybookNextJsPlugin` from [`vite-plugin-storybook-nextjs`](https://github.com/storybookjs/storybook/tree/next/code/lib/vite-plugin-storybook-nextjs) for this purpose.
+
+When you use the Vitest addon with [automatic setup](../../writing-tests/integrations/vitest-addon/index.mdx#automatic-setup), the plugin is loaded through Storybook's Vite configuration. If you configure Vitest manually or use portable stories in your own `vitest.config.ts`, add `storybookNextJsPlugin()` to your Vitest plugins:
+
+<CodeSnippets path="vite-includeStorybookNextjsPlugin.md" />
+
+If you see errors like `Cannot find module 'sb-original/image-context'`, the plugin is likely missing from your Vitest configuration.
+
 ## FAQ
 
 ### How do I migrate from the `nextjs` (Webpack 5) addon?

--- a/docs/writing-tests/integrations/vitest-addon/index.mdx
+++ b/docs/writing-tests/integrations/vitest-addon/index.mdx
@@ -331,6 +331,16 @@ export default defineConfig({
 });
 ```
 
+### How do I configure Vitest for Next.js?
+
+Next.js projects must use the [`@storybook/nextjs-vite` framework](../../../get-started/frameworks/nextjs-vite.mdx). When you set up the Vitest addon with [automatic setup](#automatic-setup), Storybook's Next.js Vite plugin is included in your test configuration.
+
+If you configure Vitest manually, or run [portable stories](../../../api/portable-stories/portable-stories-vitest.mdx) outside the addon, add `storybookNextJsPlugin()` to your Vitest configuration so Next.js features work in tests:
+
+<CodeSnippets path="vite-includeStorybookNextjsPlugin.md" />
+
+See the [Next.js (Vite) framework docs](../../../get-started/frameworks/nextjs-vite.mdx#testing-with-vitest) for more details.
+
 </If>
 
 ### How do I fix the `Error: Vitest failed to find the current suite` error?


### PR DESCRIPTION
Closes #35880

## What I did

Document `storybookNextJsPlugin()` on the Vitest addon and Next.js (Vite) framework docs pages. The plugin was already described in the addon README and a troubleshooting snippet existed for portable stories, but it was missing from the main site pages users reach when setting up Next.js + Vitest.

Changes:
- Add a **Testing with Vitest** section to the Next.js (Vite) framework docs
- Add a **How do I configure Vitest for Next.js?** FAQ entry to the Vitest addon docs
- Clarify the shared snippet comment about when manual configuration is required

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No manual testing required — documentation-only change. Verify the new sections render correctly on the docs site.

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below: