### PR TITLE
fix: toggle Vitest coverage without restarting

### DIFF
--- a/code/addons/vitest/src/node/vitest-manager.ts
+++ b/code/addons/vitest/src/node/vitest-manager.ts
@@ -382,7 +382,11 @@ export class VitestManager {
     if (!this.vitest) {
       await this.startVitest({ coverage: coverageShouldBeEnabled });
     } else if (currentCoverage !== coverageShouldBeEnabled) {
-      await this.restartVitest({ coverage: coverageShouldBeEnabled });
+      if (coverageShouldBeEnabled) {
+        await this.vitest.enableCoverage();
+      } else {
+        this.vitest.disableCoverage();
+      }
     } else {
       await this.vitestRestartPromise;
     }


### PR DESCRIPTION
## What I did

- Use Vitest 4's `enableCoverage()` and `disableCoverage()` APIs when the coverage setting changes between Storybook Vitest runs.
- Keep the existing Vitest instance alive instead of recreating it for a coverage toggle.

## Why

Issue #36215 follows the Vitest 4 migration and requests using the dynamic coverage API. Reusing the existing instance avoids restarting the Vitest server and preserves the active test manager state.

Fixes #36215

## Validation

- `git diff --check`
- Reviewed against Vitest 4's documented `enableCoverage()` / `disableCoverage()` API.

The repository uses Yarn and its full dependency install was not available in this sparse checkout, so the focused package test could not be run locally.

## AI assistance

This pull request was prepared with Codex assistance and reviewed by the submitting contributor.
