### PR TITLE
Nextjs-Vite: Skip unresolved image imports

### DIFF
--- a/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-image/plugin.test.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-image/plugin.test.ts
@@ -89,6 +89,27 @@ describe('vitePluginNextImage resolveId', () => {
     expect(loaded).toContain(resolvedPath);
   });
 
+  it('does not claim bare image imports that cannot be resolved', async () => {
+    const plugin = vitePluginNextImage(passthroughConfig);
+    const importer = '/project/src/Component.tsx';
+    const resolve = vi.fn().mockResolvedValue(null);
+    requireResolveMock.mockImplementationOnce(() => {
+      throw new Error('Cannot find module');
+    });
+
+    const id = await plugin.resolveId!.call(
+      createContext(resolve),
+      '@/assets/avatar.png',
+      importer
+    );
+
+    expect(resolve).toHaveBeenCalledWith('@/assets/avatar.png', importer, { skipSelf: true });
+    expect(requireResolveMock).toHaveBeenCalledWith('@/assets/avatar.png', {
+      paths: [dirname(importer)],
+    });
+    expect(id).toBeNull();
+  });
+
   it('keeps virtual IDs short and stable for deeply nested monorepo paths', async () => {
     const plugin = vitePluginNextImage(passthroughConfig);
     const deepDir = `/Users/x/dev/${'nested-'.repeat(30)}leaf`;

--- a/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-image/plugin.ts
+++ b/code/lib/vite-plugin-storybook-nextjs/src/plugins/next-image/plugin.ts
@@ -145,7 +145,7 @@ export function vitePluginNextImage(
                   paths: [path.dirname(importerPath)],
                 });
               } catch {
-                imagePath = source;
+                return null;
               }
             }
           }


### PR DESCRIPTION
Closes #36285

## What I did

- Stop the Next.js image plugin from creating a virtual module when both Vite resolution and the `require.resolve` fallback fail for a bare image import.
- Add a regression test for an unresolved aliased image while preserving the existing relative-import and package-resolution paths.
- Leave the existing malformed/corrupt image load behavior unchanged; this PR only fixes ownership of unresolved imports.

On Vite 8.1+, tsconfig path aliases are scoped to files included by the tsconfig. For an excluded story, the previous fallback registered the raw alias as if it were a resolved filesystem path. The load hook then returned `undefined`, allowing Rolldown to interpret the NUL-prefixed virtual ID as a file path. Returning `null` from `resolveId` keeps the unresolved import in Vite's normal resolution/error path instead.

AI disclosure: Codex was used for investigation, implementation, tests, and drafting. This contribution was submitted under the account owner's direction, and the account owner remains responsible for follow-up.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

No browser QA is required because this changes only the image plugin's resolver fallback. To verify the reported path manually:

1. Use the minimal reproduction from #36285 with Vite 8.3 and keep `**/*.stories.tsx` excluded from `tsconfig.json`.
2. Run `npx storybook build`.
3. Confirm that the plugin no longer creates a `\0virtual:next-image:*` module from `@/assets/pic.webp`; the unresolved alias remains in Vite's normal resolution path instead of producing the misleading `unexpected NUL byte` error.
4. Remove the story exclusion (or otherwise make the alias resolvable) and confirm that the build still succeeds through the existing Vite-resolution path.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
  <details>
    <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

  </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
