### PR TITLE
CLI: Report the real error when doctor fails to gather project data

### DIFF
--- a/code/lib/cli-storybook/src/doctor/index.test.ts
+++ b/code/lib/cli-storybook/src/doctor/index.test.ts
@@ -3,8 +3,9 @@ import { describe, expect, it } from 'vitest';
 import type { JsPackageManager } from 'storybook/internal/common';
 import type { StorybookConfigRaw } from 'storybook/internal/types';
 
-import { getDoctorDiagnostics } from './index.ts';
-import { DiagnosticType } from './types.ts';
+import { collectDeduplicatedDiagnostics, getDoctorDiagnostics } from './index.ts';
+import { DiagnosticStatus, DiagnosticType } from './types.ts';
+import type { DiagnosticMessage, ProjectDoctorResults } from './types.ts';
 
 const packageManagerMock = {} as JsPackageManager;
 
@@ -43,5 +44,70 @@ describe('getDoctorDiagnostics', () => {
       expect(results[0].type).toBe(DiagnosticType.CONFIGURATION_ERROR);
       expect(results[0].message).toContain('Unable to determine Storybook version');
     });
+  });
+});
+
+describe('collectDeduplicatedDiagnostics', () => {
+  const allPassed = Object.fromEntries(
+    Object.values(DiagnosticType).map((type) => [type, DiagnosticStatus.PASSED])
+  ) as Record<DiagnosticType, DiagnosticStatus>;
+
+  const projectWithConfigurationError = (
+    configDir: string,
+    title: string,
+    message: string
+  ): ProjectDoctorResults => ({
+    configDir,
+    status: 'check_error',
+    diagnostics: {
+      ...allPassed,
+      [DiagnosticType.CONFIGURATION_ERROR]: DiagnosticStatus.CHECK_ERROR,
+    },
+    messages: {
+      [DiagnosticType.CONFIGURATION_ERROR]: { title, message },
+    } as Record<DiagnosticType, DiagnosticMessage>,
+  });
+
+  it('reports different configuration errors as separate diagnostics', () => {
+    const diagnostics = collectDeduplicatedDiagnostics({
+      '.storybook': projectWithConfigurationError(
+        '.storybook',
+        'Configuration Error',
+        '❌ Failed to evaluate main.ts: boom A'
+      ),
+      'packages/app/.storybook': projectWithConfigurationError(
+        'packages/app/.storybook',
+        'Configuration Error',
+        '❌ Failed to evaluate main.ts: boom B'
+      ),
+    });
+
+    expect(diagnostics).toHaveLength(2);
+    expect(diagnostics[0].message).toContain('boom A');
+    expect(diagnostics[0].projects).toEqual([{ configDir: '.storybook' }]);
+    expect(diagnostics[1].message).toContain('boom B');
+    expect(diagnostics[1].projects).toEqual([{ configDir: 'packages/app/.storybook' }]);
+  });
+
+  it('groups identical errors across projects and keeps the original title', () => {
+    const diagnostics = collectDeduplicatedDiagnostics({
+      '.storybook': projectWithConfigurationError(
+        '.storybook',
+        'Version Detection Failed',
+        'same failure'
+      ),
+      'packages/app/.storybook': projectWithConfigurationError(
+        'packages/app/.storybook',
+        'Version Detection Failed',
+        'same failure'
+      ),
+    });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].title).toBe('Version Detection Failed');
+    expect(diagnostics[0].projects).toEqual([
+      { configDir: '.storybook' },
+      { configDir: 'packages/app/.storybook' },
+    ]);
   });
 });

