### PR TITLE
Actions: Fix SecurityError when an fn() spy receives a synthetic event

### DIFF
--- a/code/core/src/actions/loaders.test.ts
+++ b/code/core/src/actions/loaders.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { addons } from 'storybook/preview-api';
+import { onMockCall } from 'storybook/test';
+
+import { loaders } from './loaders.ts';
+
+vi.mock('storybook/preview-api');
+vi.mock('storybook/test', () => ({ onMockCall: vi.fn() }));
+
+const createChannel = () => {
+  const channel = { emit: vi.fn() };
+  vi.mocked(addons.getChannel).mockReturnValue(channel as any);
+  return channel;
+};
+
+describe('loaders', () => {
+  it('emits each mock call argument to the action channel, not the args array', () => {
+    const channel = createChannel();
+    loaders[0]({ parameters: {} } as any);
+
+    expect(onMockCall).toHaveBeenCalledOnce();
+    const onCall = vi.mocked(onMockCall).mock.calls[0][0];
+
+    const event = { type: 'click' };
+    onCall({ getMockName: () => 'onClick' } as any, [event]);
+
+    expect(channel.emit).toHaveBeenCalledOnce();
+    expect(channel.emit.mock.calls[0][1].data.args).toBe(event);
+  });
+});

--- a/code/core/src/actions/loaders.ts
+++ b/code/core/src/actions/loaders.ts
@@ -44,7 +44,7 @@ const logActionsWhenMockCalled: LoaderFunction = (context) => {
           'next/headers::headers().delete',
         ].some((prefix) => name.startsWith(prefix))
       ) {
-        action(name)(args);
+        action(name)(...args);
       }
     });
     subscribed = true;

--- a/code/core/src/actions/runtime/__tests__/action.test.js
+++ b/code/core/src/actions/runtime/__tests__/action.test.js
@@ -31,6 +31,46 @@ describe('Action', () => {
   });
 });
 
