### PR TITLE
Docs: Document QueryClient Isolation for Docs Pages and Parallel Story Tests

### DIFF
--- a/docs/_snippets/tanstack-react-query-per-story-client.md
+++ b/docs/_snippets/tanstack-react-query-per-story-client.md
@@ -53,10 +53,9 @@ const preview: Preview = {
       </QueryClientProvider>
     ),
   ],
-  afterEach: ({ id }) => {
-    // Drop the client once the story's test finishes
-    removeStoryClient(id);
-  },
+  // Return the cleanup from beforeEach: it runs after the story
+  // unmounts, so the client is never cleared while still rendering
+  beforeEach: ({ id }) => () => removeStoryClient(id),
 };
 
 export default preview;
@@ -88,10 +87,9 @@ export default definePreview({
       </QueryClientProvider>
     ),
   ],
-  afterEach: ({ id }) => {
-    // Drop the client once the story's test finishes
-    removeStoryClient(id);
-  },
+  // Return the cleanup from beforeEach: it runs after the story
+  // unmounts, so the client is never cleared while still rendering
+  beforeEach: ({ id }) => () => removeStoryClient(id),
 });
 ```
 

--- a/docs/_snippets/tanstack-react-query-per-story-client.md
+++ b/docs/_snippets/tanstack-react-query-per-story-client.md
@@ -1,0 +1,121 @@
+```ts filename=".storybook/query-clients.ts" renderer="react" language="ts"
+import { QueryClient } from '@tanstack/react-query';
+
+const clients = new Map<string, QueryClient>();
+
+// One QueryClient per story, shared by the router context, the
+// QueryClientProvider, and story setup hooks.
+export function queryClientForStory(storyId: string): QueryClient {
+  let client = clients.get(storyId);
+  if (!client) {
+    client = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          staleTime: Infinity,
+        },
+      },
+    });
+    clients.set(storyId, client);
+  }
+  return client;
+}
+
+export function removeStoryClient(storyId: string) {
+  clients.get(storyId)?.clear();
+  clients.delete(storyId);
+}
+```
+
+```tsx filename=".storybook/preview.tsx" renderer="react" language="tsx" tabTitle="CSF 3"
+import { QueryClientProvider } from '@tanstack/react-query';
+import type { Preview } from '@storybook/tanstack-react';
+
+import { queryClientForStory, removeStoryClient } from './query-clients';
+
+const preview: Preview = {
+  parameters: {
+    tanstack: {
+      router: {
+        // The factory runs before the router's initial load, so route
+        // loaders see the story's own client
+        context: ({ storyContext }) => ({
+          queryClient: queryClientForStory(storyContext.id),
+        }),
+      },
+    },
+  },
+  decorators: [
+    (Story, context) => (
+      // The React tree reads the same per-story client
+      <QueryClientProvider client={queryClientForStory(context.id)}>
+        <Story />
+      </QueryClientProvider>
+    ),
+  ],
+  afterEach: ({ id }) => {
+    // Drop the client once the story's test finishes
+    removeStoryClient(id);
+  },
+};
+
+export default preview;
+```
+
+```tsx filename=".storybook/preview.tsx" renderer="react" language="tsx" tabTitle="CSF Next 🧪"
+import { QueryClientProvider } from '@tanstack/react-query';
+import { definePreview } from '@storybook/tanstack-react';
+
+import { queryClientForStory, removeStoryClient } from './query-clients';
+
+export default definePreview({
+  parameters: {
+    tanstack: {
+      router: {
+        // The factory runs before the router's initial load, so route
+        // loaders see the story's own client
+        context: ({ storyContext }) => ({
+          queryClient: queryClientForStory(storyContext.id),
+        }),
+      },
+    },
+  },
+  decorators: [
+    (Story, context) => (
+      // The React tree reads the same per-story client
+      <QueryClientProvider client={queryClientForStory(context.id)}>
+        <Story />
+      </QueryClientProvider>
+    ),
+  ],
+  afterEach: ({ id }) => {
+    // Drop the client once the story's test finishes
+    removeStoryClient(id);
+  },
+});
+```
+
+```tsx filename="Navbar.stories.ts" renderer="react" language="ts"
+import type { Meta, StoryObj } from '@storybook/tanstack-react';
+
+import { queryClientForStory } from '../.storybook/query-clients';
+
+import { Navbar } from './Navbar';
+
+const meta = {
+  component: Navbar,
+} satisfies Meta<typeof Navbar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const LoggedIn: Story = {
+  beforeEach: ({ id }) => {
+    // Seed the story's own client; other stories never see this data
+    queryClientForStory(id).setQueryData(['currentUser'], {
+      id: 'user-1',
+      name: 'Ada Lovelace',
+    });
+  },
+};
+```

--- a/docs/get-started/frameworks/tanstack-react.mdx
+++ b/docs/get-started/frameworks/tanstack-react.mdx
@@ -197,7 +197,7 @@ For per-story isolation, create one client per story and pass the same instance 
 
 <CodeSnippets path="tanstack-react-query-per-story-client.md" />
 
-Two details matter here. First, with the factory form, `parameters.tanstack.router.context` is a function, so story hooks can no longer read the client from parameters; key the clients by story ID in a shared module and use that helper in story `beforeEach` hooks, as shown above. Second, per-story clients own timers and subscriptions, so drop each client when its story's test finishes (the `afterEach` hook in the example). Clients used only for Docs rendering live as long as the page.
+Two details matter here. First, with the factory form, `parameters.tanstack.router.context` is a function, so story hooks can no longer read the client from parameters; key the clients by story ID in a shared module and use that helper in story `beforeEach` hooks, as shown above. Second, per-story clients own timers and subscriptions, so drop each client after its story unmounts (the cleanup returned from `beforeEach` in the example). Returning the cleanup from `beforeEach` runs it after the story's own teardown, so the client is never cleared while the story is still rendering. Clients used only for Docs rendering live as long as the page.
 
 If story tests still flake because several stories overlap in one browser context, and switching to per-story clients is not an option, disable file parallelism for the story test project so files run one at a time:
 

--- a/docs/get-started/frameworks/tanstack-react.mdx
+++ b/docs/get-started/frameworks/tanstack-react.mdx
@@ -187,6 +187,31 @@ This setup keeps the router context and React provider pointed at the same `Quer
 
 You can create a separate `QueryClient` for each story when you need stronger isolation, such as rendering several stories with the same query keys on one Docs page and keeping their cached responses independent. The tradeoff is that you must make the per-story client available to both the router context and the `QueryClientProvider` for that story. If those two places receive different clients, route loaders and components can read different caches, and story setup that calls `setQueryData` may not affect the component being rendered. Per-story clients also require explicit cleanup of timers, subscriptions, and cached data owned by each client.
 