--- a/code/lib/cli-storybook/src/doctor/index.test.ts
+++ b/code/lib/cli-storybook/src/doctor/index.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { JsPackageManager } from 'storybook/internal/common';
+import type { StorybookConfigRaw } from 'storybook/internal/types';
+
+import { getDoctorDiagnostics } from './index.ts';
+import { DiagnosticType } from './types.ts';
+
+vi.mock('picocolors', () => ({
+  default: {
+    cyan: (str: string) => str,
+    yellow: (str: string) => str,
+    blue: (str: string) => str,
+  },
+}));
+
+const packageManagerMock = {} as JsPackageManager;
+
+const baseData = {
+  configDir: '.storybook',
+  packageManager: packageManagerMock,
+  mainConfig: {} as StorybookConfigRaw,
+};
+
+describe('getDoctorDiagnostics', () => {
+  describe('when the Storybook version cannot be determined', () => {
+    it('reports the real configuration error when gathering project data failed', async () => {
+      const results = await getDoctorDiagnostics({
+        ...baseData,
+        storybookVersion: undefined,
+        configurationError: {
+          title: 'Configuration Error',
+          message: "❌ Storybook couldn't evaluate your .storybook/main.ts file.",
+        },
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].type).toBe(DiagnosticType.CONFIGURATION_ERROR);
+      expect(results[0].title).toBe('Configuration Error');
+      expect(results[0].message).toContain("couldn't evaluate");
+      expect(results[0].message).not.toContain('Unable to determine Storybook version');
+    });
+
+    it('falls back to the generic message when no configuration error was captured', async () => {
+      const results = await getDoctorDiagnostics({
+        ...baseData,
+        storybookVersion: undefined,
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].type).toBe(DiagnosticType.CONFIGURATION_ERROR);
+      expect(results[0].message).toContain('Unable to determine Storybook version');
+    });
+  });
+});

--- a/code/lib/cli-storybook/src/doctor/index.test.ts
+++ b/code/lib/cli-storybook/src/doctor/index.test.ts
@@ -1,18 +1,10 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import type { JsPackageManager } from 'storybook/internal/common';
 import type { StorybookConfigRaw } from 'storybook/internal/types';
 
 import { getDoctorDiagnostics } from './index.ts';
 import { DiagnosticType } from './types.ts';
-
-vi.mock('picocolors', () => ({
-  default: {
-    cyan: (str: string) => str,
-    yellow: (str: string) => str,
-    blue: (str: string) => str,
-  },
-}));
 
 const packageManagerMock = {} as JsPackageManager;
 

