### PR TITLE
Explore: unified SVG trace layer for the sidebar tree (Design 3)

### DIFF
--- a/code/core/src/manager/components/sidebar/Tree.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Tree.stories.tsx
@@ -659,17 +659,11 @@ export const StickyAncestors: Story = {
     expect(pinnedRoot.querySelector('use')).toBeNull();
     expect(pinnedRoot.querySelector('[data-testid="pinned-collapse"] svg')).not.toBeNull();
 
-    // Trace lines of pinned copies must sit on the same x positions as the natural rows below.
-    const traceLefts = (root: Element) =>
-      [...root.querySelectorAll('[data-testid="trace-line"]')].map((el) =>
-        Math.round(el.getBoundingClientRect().left)
-      );
-    const naturalLefts = traceLefts(scroller);
-    const overlay = canvasElement.querySelector('[data-testid="sticky-overlay"]')!;
-    expect(traceLefts(overlay).length).toBeGreaterThan(0);
-    for (const left of traceLefts(overlay)) {
-      expect(naturalLefts).toContain(left);
-    }
+    // The unified trace layer draws every guide line as one continuous SVG path spanning the
+    // pinned stack and the scrolling rows (Design 3), so pinned and natural lines share x by
+    // construction. Assert the layer is present and has drawn segments.
+    const tracePath = canvasElement.querySelector('[data-testid="trace-layer"] path')!;
+    expect(tracePath.getAttribute('d')?.length ?? 0).toBeGreaterThan(0);
 
     // Jitter regression: overlay membership must be stable across single-pixel scrolls
     // (membership derives from row offsets only, never from the engaged stack).

--- a/code/core/src/manager/components/sidebar/Tree.tsx
+++ b/code/core/src/manager/components/sidebar/Tree.tsx
@@ -107,7 +107,7 @@ const TreeWrapper = styled.div(({ theme }) => ({
 // Design 3: a single SVG above the fade and the pinned rows carries every trace line, so they are
 // continuous by construction (no per-row seams, no bridge, nothing can leak through). The path is
 // filled imperatively on scroll (see the scroll effect). Gated on hover/focus like the old lines.
-const TraceLayer = styled.svg({
+const TraceLayer = styled.svg(({ theme }) => ({
   position: 'absolute',
   inset: 0,
   width: '100%',
@@ -118,11 +118,17 @@ const TraceLayer = styled.svg({
   transition: 'opacity 150ms ease',
   shapeRendering: 'crispEdges',
   '& path': {
-    stroke: 'var(--trace-color)',
     strokeWidth: 1,
     fill: 'none',
   },
-});
+  // Grey grid; the hovered/focused row's slice is drawn over it in the accent colour.
+  '& path[data-trace-grid]': {
+    stroke: theme.appBorderColor,
+  },
+  '& path[data-trace-hover]': {
+    stroke: transparentize(0.52, theme.color.secondary),
+  },
+}));
 
 const PinnedOverlay = styled.div({
   position: 'absolute',
@@ -254,8 +260,14 @@ export const Tree = React.memo<TreeProps>(function Tree({
   onSelectStoryId: onSelectStoryIdProp,
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
-  // Design 3: the whole trace grid is drawn into this one path, updated imperatively on scroll.
+  const treeWrapperRef = useRef<HTMLDivElement>(null);
+  // Design 3: the whole trace grid is drawn into these two paths, updated imperatively on scroll.
+  // The grey path carries every line; the blue path re-draws just the hovered/focused row's slice.
   const tracePathRef = useRef<SVGPathElement>(null);
+  const traceHoverPathRef = useRef<SVGPathElement>(null);
+  const pinnedIdsRef = useRef<string[]>([]);
+  // The row (natural or pinned) currently under the pointer, whose trace slice is drawn blue.
+  const hoveredTraceRef = useRef<{ id: string; pinned: boolean } | null>(null);
   const api = useStorybookApi();
   const { isMobile } = useLayout();
   // Mirrors the labelContext TreeNode passes to renderLabel, so pinned copies match their rows.
@@ -630,6 +642,94 @@ export const Tree = React.memo<TreeProps>(function Tree({
   // subtree continues below it; each pinned row hands off once the rows below its slot leave
   // its subtree, so an incoming container's header is never covered by the stack.
   const [pinnedIds, setPinnedIds] = useState<string[]>([]);
+
+  // Design 3: draw the whole trace grid into two SVG paths in viewport space — the pinned stack at
+  // fixed slots, the scrolling rows offset by scrollTop. The grey path carries every guide (a
+  // level-D row fills columns 1..D at x=k*20-7; adjacent rows' segments abut into continuous lines
+  // with no merge). The blue path re-draws only the hovered/focused row's own slice, restoring the
+  // per-row highlight the old row-level `--trace-color` gave. Written imperatively so scrolling and
+  // hovering never re-render the tree. Reads the last pinned chain from pinnedIdsRef.
+  const drawTraces = useCallback(() => {
+    const scroller = containerRef.current;
+    if (!scroller) {
+      return;
+    }
+    const { offsets, depths, indexById } = flatRowsRef.current;
+    const data = collapsedDataRef.current;
+    const chain = pinnedIdsRef.current;
+    const targetY = scroller.scrollTop;
+    const viewH = scroller.clientHeight;
+    const rowH = TREE_ROW_HEIGHT;
+    const slots = chain.length;
+    const stackBottom = slots * rowH;
+    const depthOf = (id: string) => {
+      const entry = data[id];
+      return entry ? (entry.type === 'root' ? 0 : (entry.depth ?? 0)) : 0;
+    };
+    const seg = (parts: string[], col: number, y1: number, y2: number) => {
+      const x = col * 20 - 7 + 0.5; // +0.5 keeps the 1px stroke on the device-pixel grid
+      parts.push(`M${x} ${Math.round(y1)}V${Math.round(y2)}`);
+    };
+
+    const grey: string[] = [];
+    for (let s = 0; s < slots; s += 1) {
+      const depth = depthOf(chain[s]);
+      for (let k = 1; k <= depth; k += 1) {
+        seg(grey, k, s * rowH, (s + 1) * rowH);
+      }
+    }
+    for (let i = 0; i < offsets.length; i += 1) {
+      const yTop = offsets[i] - targetY;
+      if (yTop >= viewH) {
+        break;
+      }
+      const yBot = yTop + rowH;
+      if (yBot <= stackBottom) {
+        continue; // occluded by the pinned stack
+      }
+      const top = Math.max(yTop, stackBottom);
+      for (let k = 1; k <= depths[i]; k += 1) {
+        seg(grey, k, top, yBot);
+      }
+    }
+    tracePathRef.current?.setAttribute('d', grey.join(''));
+
+    // Blue overlay: the hovered/focused row's own guide slice (drawn over the grey path).
+    const blue: string[] = [];
+    const naturalSlice = (id: string) => {
+      const idx = indexById.get(id);
+      if (idx === undefined) {
+        return;
+      }
+      const yTop = offsets[idx] - targetY;
+      const yBot = yTop + rowH;
+      if (yBot <= stackBottom || yTop >= viewH) {
+        return; // occluded or off-screen
+      }
+      const top = Math.max(yTop, stackBottom);
+      for (let k = 1; k <= depths[idx]; k += 1) {
+        seg(blue, k, top, yBot);
+      }
+    };
+    const hovered = hoveredTraceRef.current;
+    if (hovered?.pinned) {
+      const slot = chain.indexOf(hovered.id);
+      if (slot >= 0) {
+        const depth = depthOf(hovered.id);
+        for (let k = 1; k <= depth; k += 1) {
+          seg(blue, k, slot * rowH, (slot + 1) * rowH);
+        }
+      }
+    } else if (hovered) {
+      naturalSlice(hovered.id);
+    }
+    const focused = focusedItemIdRef.current;
+    if (focused && focused !== hovered?.id) {
+      naturalSlice(focused);
+    }
+    traceHoverPathRef.current?.setAttribute('d', blue.join(''));
+  }, []);
+
   useEffect(() => {
     const scroller = containerRef.current;
     if (!scroller) {
@@ -638,7 +738,7 @@ export const Tree = React.memo<TreeProps>(function Tree({
     let rafId: number | null = null;
     const update = () => {
       rafId = null;
-      const { ids, offsets, depths, indexById, subtreeBottoms } = flatRowsRef.current;
+      const { ids, offsets, indexById, subtreeBottoms } = flatRowsRef.current;
       const targetY = scroller.scrollTop;
       // First row whose bottom is below the top line (bottom = next row's offset, or the
       // row's own offset + height for the last row).
@@ -683,46 +783,8 @@ export const Tree = React.memo<TreeProps>(function Tree({
           ? prev
           : chainIds
       );
-
-      // Design 3: one continuous trace layer. Emit every visible guide segment (a level-D row
-      // fills columns 1..D at x = k*20-7) in viewport space — the pinned stack at fixed slots, the
-      // scrolling rows offset by scrollTop. Because the layer sits above the fade, the lines never
-      // break at the seam, and content can't leak (unlike the masked fade). Written imperatively to
-      // one <path> so scrolling doesn't re-render the tree. Guide columns for a level-D row are the
-      // same as its ancestors', so adjacent rows' segments abut into continuous lines with no merge.
-      const data = collapsedDataRef.current;
-      const rowH = TREE_ROW_HEIGHT;
-      const slots = chainIds.length;
-      const stackBottom = slots * rowH;
-      const viewH = scroller.clientHeight;
-      let d = '';
-      const line = (col: number, y1: number, y2: number) => {
-        const x = col * 20 - 7 + 0.5; // +0.5 keeps the 1px stroke on the device-pixel grid
-        d += `M${x} ${Math.round(y1)}V${Math.round(y2)}`;
-      };
-      for (let s = 0; s < slots; s += 1) {
-        const entry = data[chainIds[s]];
-        const depth = entry ? (entry.type === 'root' ? 0 : (entry.depth ?? 0)) : 0;
-        for (let k = 1; k <= depth; k += 1) {
-          line(k, s * rowH, (s + 1) * rowH);
-        }
-      }
-      for (let i = 0; i < offsets.length; i += 1) {
-        const yTop = offsets[i] - targetY;
-        if (yTop >= viewH) {
-          break;
-        }
-        const yBot = yTop + rowH;
-        if (yBot <= stackBottom) {
-          continue; // occluded by the pinned stack
-        }
-        const depth = depths[i];
-        const top = Math.max(yTop, stackBottom);
-        for (let k = 1; k <= depth; k += 1) {
-          line(k, top, yBot);
-        }
-      }
-      tracePathRef.current?.setAttribute('d', d);
+      pinnedIdsRef.current = chainIds;
+      drawTraces();
     };
     const scheduleUpdate = () => {
       if (rafId === null) {
@@ -737,7 +799,46 @@ export const Tree = React.memo<TreeProps>(function Tree({
         cancelAnimationFrame(rafId);
       }
     };
-  }, [flatRows]);
+  }, [flatRows, drawTraces]);
+
+  // Redraw the trace grid when the tree wants to (hover moves the blue slice, focus/geometry
+  // changes shift lines) without waiting for a scroll event.
+  useEffect(() => {
+    const wrapper = treeWrapperRef.current;
+    if (!wrapper) {
+      return;
+    }
+    const setHovered = (next: { id: string; pinned: boolean } | null) => {
+      const prev = hoveredTraceRef.current;
+      if (prev?.id === next?.id && prev?.pinned === next?.pinned) {
+        return;
+      }
+      hoveredTraceRef.current = next;
+      drawTraces();
+    };
+    const onOver = (event: Event) => {
+      const target = event.target as Element | null;
+      const pinned = target?.closest?.('[data-pinned-item-id]');
+      if (pinned) {
+        setHovered({ id: pinned.getAttribute('data-pinned-item-id')!, pinned: true });
+        return;
+      }
+      const natural = target?.closest?.('[data-item-id]');
+      setHovered(natural ? { id: natural.getAttribute('data-item-id')!, pinned: false } : null);
+    };
+    const onLeave = () => setHovered(null);
+    wrapper.addEventListener('mouseover', onOver);
+    wrapper.addEventListener('mouseleave', onLeave);
+    return () => {
+      wrapper.removeEventListener('mouseover', onOver);
+      wrapper.removeEventListener('mouseleave', onLeave);
+    };
+  }, [drawTraces]);
+
+  // Keyboard focus also highlights its row's slice.
+  useEffect(() => {
+    drawTraces();
+  }, [focusedItemId, drawTraces]);
 
   // Clicking a pinned row scrolls its real row to the exact position the pinned copy occupies
   // (slot i of the overlay), so nothing appears to move.
@@ -948,7 +1049,7 @@ export const Tree = React.memo<TreeProps>(function Tree({
   return (
     <StatusContext.Provider value={statusContextValue}>
       <RowUiContext.Provider value={rowUiStoreRef.current}>
-        <TreeWrapper>
+        <TreeWrapper ref={treeWrapperRef}>
           <Virtualizer layout={treeLayout}>
             <StyledAriaTree
               ref={containerRef}
@@ -1017,7 +1118,8 @@ export const Tree = React.memo<TreeProps>(function Tree({
             </PinnedOverlay>
           )}
           <TraceLayer aria-hidden="true" data-testid="trace-layer">
-            <path ref={tracePathRef} />
+            <path ref={tracePathRef} data-trace-grid />
+            <path ref={traceHoverPathRef} data-trace-hover />
           </TraceLayer>
         </TreeWrapper>
         {supportsAnchorPositioning && focusedItemShortcutLabel && (

--- a/code/core/src/manager/components/sidebar/Tree.tsx
+++ b/code/core/src/manager/components/sidebar/Tree.tsx
@@ -13,7 +13,7 @@ import {
   getAncestorIds,
   indexToTree,
 } from '../../utils/tree.ts';
-import { SECTION_GAP, TREE_ROW_HEIGHT, Traces, TreeNode, type TreeNodeProps } from './TreeNode.tsx';
+import { SECTION_GAP, TREE_ROW_HEIGHT, TreeNode, type TreeNodeProps } from './TreeNode.tsx';
 
 import {
   Addon_TypesEnum,
@@ -83,9 +83,8 @@ const TreeWrapper = styled.div(({ theme }) => ({
   // Contain the overlay's z-index so UI outside the tree still paints above it.
   isolation: 'isolate',
   '--sticky-bg': theme.background.content,
-  // Show trace lines only while hovering or keyboard-focused inside the tree. Scoped to the whole
-  // wrapper (not just the scroller) so the pinned overlay's lines follow the same rule instead of
-  // being permanently drawn.
+  '--trace-color': theme.appBorderColor,
+  // Show trace lines only while hovering or keyboard-focused inside the tree.
   '&:hover, &:has(:focus-visible)': {
     '--trace-opacity': 1,
   },
@@ -105,14 +104,34 @@ const TreeWrapper = styled.div(({ theme }) => ({
   },
 }));
 
-const PinnedOverlay = styled.div(({ theme }) => ({
+// Design 3: a single SVG above the fade and the pinned rows carries every trace line, so they are
+// continuous by construction (no per-row seams, no bridge, nothing can leak through). The path is
+// filled imperatively on scroll (see the scroll effect). Gated on hover/focus like the old lines.
+const TraceLayer = styled.svg({
+  position: 'absolute',
+  inset: 0,
+  width: '100%',
+  height: '100%',
+  zIndex: 4,
+  pointerEvents: 'none',
+  opacity: 'var(--trace-opacity, 0)',
+  transition: 'opacity 150ms ease',
+  shapeRendering: 'crispEdges',
+  '& path': {
+    stroke: 'var(--trace-color)',
+    strokeWidth: 1,
+    fill: 'none',
+  },
+});
+
+const PinnedOverlay = styled.div({
   position: 'absolute',
   top: 0,
   left: 0,
   right: 0,
   zIndex: 3,
-  '--trace-color': theme.appBorderColor,
-  // Soft fade between the pinned stack and the scrolling rows beneath it.
+  // Soft fade between the pinned stack and the scrolling rows beneath it. The trace lines sit above
+  // it (in TraceLayer), so they stay continuous through it.
   '&::after': {
     content: '""',
     position: 'absolute',
@@ -123,12 +142,7 @@ const PinnedOverlay = styled.div(({ theme }) => ({
     pointerEvents: 'none',
     background: 'linear-gradient(to bottom, var(--sticky-bg), transparent)',
   },
-  // The bridge continues the deepest pinned row's lines, so it blues with that row (the last
-  // pinned button) — keeping the continued line one colour on hover.
-  '&:has([data-pinned-item-id]:last-of-type:hover) [data-pinned-bridge]': {
-    '--trace-color': transparentize(0.52, theme.color.secondary),
-  },
-}));
+});
 
 const PinnedRow = styled.button<{ $level: number }>(({ $level, theme }) => ({
   position: 'relative',
@@ -161,10 +175,6 @@ const PinnedRow = styled.button<{ $level: number }>(({ $level, theme }) => ({
   '&:hover::before': {
     background: theme.background.hoverable,
   },
-  // Blue the trace lines on hover, like natural rows (StyledTreeItem).
-  '&:hover': {
-    '--trace-color': transparentize(0.52, theme.color.secondary),
-  },
   '& svg': {
     flexShrink: 0,
   },
@@ -193,29 +203,6 @@ const PinnedRowIcon = styled.span({
   display: 'flex',
   alignItems: 'center',
 });
-
-// Zero-width anchor fixed at the natural row's content-box start (level indent, before the
-// 7px content padding), so the trace lines it hosts land exactly where real rows draw them.
-// Out of the flex flow, or the row gap would push the icon off the natural rows' grid.
-const PinnedTraceAnchor = styled.span<{ $level: number }>(({ $level }) => ({
-  position: 'absolute',
-  insetBlock: 0,
-  insetInlineStart: `calc(${$level} * 20px)`,
-  width: 0,
-}));
-
-// Continues the deepest pinned row's ancestor trace lines down through the fade, so they read as
-// one line with the scrolling rows below instead of being cut by the fade. Painted above the fade
-// (which sits at the overlay's ::after, z-index auto). Anchored like PinnedTraceAnchor.
-const PinnedFadeBridge = styled.span<{ $level: number }>(({ $level }) => ({
-  position: 'absolute',
-  top: '100%',
-  height: SECTION_GAP,
-  insetInlineStart: `calc(${$level} * 20px)`,
-  width: 0,
-  zIndex: 1,
-  pointerEvents: 'none',
-}));
 
 // The label must own the free space and truncate stably, or the row content jitters
 // horizontally as pinned rows swap while scrolling. position: relative keeps it above the row's
@@ -267,6 +254,8 @@ export const Tree = React.memo<TreeProps>(function Tree({
   onSelectStoryId: onSelectStoryIdProp,
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
+  // Design 3: the whole trace grid is drawn into this one path, updated imperatively on scroll.
+  const tracePathRef = useRef<SVGPathElement>(null);
   const api = useStorybookApi();
   const { isMobile } = useLayout();
   // Mirrors the labelContext TreeNode passes to renderLabel, so pinned copies match their rows.
@@ -604,6 +593,8 @@ export const Tree = React.memo<TreeProps>(function Tree({
     const ids: string[] = [];
     const gapIds = new Set<string>();
     const offsets: number[] = [];
+    // Indent depth per row (0 for a top-level root), used to place trace guide lines.
+    const depths: number[] = [];
     const indexById = new Map<string, number>();
     const subtreeBottoms = new Map<string, number>();
     let y = 0;
@@ -617,6 +608,7 @@ export const Tree = React.memo<TreeProps>(function Tree({
         }
         indexById.set(entry.id, ids.length);
         ids.push(entry.id);
+        depths.push(level - 1);
         offsets.push(y + (hasGap ? SECTION_GAP : 0));
         y += TREE_ROW_HEIGHT + (hasGap ? SECTION_GAP : 0);
         prevLevel1 = isLevel1;
@@ -627,7 +619,7 @@ export const Tree = React.memo<TreeProps>(function Tree({
       }
     };
     walk(tree, 1);
-    return { ids, gapIds, offsets, indexById, subtreeBottoms, totalHeight: y };
+    return { ids, gapIds, offsets, depths, indexById, subtreeBottoms, totalHeight: y };
   }, [tree, expanded]);
   const flatRowsRef = useRef(flatRows);
   flatRowsRef.current = flatRows;
@@ -646,7 +638,7 @@ export const Tree = React.memo<TreeProps>(function Tree({
     let rafId: number | null = null;
     const update = () => {
       rafId = null;
-      const { ids, offsets, indexById, subtreeBottoms } = flatRowsRef.current;
+      const { ids, offsets, depths, indexById, subtreeBottoms } = flatRowsRef.current;
       const targetY = scroller.scrollTop;
       // First row whose bottom is below the top line (bottom = next row's offset, or the
       // row's own offset + height for the last row).
@@ -691,6 +683,46 @@ export const Tree = React.memo<TreeProps>(function Tree({
           ? prev
           : chainIds
       );
+
+      // Design 3: one continuous trace layer. Emit every visible guide segment (a level-D row
+      // fills columns 1..D at x = k*20-7) in viewport space — the pinned stack at fixed slots, the
+      // scrolling rows offset by scrollTop. Because the layer sits above the fade, the lines never
+      // break at the seam, and content can't leak (unlike the masked fade). Written imperatively to
+      // one <path> so scrolling doesn't re-render the tree. Guide columns for a level-D row are the
+      // same as its ancestors', so adjacent rows' segments abut into continuous lines with no merge.
+      const data = collapsedDataRef.current;
+      const rowH = TREE_ROW_HEIGHT;
+      const slots = chainIds.length;
+      const stackBottom = slots * rowH;
+      const viewH = scroller.clientHeight;
+      let d = '';
+      const line = (col: number, y1: number, y2: number) => {
+        const x = col * 20 - 7 + 0.5; // +0.5 keeps the 1px stroke on the device-pixel grid
+        d += `M${x} ${Math.round(y1)}V${Math.round(y2)}`;
+      };
+      for (let s = 0; s < slots; s += 1) {
+        const entry = data[chainIds[s]];
+        const depth = entry ? (entry.type === 'root' ? 0 : (entry.depth ?? 0)) : 0;
+        for (let k = 1; k <= depth; k += 1) {
+          line(k, s * rowH, (s + 1) * rowH);
+        }
+      }
+      for (let i = 0; i < offsets.length; i += 1) {
+        const yTop = offsets[i] - targetY;
+        if (yTop >= viewH) {
+          break;
+        }
+        const yBot = yTop + rowH;
+        if (yBot <= stackBottom) {
+          continue; // occluded by the pinned stack
+        }
+        const depth = depths[i];
+        const top = Math.max(yTop, stackBottom);
+        for (let k = 1; k <= depth; k += 1) {
+          line(k, top, yBot);
+        }
+      }
+      tracePathRef.current?.setAttribute('d', d);
     };
     const scheduleUpdate = () => {
       if (rafId === null) {
@@ -955,9 +987,6 @@ export const Tree = React.memo<TreeProps>(function Tree({
                     tabIndex={-1}
                     onClick={() => scrollPinnedRowIntoPlace(id, overlayIndex)}
                   >
-                    <PinnedTraceAnchor $level={level}>
-                      <Traces level={level} isAlongsideSelected={false} />
-                    </PinnedTraceAnchor>
                     <PinnedRowIcon
                       data-testid="pinned-collapse"
                       onClick={(event) => {
@@ -985,24 +1014,11 @@ export const Tree = React.memo<TreeProps>(function Tree({
                   </PinnedRow>
                 );
               })}
-              {(() => {
-                // Bridge the deepest pinned row's ancestor lines through the fade. The deepest
-                // level itself has no parent line above to continue, so it is excluded (a lone
-                // pinned root, level 0, draws no line at all).
-                const lastEntry = collapsedData[pinnedIds[pinnedIds.length - 1]];
-                const deepestLevel = lastEntry
-                  ? lastEntry.type === 'root'
-                    ? 0
-                    : (lastEntry.depth ?? 0)
-                  : 0;
-                return deepestLevel > 0 ? (
-                  <PinnedFadeBridge $level={deepestLevel} data-pinned-bridge>
-                    <Traces level={deepestLevel} isAlongsideSelected={false} />
-                  </PinnedFadeBridge>
-                ) : null;
-              })()}
             </PinnedOverlay>
           )}
+          <TraceLayer aria-hidden="true" data-testid="trace-layer">
+            <path ref={tracePathRef} />
+          </TraceLayer>
         </TreeWrapper>
         {supportsAnchorPositioning && focusedItemShortcutLabel && (
           <FocusTooltipNote note={focusedItemShortcutLabel} shortcut={contextMenuShortcut} />

--- a/code/core/src/manager/components/sidebar/TreeNode.tsx
+++ b/code/core/src/manager/components/sidebar/TreeNode.tsx
@@ -159,56 +159,6 @@ const StyledContent = styled.div({
   position: 'relative',
 });
 
-const StyledTraces = styled.span({
-  display: 'flex',
-  gap: 0,
-  alignItems: 'stretch',
-  height: '100%',
-  position: 'absolute',
-  left: 0,
-  top: 0,
-  bottom: 0,
-  pointerEvents: 'none',
-});
-
-const StyledTraceLine = styled.span<{ $offset: number; $forceVisible?: boolean }>(
-  ({ $offset, $forceVisible }) => ({
-    position: 'absolute',
-    left: `calc(${$offset} * -20px - 7px)`,
-    top: 0,
-    bottom: 0,
-    width: 1,
-    backgroundColor: 'var(--trace-color)',
-    opacity: $forceVisible ? 1 : 'var(--trace-opacity, 0)',
-    transition: 'opacity 150ms ease',
-  })
-);
-
-export const Traces = ({
-  level,
-  isAlongsideSelected,
-}: {
-  level: number;
-  isAlongsideSelected: boolean;
-}) => {
-  if (level === 0) {
-    return null;
-  }
-
-  return (
-    <StyledTraces>
-      {Array.from({ length: level }, (_, i) => (
-        <StyledTraceLine
-          key={i}
-          data-testid="trace-line"
-          $offset={i}
-          $forceVisible={isAlongsideSelected && i === 0}
-        />
-      ))}
-    </StyledTraces>
-  );
-};
-
 const StyledLabel = styled.span({
   flex: '1 1 auto',
   minWidth: 0,
@@ -304,10 +254,6 @@ export const TreeNode = React.memo<TreeNodeProps>(function TreeNode({
   // as react-aria collection dependencies they re-rendered every row in the tree on each
   // selection change. Only rows whose derived value changes re-render.
   const rowUi = useContext(RowUiContext);
-  const isAlongsideSelected = useSyncExternalStore(
-    rowUi.subscribe,
-    () => item.type !== 'root' && rowUi.getState().selectedParentId === item.parent
-  );
   const contextMenuEntryMethod = useSyncExternalStore(rowUi.subscribe, () => {
     const menu = rowUi.getState().contextMenu;
     return menu?.itemId === item.id ? menu.entryMethod : undefined;
@@ -452,7 +398,6 @@ export const TreeNode = React.memo<TreeNodeProps>(function TreeNode({
     >
       <TreeItemContent>
         <StyledContent>
-          <Traces level={item.depth} isAlongsideSelected={isAlongsideSelected} />
           {prefixAction}
           <StyledLabel>{item.renderLabel?.(item, api, labelContext) || item.name}</StyledLabel>
           {renderContextMenu && (


### PR DESCRIPTION
## What

An **exploration** of an alternative to the sticky-tree trace-line continuity fix on `issue-31267-sidebar-2`. Instead of drawing guide lines per-row and stitching them across the sticky fade with a `PinnedFadeBridge`, this draws **every trace line in one SVG layer** that sits above the fade and the pinned stack.

The grid is computed in viewport space from the flat-row geometry (`offsets` + per-row `depths`) and written imperatively to a `<path>` on scroll. So the lines are **continuous by construction** — they run straight through the fade with no bridge, and because the layer is on top, nothing can leak through it.

A second `<path>` re-draws just the **hovered or keyboard-focused row's own guide slice** in the accent colour, restoring the per-row blue highlight (hover is tracked with a delegated listener so it covers natural rows and pinned copies alike).

It's also net-negative on code: the per-row `Traces`, `PinnedTraceAnchor`, and `PinnedFadeBridge` all go away.

## Why open this

We were comparing three ways to keep the guide line continuous across the sticky fade:

1. **Masked fade** — punch transparent columns in the fade at the trace grid. Rejected: the mask is content-blind, so it also reveals 1px slivers of labels/icons (a "comb" artifact) wherever the grid crosses content.
2. **Bridge** (what's on the base branch) — redraw the deepest pinned row's lines through the fade. Works, but it's a special-cased element and only bridges the pinned chain.
3. **Unified layer** (this PR) — one source of truth for all lines; continuity is inherent, not stitched.

## Trade-offs to weigh before adopting

- **The path recomputes every scroll frame** — done imperatively (no React re-render), but it is per-frame work the per-row approach didn't need.
- **No "alongside selected" guide highlight** yet (the faint highlight on the selected story's parent guide). Same mechanism as the hover slice; not wired up here.

## Verification

- `Tree`, `TreeNode`, `Sidebar`, `Explorer` story suites pass (the sticky-trace assertion now checks the unified layer's path).
- Confirmed visually: the lines run continuously from the pinned stack through the fade into the scrolling rows with zero content leak, and hovering a row blues its guide slice.

Not necessarily meant to merge as-is — it's here so we can compare it directly against the bridge and decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)