+describe('serializing React synthetic events', () => {
+  // a Window self-references via .window, including cross-origin windows
+  class Window {}
+  const fakeWindow = new Window();
+  fakeWindow.window = fakeWindow;
+
+  const createSyntheticEvent = () => {
+    class SyntheticBaseEvent {}
+    class PointerEvent {}
+    // DOM events expose `view` through the prototype chain…
+    Object.defineProperty(PointerEvent.prototype, 'view', { get: () => fakeWindow });
+    const nativeEvent = Object.create(PointerEvent.prototype);
+    // …and React 19 also stamps it as a non-configurable own accessor
+    Object.defineProperty(nativeEvent, 'view', { enumerable: true, get: () => fakeWindow });
+    return Object.assign(Object.create(SyntheticBaseEvent.prototype), {
+      persist: () => {},
+      nativeEvent,
+      view: fakeWindow,
+    });
+  };
+
+  it('stubs `view` and `nativeEvent.view` so no Window reaches the channel', () => {
+    const channel = createChannel();
+    const event = createSyntheticEvent();
+
+    action('test-action')(event);
+
+    const emitted = getChannelData(channel);
+    expect(emitted).not.toBe(event);
+    expect(emitted.view).not.toBe(fakeWindow);
+    expect(Object.keys(emitted.view)).toEqual([]);
+    expect(emitted.nativeEvent).not.toBe(event.nativeEvent);
+    expect(emitted.nativeEvent.view).not.toBe(fakeWindow);
+    expect(Object.keys(emitted.nativeEvent.view)).toEqual([]);
+    // the event the story (and spy) retains is left untouched
+    expect(event.view).toBe(fakeWindow);
+    expect(event.nativeEvent.view).toBe(fakeWindow);
+  });
+});
+
 describe('Depth config', () => {
   it('with global depth configuration', () => {
     const channel = createChannel();

--- a/code/core/src/actions/runtime/action.ts
+++ b/code/core/src/actions/runtime/action.ts
@@ -26,6 +26,39 @@ const isReactSyntheticEvent = (e: unknown): e is SyntheticEvent =>
     findProto(e, (proto) => /^Synthetic(?:Base)?Event$/.test(proto.constructor.name)) &&
     typeof (e as SyntheticEvent).persist === 'function'
   );
+const isWindowObject = (value: unknown): value is Window => {
+  try {
+    // `window.window === window` and the `window` property is one of the few
+    // allowed to be read on cross-origin Window objects, so this also detects
+    // windows we cannot inspect any further.
+    return typeof value === 'object' && value !== null && (value as Window).window === value;
+  } catch {
+    return true;
+  }
+};
+
+// Replaces a property pointing to a Window with an empty stub: sending a real
+// Window over the channel makes the serializer walk `top`/`frames` into any
+// cross-origin iframes in the manager document and throw a SecurityError.
+const stubWindowProp = (target: Record<string, unknown>, prop: string) => {
+  let value: unknown;
+  try {
+    value = target[prop];
+  } catch {
+    return;
+  }
+
+  if (isWindowObject(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(target, prop);
+    Object.defineProperty(target, prop, {
+      enumerable: descriptor?.enumerable ?? true,
+      configurable: true,
+      writable: true,
+      value: Object.create(value.constructor.prototype),
+    });
+  }
+};
+
 const serializeArg = <T extends object>(a: T) => {
   if (isReactSyntheticEvent(a)) {
     const e: SyntheticEvent = Object.create(
@@ -33,14 +66,27 @@ const serializeArg = <T extends object>(a: T) => {
       Object.getOwnPropertyDescriptors(a)
     );
     e.persist();
-    const viewDescriptor = Object.getOwnPropertyDescriptor(e, 'view');
     // don't send the entire window object over.
-    const view: unknown = viewDescriptor?.value;
-    if (typeof view === 'object' && view?.constructor.name === 'Window') {
-      Object.defineProperty(e, 'view', {
-        ...viewDescriptor,
-        value: Object.create(view.constructor.prototype),
-      });
+    stubWindowProp(e, 'view');
+
+    // the native event's `view` exposes the same Window (as a non-configurable
+    // accessor in React 19); stub it on a copy so the event retained by the spy
+    // is untouched
+    const nativeEventDescriptor = Object.getOwnPropertyDescriptor(e, 'nativeEvent');
+    const nativeEvent: unknown =
+      nativeEventDescriptor && 'value' in nativeEventDescriptor
+        ? nativeEventDescriptor.value
+        : undefined;
+    if (typeof nativeEvent === 'object' && nativeEvent) {
+      const nativeEventDescriptors = Object.getOwnPropertyDescriptors(nativeEvent);
+      // `view` may be a non-configurable accessor, so it can't be redefined on the copy
+      delete nativeEventDescriptors.view;
+      const nativeEventCopy = Object.create(
+        Object.getPrototypeOf(nativeEvent),
+        nativeEventDescriptors
+      );
+      stubWindowProp(nativeEventCopy, 'view');
+      Object.defineProperty(e, 'nativeEvent', { ...nativeEventDescriptor, value: nativeEventCopy });
     }
     return e;
   }


### PR DESCRIPTION
Closes #36281

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

Fixed a `SecurityError: Failed to read a named property 'toJSON' from 'Window'` thrown when an instrumented `fn()` spy receives a React synthetic event while the manager document contains a cross-origin iframe.

Two bugs combined here:

1. The `onMockCall` listener in `actions/loaders.ts` called `action(name)(args)`, passing the whole args array as a single argument. `serializeArg` then saw an array instead of the event, so the synthetic-event branch never ran. This is also why `argTypes.action`-wired callbacks didn't reproduce the bug — that path calls the handler with the event directly.
2. Even with the event reached, only the synthetic event's own `view` was stubbed. `nativeEvent.view` (a non-configurable accessor in React 19) still exposed the real `Window`. The channel serializer copies class instances via `Object.getOwnPropertyNames`, so it walks `window.top` into the manager's child frames — reaching a cross-origin `Window` where the `toJSON` read throws inside `JSON.stringify` (before any replacer guard can run).

Changes:

- `loaders.ts`: spread mock-call args so the handler (and serializer) sees the event itself. Also fixes multi-argument mock calls being logged as a single array.
- `action.ts`: detect `Window` via `value.window === value` (readable even on cross-origin proxies) and stub Window-valued props with `Object.create(ctor.prototype)`. `nativeEvent` is cloned with `view` removed from the copied descriptors (it's non-configurable) and redefined safely — the event object the spy retains is never mutated.

> 🤖 Prepared with assistance from Devin (AI pair programmer). A human reviewed the changes and verified the fix end-to-end in a real browser reproduction.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps that a human maintainer should follow, so they can verify that your changes work. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

Do not describe how YOU tested the PR code, but how a separate maintainer should do so. A good manual test often mirrors reproduction steps provided in an issue.

-->

1. Run a React sandbox, e.g. `yarn task sandbox --template react-vite/default-ts --start-from auto`, then `yarn storybook` inside it
2. Add a story whose args include `onClick: fn()` and which passes the click event straight through, e.g. `onClick={args.onClick}` on a button
3. Open the Storybook manager in a browser, and in DevTools console inject a cross-origin iframe:
   ```js
   const f = document.createElement('iframe');
   f.src = 'https://example.com';
   document.body.appendChild(f);
   ```
4. Click the button in the story
   - On `next`: DevTools shows `SecurityError: Failed to read a named property 'toJSON' from 'Window'` and the Actions panel entry fails to render
   - On this branch: no error; the action is logged and the serialized event shows an empty object for `view`
5. Worth extra scrutiny: stories with multi-argument `fn()` callbacks (args are now logged individually instead of as one array)

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Declare whether manual QA will be needed for this PR during the next release, through `qa:needed` or `qa:skip`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

<!-- CANARY_RELEASE_HEADING -->
## 🦋 Canary Release - 🚫 Not run
<!-- CANARY_RELEASE_HEADING -->

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated.

In-repo PRs: add the `ci:canary` label. Later pushes republish while the label remains.

Fork PRs: the label does nothing (a later push must not auto-publish). A maintainer publishes from this repository with [Run workflow](https://github.com/storybookjs/storybook/actions/workflows/publish-canary.yml) and the `pr` input. `branch` and `sha` are optional; if more than one is set, they must be the same commit. The fork author does not need to do anything.

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