--- a/code/lib/cli-storybook/src/doctor/index.ts
+++ b/code/lib/cli-storybook/src/doctor/index.ts
@@ -27,25 +27,28 @@ import type {
 export function collectDeduplicatedDiagnostics(
   projectResults: Record<string, ProjectDoctorResults>
 ): DiagnosticResult[] {
-  const diagnosticMap = new Map<DiagnosticType, DiagnosticResult>();
+  const diagnosticMap = new Map<string, DiagnosticResult>();
 
   Object.entries(projectResults).forEach(([configDir, result]) => {
     Object.entries(result.diagnostics).forEach(([type, status]) => {
       if (status !== DiagnosticStatus.PASSED) {
         const diagnosticType = type as DiagnosticType;
-        const message = result.messages[diagnosticType];
+        const diagnostic = result.messages[diagnosticType];
 
-        if (message) {
-          const existing = diagnosticMap.get(diagnosticType);
+        if (diagnostic) {
+          // Diagnostics of the same type can still differ per project (e.g. distinct
+          // configuration errors), so deduplicate by their content
+          const key = `${diagnosticType}:${diagnostic.message}`;
+          const existing = diagnosticMap.get(key);
           if (existing) {
             // Add project to existing diagnostic
             existing.projects.push({ configDir });
           } else {
             // Create new diagnostic entry
-            diagnosticMap.set(diagnosticType, {
+            diagnosticMap.set(key, {
               type: diagnosticType,
-              title: type.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase()),
-              message,
+              title: diagnostic.title,
+              message: diagnostic.message,
               projects: [{ configDir }],
             });
           }
@@ -100,14 +103,13 @@ export function displayDoctorResults(
       // Display each diagnostic issue
       Object.entries(result.diagnostics).forEach(([type, status]) => {
         if (status !== DiagnosticStatus.PASSED) {
-          const message = result.messages[type as DiagnosticType];
-          if (message) {
-            const title = type.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase());
-            logger.logBox(message, {
+          const diagnostic = result.messages[type as DiagnosticType];
+          if (diagnostic) {
+            logger.logBox(diagnostic.message, {
               title:
                 status === DiagnosticStatus.CHECK_ERROR
-                  ? CLI_COLORS.error(title)
-                  : CLI_COLORS.warning(title),
+                  ? CLI_COLORS.error(diagnostic.title)
+                  : CLI_COLORS.warning(diagnostic.title),
             });
           }
         }
@@ -363,7 +365,7 @@ export async function collectDoctorResultsByProject(
         DiagnosticType,
         DiagnosticStatus
       >;
-      const messages: Record<DiagnosticType, string> = {} as Record<DiagnosticType, string>;
+      const messages: ProjectDoctorResults['messages'] = {} as ProjectDoctorResults['messages'];
 
       // Initialize all diagnostic types as passed
       Object.values(DiagType).forEach((type) => {
@@ -382,7 +384,10 @@ export async function collectDoctorResultsByProject(
           diagnostics[checkResult.type] = DiagnosticStatus.HAS_ISSUES;
           hasIssues = true;
         }
-        messages[checkResult.type] = checkResult.message;
+        messages[checkResult.type] = {
+          title: checkResult.title,
+          message: checkResult.message,
+        };
       }
 
       const status = hasErrors ? 'check_error' : hasIssues ? 'has_issues' : 'healthy';
@@ -401,15 +406,17 @@ export async function collectDoctorResultsByProject(
         DiagnosticType,
         DiagnosticStatus
       >;
-      const messages: Record<DiagnosticType, string> = {} as Record<DiagnosticType, string>;
+      const messages: ProjectDoctorResults['messages'] = {} as ProjectDoctorResults['messages'];
 
       Object.values(DiagType).forEach((type) => {
         diagnostics[type] = DiagnosticStatus.PASSED;
       });
 
       diagnostics[DiagType.CONFIGURATION_ERROR] = DiagnosticStatus.CHECK_ERROR;
-      messages[DiagType.CONFIGURATION_ERROR] =
-        `Failed to run doctor checks: ${error instanceof Error ? error.message : String(error)}`;
+      messages[DiagType.CONFIGURATION_ERROR] = {
+        title: 'Configuration Error',
+        message: `Failed to run doctor checks: ${error instanceof Error ? error.message : String(error)}`,
+      };
 
       projectResults[configDir] = {
         configDir,

--- a/code/lib/cli-storybook/src/doctor/index.ts
+++ b/code/lib/cli-storybook/src/doctor/index.ts
@@ -176,6 +176,7 @@ export async function runMultiProjectDoctor(
     packageManager: project.packageManager,
     storybookVersion: project.storybookVersion,
     mainConfig: project.mainConfig,
+    configurationError: project.configurationError,
   }));
 
   // Always return the project-based results structure
@@ -189,12 +190,11 @@ export const doctor = async ({
 }: DoctorOptions) => {
   logger.step('Checking the health of your Storybook..');
 
-  const diagnosticResults: DiagnosticResult[] = [];
-
   let packageManager!: JsPackageManager;
   let configDir!: string;
   let versionInstalled: string | undefined;
   let mainConfig!: StorybookConfigRaw;
+  let configurationError: { title: string; message: string } | undefined;
 
   try {
     ({ packageManager, configDir, versionInstalled, mainConfig } = await getStorybookData({
@@ -215,12 +215,7 @@ export const doctor = async ({
       message = `❌ ${err.message}`;
     }
 
-    diagnosticResults.push({
-      type: DiagType.CONFIGURATION_ERROR,
-      title,
-      message,
-      projects: [{ configDir }],
-    });
+    configurationError = { title, message };
   }
 
   const doctorResults = await collectDoctorResultsByProject([
@@ -229,6 +224,7 @@ export const doctor = async ({
       packageManager,
       storybookVersion: versionInstalled,
       mainConfig,
+      configurationError,
     },
   ]);
 
@@ -245,22 +241,26 @@ export async function getDoctorDiagnostics({
   packageManager,
   storybookVersion,
   mainConfig,
+  configurationError,
 }: {
   configDir: string;
   packageManager: JsPackageManager;
   storybookVersion?: string;
   mainConfig: StorybookConfigRaw;
+  configurationError?: { title: string; message: string };
 }): Promise<DoctorCheckResult[]> {
   const results: DoctorCheckResult[] = [];
 
   if (!storybookVersion) {
     results.push({
       type: DiagType.CONFIGURATION_ERROR,
-      title: 'Version Detection Failed',
-      message: dedent`
-        ❌ Unable to determine Storybook version so the command will not proceed.
-        🤔 Are you running storybook doctor from your project directory? Please specify your Storybook config directory with the --config-dir flag.
-      `,
+      title: configurationError?.title ?? 'Version Detection Failed',
+      message:
+        configurationError?.message ??
+        dedent`
+          ❌ Unable to determine Storybook version so the command will not proceed.
+          🤔 Are you running storybook doctor from your project directory? Please specify your Storybook config directory with the --config-dir flag.
+        `,
       project: { configDir },
     });
     return results;

--- a/code/lib/cli-storybook/src/doctor/types.ts
+++ b/code/lib/cli-storybook/src/doctor/types.ts
@@ -11,6 +11,11 @@ export interface ProjectDoctorData {
   packageManager: JsPackageManager;
   storybookVersion?: string;
   mainConfig: StorybookConfigRaw;
+  /**
+   * Error thrown while gathering project data (e.g. main config evaluation). When set, it is
+   * reported instead of the generic version-detection failure.
+   */
+  configurationError?: { title: string; message: string };
 }
 
 export enum DiagnosticType {

--- a/code/lib/cli-storybook/src/doctor/types.ts
+++ b/code/lib/cli-storybook/src/doctor/types.ts
@@ -50,9 +50,14 @@ export interface DoctorCheckResult {
   project: DiagnosticDoctorData;
 }
 
+export interface DiagnosticMessage {
+  title: string;
+  message: string;
+}
+
 export interface ProjectDoctorResults {
   configDir: string;
   status: 'healthy' | 'has_issues' | 'check_error';
   diagnostics: Record<DiagnosticType, DiagnosticStatus>;
-  messages: Record<DiagnosticType, string>;
+  messages: Record<DiagnosticType, DiagnosticMessage>;
 }


### PR DESCRIPTION
Closes #36173

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

When gathering project data throws (e.g. `.storybook/main.ts` cannot be evaluated), `doctor()` caught the error and pushed it into a `diagnosticResults` array that was never read. `getDoctorDiagnostics` then saw `versionInstalled` was undefined and reported a generic "Unable to determine Storybook version" message — hiding the real failure behind a misleading diagnostic.

The caught error is now carried through `ProjectDoctorData.configurationError`, so `getDoctorDiagnostics` reports the actual error (e.g. "Storybook couldn't evaluate your `.storybook/main.ts` file." followed by the original error). The generic version-detection message is kept for the genuine case where no Storybook version is installed.

This was reproduced against the reporter's repo ([inkline/inkline](https://github.com/inkline/inkline) at `b5ce93e7`, `ui/vue` workspace): before this change `storybook doctor` reported the misleading version message; after it, the real `ERR_MODULE_NOT_FOUND` from evaluating `main.ts` is surfaced.

🤖 Created with AI assistance (Devin); reviewed and submitted by a human.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. In a Storybook project, make `.storybook/main.ts` fail to evaluate (e.g. add `import 'nonexistent-package'` at the top)
2. Run `storybook doctor`
3. Before this change: `Unable to determine Storybook version so the command will not proceed.` After this change: the real config-evaluation error is shown (`Storybook couldn't evaluate your .storybook/main.ts file.` plus the original error)

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No documentation changes needed — this fixes a misleading error message.