+#### Story isolation on Docs pages and in parallel test runs
+
+The shared-client setup above is safe for parallel test files: each Vitest browser instance loads its own copy of the preview module, so stories running in different files never share a cache.
+
+It breaks down when several stories render at the same time in one browser context, most often on a [Docs page](../../writing-docs/autodocs.mdx) that shows multiple stories. Simultaneously rendered stories share the single client, so two stories that seed the same query key overwrite each other, and a `beforeEach` cache clear for one story can remove data another story is still reading. A Docs page showing `LoggedInAsAlice` and `LoggedInAsBob` stories seeded through the same key renders the last-seeded user in both.
+
+For per-story isolation, create one client per story and pass the same instance to the router context, the `QueryClientProvider`, and story setup. The [`context`](#context) factory runs before the router's initial load, so route loaders see the story's own client:
+
+<CodeSnippets path="tanstack-react-query-per-story-client.md" />
+
+Two details matter here. First, with the factory form, `parameters.tanstack.router.context` is a function, so story hooks can no longer read the client from parameters; key the clients by story ID in a shared module and use that helper in story `beforeEach` hooks, as shown above. Second, per-story clients own timers and subscriptions, so drop each client when its story's test finishes (the `afterEach` hook in the example). Clients used only for Docs rendering live as long as the page.
+
+If story tests still flake because several stories overlap in one browser context, and switching to per-story clients is not an option, disable file parallelism for the story test project so files run one at a time:
+
+```ts title="vitest.config.ts"
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Run story test files one at a time so they cannot overlap
+    fileParallelism: false,
+  },
+});
+```
+
 #### Seeding query data per story
 
 In individual stories, use [`beforeEach`](../../writing-tests/interaction-testing.mdx#beforeeach) to call [`setQueryData`](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientsetquerydata) on the shared `QueryClient` before the component renders. Access it from `parameters.tanstack.router.context`:


### PR DESCRIPTION
Closes #36233

## What I did

Added a "Story isolation on Docs pages and in parallel test runs" section to the TanStack React framework page, plus a snippet with a per-story QueryClient pattern that keeps the router context, QueryClientProvider, and story setup on the same client.

Verified against a real project (Storybook 10.6, Vitest browser mode, Playwright chromium):

- Shared preview client with two parallel browser instances: all story tests pass. Each instance loads its own preview module, so parallel files never share a cache.
- Shared client on an autodocs page with two stories seeding the same query key: both stories render the last-seeded value - the collision from the issue.
- Per-story clients via the context factory keyed by story ID: the Docs page renders each story's own data and all story tests stay green in parallel.

## Checklist for Contributors

### Testing

The changes in this PR are covered in the following automated tests:

- docs-only change, no automated tests apply

#### Manual testing

1. In a TanStack React Storybook project, add the `.storybook/query-clients.ts` helper and the preview configuration from the new snippet
2. Add two autodocs stories that seed different values under the same query key
3. Open the Docs page: each story renders its own seeded value (with the previous shared-client setup, both render the last-seeded value)

### Documentation

- [x] Add or update documentation reflecting your changes

Prepared with AI assistance; repro, testing, and review by me.